### PR TITLE
ci: add E2E test workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,26 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bunx convex codegen
+        env:
+          CONVEX_DEPLOYMENT: ${{ vars.CONVEX_DEPLOYMENT }}
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+      - run: bunx playwright install --with-deps chromium
+      - run: bun run test:e2e
+        env:
+          CONVEX_URL: ${{ vars.CONVEX_URL }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs Playwright E2E tests on PRs to main
- Tests cover UI-only flows (kanban board, sidebar, seed box) — no Claude Code terminal tests
- Uses Convex codegen for types and starts the Bun server for Playwright

## Test plan
- [ ] Verify workflow runs successfully on this PR
- [ ] Confirm Playwright tests pass against the Bun server in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)