### PR TITLE
fix: resolve TypeScript errors in Convex tasks

### DIFF
--- a/convex/tasks.test.ts
+++ b/convex/tasks.test.ts
@@ -199,7 +199,7 @@ describe("tasks.remove", () => {
 
     await t.mutation(api.tasks.remove, { id: taskId });
 
-    const tasks = await t.query(api.tasks.listAll);
+    const tasks = await t.query(api.tasks.listAll, {});
     expect(tasks).toHaveLength(0);
 
     // Sessions should be cleaned up too

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -30,7 +30,7 @@ export const listArchived = query({
       ? await ctx.db
           .query("tasks")
           .withIndex("by_repo_status", (q) =>
-            q.eq("repoId", args.repoId).eq("status", "archived"),
+            q.eq("repoId", args.repoId!).eq("status", "archived"),
           )
           .collect()
       : await ctx.db


### PR DESCRIPTION
## Summary
- Add non-null assertion in `listArchived` where `args.repoId` is already guarded by a ternary check
- Pass empty args object to `listAll` query call in test to satisfy required rest parameter

## Test plan
- [x] `bun run convex:dev` starts without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)