### PR TITLE
feat: add org/membership data model and auth helpers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "holophyte",
       "dependencies": {
+        "@auth/core": "0.37.0",
+        "@convex-dev/auth": "^0.0.90",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "class-variance-authority": "^0.7.1",
@@ -57,6 +59,8 @@
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
+    "@auth/core": ["@auth/core@0.37.0", "", { "dependencies": { "@panva/hkdf": "^1.2.1", "@types/cookie": "0.6.0", "cookie": "0.7.1", "jose": "^5.9.3", "oauth4webapi": "^3.0.0", "preact": "10.11.3", "preact-render-to-string": "5.2.3" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^6.8.0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-LybAgfFC5dta3Mu3al0UbnzMGVBpZRqLMvvXupQOfETtPNlL7rXgTO13EVRTCdvPqMQrVYjODUDvgVfQM1M3Qg=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
@@ -108,6 +112,8 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
+
+    "@convex-dev/auth": ["@convex-dev/auth@0.0.90", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0", "cookie": "^1.0.1", "is-network-error": "^1.1.0", "jose": "^5.2.2", "jwt-decode": "^4.0.0", "lucia": "^3.2.0", "oauth4webapi": "^3.1.2", "path-to-regexp": "^6.3.0", "server-only": "^0.0.1" }, "peerDependencies": { "@auth/core": "^0.37.0", "convex": "^1.17.0", "react": "^18.2.0 || ^19.0.0-0" }, "optionalPeers": ["react"], "bin": { "auth": "dist/bin.cjs" } }, "sha512-aqw88EB042HvnaF4wcf/f/wTocmT2Bus2VDQRuV79cM0+8kORM0ICK/ByZ6XsHgQ9qr6TmidNbXm6QAgndrdpQ=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
@@ -223,6 +229,14 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
+    "@oslojs/asn1": ["@oslojs/asn1@1.0.0", "", { "dependencies": { "@oslojs/binary": "1.0.0" } }, "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA=="],
+
+    "@oslojs/binary": ["@oslojs/binary@1.0.0", "", {}, "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ=="],
+
+    "@oslojs/crypto": ["@oslojs/crypto@1.0.1", "", { "dependencies": { "@oslojs/asn1": "1.0.0", "@oslojs/binary": "1.0.0" } }, "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ=="],
+
+    "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
     "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-df7smckMWSUfaT5mzwN9Lfpd3ZGkOqo+vmQ8VV2a32gl14v6uZ/qeeo+1RlANXn8M0uzXPWWCkrKZIWSZUR0qw=="],
 
     "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-YiLxfsPzQqaVvT2a+nxH9do0YfUjrlxF3tKP0b1DDgvfgCcVKGsrQH3Wa82qHgL4dnT8h2bqi94JxXESEuPmcA=="],
@@ -244,6 +258,8 @@
     "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-/d6vAmgKvkoYlsGPsRPlPmOK1slPis/F40UG02pYwypTH0wmY0smgzdFqR4YmryxFh17XrW1kITv+U99Oajk9Q=="],
 
     "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-a/+hSrrDpMD7THyXvE2KJy1skxzAD0cnW4K1WjuI/91VqsphjNzvf5t/ZgxEVL4wb6f+hKrSJ5J3aH47zPr61g=="],
+
+    "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
     "@playwright/test": ["@playwright/test@1.58.1", "", { "dependencies": { "playwright": "1.58.1" }, "bin": { "playwright": "cli.js" } }, "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w=="],
 
@@ -493,6 +509,8 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/doctrine": ["@types/doctrine@0.0.9", "", {}, "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA=="],
@@ -593,7 +611,7 @@
 
     "convex-test": ["convex-test@0.0.41", "", { "peerDependencies": { "convex": "^1.16.4" } }, "sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie": ["cookie@0.7.1", "", {}, "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="],
 
     "css-tree": ["css-tree@3.1.0", "", { "dependencies": { "mdn-data": "2.12.2", "source-map-js": "^1.0.1" } }, "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w=="],
 
@@ -695,6 +713,8 @@
 
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
+    "is-network-error": ["is-network-error@1.3.0", "", {}, "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw=="],
+
     "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
@@ -703,6 +723,8 @@
 
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
+    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "jsdom": ["jsdom@28.0.0", "", { "dependencies": { "@acemir/cssom": "^0.9.31", "@asamuzakjp/dom-selector": "^6.7.6", "@exodus/bytes": "^1.11.0", "cssstyle": "^5.3.7", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.0", "undici": "^7.20.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA=="],
@@ -710,6 +732,8 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jwt-decode": ["jwt-decode@4.0.0", "", {}, "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="],
 
     "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
 
@@ -739,6 +763,8 @@
 
     "lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
 
+    "lucia": ["lucia@3.2.2", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0" } }, "sha512-P1FlFBGCMPMXu+EGdVD9W4Mjm0DqsusmKgO7Xc33mI5X1bklmsQb0hfzPhXomQr9waWIBDsiOjvr1e6BTaUqpA=="],
+
     "lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
@@ -767,6 +793,8 @@
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
+    "oauth4webapi": ["oauth4webapi@3.8.4", "", {}, "sha512-EKlVEgav8zH31IXxvhCqjEgQws6S9QmnmJyLXmeV5REf59g7VmqRVa5l/rhGWtUqGm2rLVTNwukn9hla5kJ2WQ=="],
+
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
@@ -794,6 +822,10 @@
     "playwright-core": ["playwright-core@1.58.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "preact": ["preact@10.11.3", "", {}, "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="],
+
+    "preact-render-to-string": ["preact-render-to-string@5.2.3", "", { "dependencies": { "pretty-format": "^3.8.0" }, "peerDependencies": { "preact": ">=10" } }, "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
@@ -842,6 +874,8 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
@@ -981,6 +1015,8 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@convex-dev/auth/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
@@ -1012,6 +1048,10 @@
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "msw/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "preact-render-to-string/pretty-format": ["pretty-format@3.8.0", "", {}, "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="],
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 

--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -1,0 +1,8 @@
+export default {
+  providers: [
+    {
+      domain: process.env.CONVEX_SITE_URL,
+      applicationID: 'convex',
+    },
+  ],
+};

--- a/convex/lib/auth.test.ts
+++ b/convex/lib/auth.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment edge-runtime
+import { convexTest } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+import schema from '../schema';
+import { requireAuth, requireOrgMembership, requireRole } from './auth';
+
+/** Create a user and return their ID. */
+async function createUser(
+  t: ReturnType<typeof convexTest>,
+  name = 'Test User',
+) {
+  return await t.run(async (ctx) => {
+    return await ctx.db.insert('users', { name });
+  });
+}
+
+/** Create a user + org + membership. Returns { userId, orgId, membershipId }. */
+async function createUserWithOrg(
+  t: ReturnType<typeof convexTest>,
+  role: 'owner' | 'admin' | 'member' | 'viewer' = 'owner',
+) {
+  return await t.run(async (ctx) => {
+    const userId = await ctx.db.insert('users', { name: 'Test User' });
+    const orgId = await ctx.db.insert('organizations', {
+      name: 'Test Org',
+      slug: 'test-org',
+      personal: false,
+    });
+    const membershipId = await ctx.db.insert('memberships', {
+      userId,
+      orgId,
+      role,
+    });
+    return { userId, orgId, membershipId };
+  });
+}
+
+describe('requireAuth', () => {
+  it('returns userId when authenticated', async () => {
+    const t = convexTest(schema);
+    const userId = await createUser(t);
+    const authed = t.withIdentity({ subject: `${userId}|session123` });
+
+    const result = await authed.run(async (ctx) => {
+      return await requireAuth(ctx);
+    });
+    expect(result).toBe(userId);
+  });
+
+  it('throws when not authenticated', async () => {
+    const t = convexTest(schema);
+
+    await expect(
+      t.run(async (ctx) => {
+        return await requireAuth(ctx);
+      }),
+    ).rejects.toThrow('Not authenticated');
+  });
+});
+
+describe('requireOrgMembership', () => {
+  it('returns userId and membership for valid members', async () => {
+    const t = convexTest(schema);
+    const { userId, orgId, membershipId } = await createUserWithOrg(t);
+    const authed = t.withIdentity({ subject: `${userId}|session123` });
+
+    const result = await authed.run(async (ctx) => {
+      return await requireOrgMembership(ctx, orgId);
+    });
+    expect(result.userId).toBe(userId);
+    expect(result.membership._id).toBe(membershipId);
+    expect(result.membership.role).toBe('owner');
+  });
+
+  it('throws for non-members', async () => {
+    const t = convexTest(schema);
+    const { orgId } = await createUserWithOrg(t);
+
+    // Create a different user who is NOT a member
+    const otherUserId = await createUser(t, 'Other User');
+    const authed = t.withIdentity({ subject: `${otherUserId}|session456` });
+
+    await expect(
+      authed.run(async (ctx) => {
+        return await requireOrgMembership(ctx, orgId);
+      }),
+    ).rejects.toThrow('Not a member of this organization');
+  });
+
+  it('throws when not authenticated', async () => {
+    const t = convexTest(schema);
+    const { orgId } = await createUserWithOrg(t);
+
+    await expect(
+      t.run(async (ctx) => {
+        return await requireOrgMembership(ctx, orgId);
+      }),
+    ).rejects.toThrow('Not authenticated');
+  });
+});
+
+describe('requireRole', () => {
+  it('passes when role meets minimum', async () => {
+    const t = convexTest(schema);
+    const { membershipId } = await createUserWithOrg(t, 'admin');
+
+    const membership = await t.run(async (ctx) => {
+      return await ctx.db.get(membershipId);
+    });
+
+    // admin >= member should pass
+    expect(() => requireRole(membership!, 'member')).not.toThrow();
+    // admin >= admin should pass
+    expect(() => requireRole(membership!, 'admin')).not.toThrow();
+    // admin >= viewer should pass
+    expect(() => requireRole(membership!, 'viewer')).not.toThrow();
+  });
+
+  it('throws when role is below minimum', async () => {
+    const t = convexTest(schema);
+    const { membershipId } = await createUserWithOrg(t, 'member');
+
+    const membership = await t.run(async (ctx) => {
+      return await ctx.db.get(membershipId);
+    });
+
+    // member < admin should throw
+    expect(() => requireRole(membership!, 'admin')).toThrow(
+      'Requires admin role or higher',
+    );
+    // member < owner should throw
+    expect(() => requireRole(membership!, 'owner')).toThrow(
+      'Requires owner role or higher',
+    );
+  });
+
+  it('viewer cannot access member-level resources', async () => {
+    const t = convexTest(schema);
+    const { membershipId } = await createUserWithOrg(t, 'viewer');
+
+    const membership = await t.run(async (ctx) => {
+      return await ctx.db.get(membershipId);
+    });
+
+    expect(() => requireRole(membership!, 'member')).toThrow(
+      'Requires member role or higher',
+    );
+  });
+});

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -1,0 +1,53 @@
+import { getAuthUserId } from '@convex-dev/auth/server';
+import type { Doc, Id } from '../_generated/dataModel';
+import type { MutationCtx, QueryCtx } from '../_generated/server';
+
+const ROLE_LEVELS: Record<Doc<'memberships'>['role'], number> = {
+  viewer: 0,
+  member: 1,
+  admin: 2,
+  owner: 3,
+};
+
+/** Returns userId or throws — use in mutations/queries that require auth. */
+export async function requireAuth(ctx: QueryCtx | MutationCtx) {
+  const userId = await getAuthUserId(ctx);
+  if (!userId) throw new Error('Not authenticated');
+  return userId;
+}
+
+/** Returns userId + membership or throws — verifies user belongs to org. */
+export async function requireOrgMembership(
+  ctx: QueryCtx | MutationCtx,
+  orgId: Id<'organizations'>,
+) {
+  const userId = await requireAuth(ctx);
+  const membership = await ctx.db
+    .query('memberships')
+    .withIndex('by_user_org', (q) => q.eq('userId', userId).eq('orgId', orgId))
+    .first();
+  if (!membership) throw new Error('Not a member of this organization');
+  return { userId, membership };
+}
+
+/** Throws if the membership role is below the required minimum. */
+export function requireRole(
+  membership: Doc<'memberships'>,
+  minRole: 'viewer' | 'member' | 'admin' | 'owner',
+) {
+  if (ROLE_LEVELS[membership.role] < ROLE_LEVELS[minRole]) {
+    throw new Error(`Requires ${minRole} role or higher`);
+  }
+}
+
+/** Resolve orgId from a task ID via its repo. */
+export async function getOrgIdFromTask(
+  ctx: QueryCtx | MutationCtx,
+  taskId: Id<'tasks'>,
+) {
+  const task = await ctx.db.get(taskId);
+  if (!task) throw new Error('Task not found');
+  const repo = await ctx.db.get(task.repoId);
+  if (!repo) throw new Error('Repo not found');
+  return repo.orgId;
+}

--- a/convex/memberships.test.ts
+++ b/convex/memberships.test.ts
@@ -1,0 +1,281 @@
+// @vitest-environment edge-runtime
+import { convexTest } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+import { api } from './_generated/api';
+import schema from './schema';
+
+/** Create a user and return an authenticated test client + userId. */
+async function setupUser(t: ReturnType<typeof convexTest>, name = 'Test User') {
+  const userId = await t.run(async (ctx) => {
+    return await ctx.db.insert('users', { name });
+  });
+  return { userId, authed: t.withIdentity({ subject: `${userId}|s1` }) };
+}
+
+/** Create a user, org (as owner), and return everything needed. */
+async function setupOwnerWithOrg(t: ReturnType<typeof convexTest>) {
+  const { userId, authed } = await setupUser(t, 'Owner');
+  const orgId = await authed.mutation(api.organizations.create, {
+    name: 'Test Org',
+    slug: 'test-org',
+  });
+  return { userId, authed, orgId };
+}
+
+describe('memberships.invite', () => {
+  it('admin can invite a new member', async () => {
+    const t = convexTest(schema);
+    const { authed: owner, orgId } = await setupOwnerWithOrg(t);
+    const { userId: newUserId } = await setupUser(t, 'New Member');
+
+    await owner.mutation(api.memberships.invite, {
+      orgId,
+      userId: newUserId,
+      role: 'member',
+    });
+
+    const members = await owner.query(api.memberships.listByOrg, { orgId });
+    expect(members).toHaveLength(2);
+    const invited = members.find((m) => m.userId === newUserId);
+    expect(invited).toMatchObject({ role: 'member' });
+  });
+
+  it('requires admin role to invite', async () => {
+    const t = convexTest(schema);
+    const { orgId } = await setupOwnerWithOrg(t);
+    const { userId: memberId, authed: member } = await setupUser(t, 'Member');
+    const { userId: newUserId } = await setupUser(t, 'New');
+
+    // Add user as a regular member
+    await t.run(async (ctx) => {
+      await ctx.db.insert('memberships', {
+        userId: memberId,
+        orgId,
+        role: 'member',
+      });
+    });
+
+    await expect(
+      member.mutation(api.memberships.invite, {
+        orgId,
+        userId: newUserId,
+        role: 'viewer',
+      }),
+    ).rejects.toThrow('Requires admin role or higher');
+  });
+
+  it('admin cannot invite with owner role', async () => {
+    const t = convexTest(schema);
+    const { authed: owner, orgId } = await setupOwnerWithOrg(t);
+    const { userId: adminId, authed: admin } = await setupUser(t, 'Admin');
+    const { userId: newUserId } = await setupUser(t, 'New');
+
+    // Add user as admin
+    await t.run(async (ctx) => {
+      await ctx.db.insert('memberships', {
+        userId: adminId,
+        orgId,
+        role: 'admin',
+      });
+    });
+
+    await expect(
+      admin.mutation(api.memberships.invite, {
+        orgId,
+        userId: newUserId,
+        role: 'owner',
+      }),
+    ).rejects.toThrow('Only owners can assign the owner role');
+  });
+
+  it('rejects duplicate membership', async () => {
+    const t = convexTest(schema);
+    const {
+      userId: ownerId,
+      authed: owner,
+      orgId,
+    } = await setupOwnerWithOrg(t);
+
+    await expect(
+      owner.mutation(api.memberships.invite, {
+        orgId,
+        userId: ownerId,
+        role: 'member',
+      }),
+    ).rejects.toThrow('User is already a member');
+  });
+});
+
+describe('memberships.updateRole', () => {
+  it('admin can change member role', async () => {
+    const t = convexTest(schema);
+    const { authed: owner, orgId } = await setupOwnerWithOrg(t);
+    const { userId: memberId } = await setupUser(t, 'Member');
+
+    const membershipId = await t.run(async (ctx) => {
+      return await ctx.db.insert('memberships', {
+        userId: memberId,
+        orgId,
+        role: 'member',
+      });
+    });
+
+    await owner.mutation(api.memberships.updateRole, {
+      id: membershipId,
+      role: 'admin',
+    });
+
+    const members = await owner.query(api.memberships.listByOrg, { orgId });
+    const updated = members.find((m) => m.userId === memberId);
+    expect(updated).toMatchObject({ role: 'admin' });
+  });
+
+  it('admin cannot promote to owner', async () => {
+    const t = convexTest(schema);
+    const { authed: owner, orgId } = await setupOwnerWithOrg(t);
+    const { userId: adminId, authed: admin } = await setupUser(t, 'Admin');
+    const { userId: memberId } = await setupUser(t, 'Member');
+
+    // Add admin and member
+    await t.run(async (ctx) => {
+      await ctx.db.insert('memberships', {
+        userId: adminId,
+        orgId,
+        role: 'admin',
+      });
+    });
+    const membershipId = await t.run(async (ctx) => {
+      return await ctx.db.insert('memberships', {
+        userId: memberId,
+        orgId,
+        role: 'member',
+      });
+    });
+
+    await expect(
+      admin.mutation(api.memberships.updateRole, {
+        id: membershipId,
+        role: 'owner',
+      }),
+    ).rejects.toThrow('Only owners can promote to owner');
+  });
+
+  it('cannot demote an owner', async () => {
+    const t = convexTest(schema);
+    const { authed: owner, orgId } = await setupOwnerWithOrg(t);
+
+    // Add a second owner
+    const { userId: owner2Id, authed: owner2 } = await setupUser(t, 'Owner 2');
+    const owner2MembershipId = await t.run(async (ctx) => {
+      return await ctx.db.insert('memberships', {
+        userId: owner2Id,
+        orgId,
+        role: 'owner',
+      });
+    });
+
+    // Get the first owner's membership
+    const memberships = await owner.query(api.memberships.listByOrg, { orgId });
+    const firstOwnerMembership = memberships.find(
+      (m) => m.role === 'owner' && m.userId !== owner2Id,
+    );
+
+    // owner2 tries to demote original owner
+    await expect(
+      owner2.mutation(api.memberships.updateRole, {
+        id: firstOwnerMembership!._id,
+        role: 'admin',
+      }),
+    ).rejects.toThrow('Cannot change the role of an owner');
+  });
+});
+
+describe('memberships.remove', () => {
+  it('admin can remove a member', async () => {
+    const t = convexTest(schema);
+    const { authed: owner, orgId } = await setupOwnerWithOrg(t);
+    const { userId: memberId } = await setupUser(t, 'Member');
+
+    const membershipId = await t.run(async (ctx) => {
+      return await ctx.db.insert('memberships', {
+        userId: memberId,
+        orgId,
+        role: 'member',
+      });
+    });
+
+    await owner.mutation(api.memberships.remove, { id: membershipId });
+
+    const members = await owner.query(api.memberships.listByOrg, { orgId });
+    expect(members).toHaveLength(1); // only owner remains
+  });
+
+  it('cannot remove an owner', async () => {
+    const t = convexTest(schema);
+    const { authed: owner, orgId } = await setupOwnerWithOrg(t);
+    const { userId: owner2Id } = await setupUser(t, 'Owner 2');
+
+    const owner2MembershipId = await t.run(async (ctx) => {
+      return await ctx.db.insert('memberships', {
+        userId: owner2Id,
+        orgId,
+        role: 'owner',
+      });
+    });
+
+    await expect(
+      owner.mutation(api.memberships.remove, { id: owner2MembershipId }),
+    ).rejects.toThrow('Cannot remove an owner');
+  });
+});
+
+describe('memberships.leave', () => {
+  it('member can leave an org', async () => {
+    const t = convexTest(schema);
+    const { authed: owner, orgId } = await setupOwnerWithOrg(t);
+    const { userId: memberId, authed: member } = await setupUser(t, 'Member');
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('memberships', {
+        userId: memberId,
+        orgId,
+        role: 'member',
+      });
+    });
+
+    await member.mutation(api.memberships.leave, { orgId });
+
+    const members = await owner.query(api.memberships.listByOrg, { orgId });
+    expect(members).toHaveLength(1); // only owner remains
+  });
+
+  it('prevents last owner from leaving', async () => {
+    const t = convexTest(schema);
+    const { authed: owner, orgId } = await setupOwnerWithOrg(t);
+
+    await expect(
+      owner.mutation(api.memberships.leave, { orgId }),
+    ).rejects.toThrow('Cannot leave: you are the only owner');
+  });
+
+  it('allows owner to leave if other owners exist', async () => {
+    const t = convexTest(schema);
+    const { authed: owner1, orgId } = await setupOwnerWithOrg(t);
+    const { userId: owner2Id, authed: owner2 } = await setupUser(t, 'Owner 2');
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('memberships', {
+        userId: owner2Id,
+        orgId,
+        role: 'owner',
+      });
+    });
+
+    // owner1 can leave since owner2 exists
+    await owner1.mutation(api.memberships.leave, { orgId });
+
+    const members = await owner2.query(api.memberships.listByOrg, { orgId });
+    expect(members).toHaveLength(1);
+    expect(members[0]!.role).toBe('owner');
+  });
+});

--- a/convex/memberships.ts
+++ b/convex/memberships.ts
@@ -1,0 +1,112 @@
+import { v } from 'convex/values';
+import { mutation, query } from './_generated/server';
+import { requireAuth, requireOrgMembership, requireRole } from './lib/auth';
+import { roleValidator } from './schema';
+
+export const listByOrg = query({
+  args: { orgId: v.id('organizations') },
+  handler: async (ctx, args) => {
+    await requireOrgMembership(ctx, args.orgId);
+    const memberships = await ctx.db
+      .query('memberships')
+      .withIndex('by_org', (q) => q.eq('orgId', args.orgId))
+      .collect();
+    return Promise.all(
+      memberships.map(async (m) => {
+        const user = await ctx.db.get(m.userId);
+        return { ...m, user };
+      }),
+    );
+  },
+});
+
+export const invite = mutation({
+  args: {
+    orgId: v.id('organizations'),
+    userId: v.id('users'),
+    role: roleValidator,
+  },
+  handler: async (ctx, args) => {
+    const { membership } = await requireOrgMembership(ctx, args.orgId);
+    requireRole(membership, 'admin');
+    if (args.role === 'owner' && membership.role !== 'owner') {
+      throw new Error('Only owners can assign the owner role');
+    }
+    const existing = await ctx.db
+      .query('memberships')
+      .withIndex('by_user_org', (q) =>
+        q.eq('userId', args.userId).eq('orgId', args.orgId),
+      )
+      .first();
+    if (existing) throw new Error('User is already a member');
+    return await ctx.db.insert('memberships', {
+      userId: args.userId,
+      orgId: args.orgId,
+      role: args.role,
+    });
+  },
+});
+
+export const updateRole = mutation({
+  args: {
+    id: v.id('memberships'),
+    role: roleValidator,
+  },
+  handler: async (ctx, args) => {
+    const target = await ctx.db.get(args.id);
+    if (!target) throw new Error('Membership not found');
+    const { membership } = await requireOrgMembership(ctx, target.orgId);
+    requireRole(membership, 'admin');
+    if (target.role === 'owner') {
+      throw new Error('Cannot change the role of an owner');
+    }
+    if (args.role === 'owner' && membership.role !== 'owner') {
+      throw new Error('Only owners can promote to owner');
+    }
+    await ctx.db.patch(args.id, { role: args.role });
+  },
+});
+
+export const remove = mutation({
+  args: { id: v.id('memberships') },
+  handler: async (ctx, args) => {
+    const target = await ctx.db.get(args.id);
+    if (!target) throw new Error('Membership not found');
+    const { membership } = await requireOrgMembership(ctx, target.orgId);
+    requireRole(membership, 'admin');
+    if (target.role === 'owner') {
+      throw new Error('Cannot remove an owner');
+    }
+    await ctx.db.delete(args.id);
+  },
+});
+
+export const leave = mutation({
+  args: { orgId: v.id('organizations') },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+    const membership = await ctx.db
+      .query('memberships')
+      .withIndex('by_user_org', (q) =>
+        q.eq('userId', userId).eq('orgId', args.orgId),
+      )
+      .first();
+    if (!membership) throw new Error('Not a member of this organization');
+    if (membership.role === 'owner') {
+      // Check if there are other owners
+      const orgMembers = await ctx.db
+        .query('memberships')
+        .withIndex('by_org', (q) => q.eq('orgId', args.orgId))
+        .collect();
+      const otherOwners = orgMembers.filter(
+        (m) => m.role === 'owner' && m.userId !== userId,
+      );
+      if (otherOwners.length === 0) {
+        throw new Error(
+          'Cannot leave: you are the only owner. Transfer ownership first.',
+        );
+      }
+    }
+    await ctx.db.delete(membership._id);
+  },
+});

--- a/convex/organizations.test.ts
+++ b/convex/organizations.test.ts
@@ -1,0 +1,249 @@
+// @vitest-environment edge-runtime
+import { convexTest } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+import { api, internal } from './_generated/api';
+import schema from './schema';
+
+/** Create a user and return an authenticated test client + userId. */
+async function setupUser(t: ReturnType<typeof convexTest>, name = 'Test User') {
+  const userId = await t.run(async (ctx) => {
+    return await ctx.db.insert('users', { name });
+  });
+  return { userId, authed: t.withIdentity({ subject: `${userId}|s1` }) };
+}
+
+describe('organizations.create', () => {
+  it('creates an org and auto-creates owner membership', async () => {
+    const t = convexTest(schema);
+    const { userId, authed } = await setupUser(t);
+
+    const orgId = await authed.mutation(api.organizations.create, {
+      name: 'My Org',
+      slug: 'my-org',
+    });
+
+    const orgs = await authed.query(api.organizations.listByUser);
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0]).toMatchObject({
+      _id: orgId,
+      name: 'My Org',
+      slug: 'my-org',
+      personal: false,
+      role: 'owner',
+    });
+  });
+
+  it('rejects duplicate slugs', async () => {
+    const t = convexTest(schema);
+    const { authed } = await setupUser(t);
+
+    await authed.mutation(api.organizations.create, {
+      name: 'First',
+      slug: 'same-slug',
+    });
+
+    await expect(
+      authed.mutation(api.organizations.create, {
+        name: 'Second',
+        slug: 'same-slug',
+      }),
+    ).rejects.toThrow('Organization slug already taken');
+  });
+
+  it('requires authentication', async () => {
+    const t = convexTest(schema);
+
+    await expect(
+      t.mutation(api.organizations.create, {
+        name: 'Org',
+        slug: 'org',
+      }),
+    ).rejects.toThrow('Not authenticated');
+  });
+});
+
+describe('organizations.createPersonal', () => {
+  it('creates a personal org with owner membership', async () => {
+    const t = convexTest(schema);
+    const { userId, authed } = await setupUser(t, 'Alice');
+
+    await t.mutation(internal.organizations.createPersonal, {
+      userId,
+    });
+
+    const orgs = await authed.query(api.organizations.listByUser);
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0]).toMatchObject({
+      name: 'Alice',
+      personal: true,
+      role: 'owner',
+    });
+    expect(orgs[0]!.slug).toBe(`personal-${userId}`);
+  });
+
+  it('is idempotent — calling twice returns the same orgId', async () => {
+    const t = convexTest(schema);
+    const { userId, authed } = await setupUser(t, 'Bob');
+
+    const orgId1 = await t.mutation(internal.organizations.createPersonal, {
+      userId,
+    });
+    const orgId2 = await t.mutation(internal.organizations.createPersonal, {
+      userId,
+    });
+
+    expect(orgId1).toBe(orgId2);
+
+    // Should still only have one org and one membership
+    const orgs = await authed.query(api.organizations.listByUser);
+    expect(orgs).toHaveLength(1);
+  });
+});
+
+describe('organizations.listByUser', () => {
+  it('only shows orgs the user belongs to', async () => {
+    const t = convexTest(schema);
+    const { authed: user1 } = await setupUser(t, 'User 1');
+    const { authed: user2 } = await setupUser(t, 'User 2');
+
+    await user1.mutation(api.organizations.create, {
+      name: 'Org A',
+      slug: 'org-a',
+    });
+    await user2.mutation(api.organizations.create, {
+      name: 'Org B',
+      slug: 'org-b',
+    });
+
+    const user1Orgs = await user1.query(api.organizations.listByUser);
+    expect(user1Orgs).toHaveLength(1);
+    expect(user1Orgs[0]!.name).toBe('Org A');
+
+    const user2Orgs = await user2.query(api.organizations.listByUser);
+    expect(user2Orgs).toHaveLength(1);
+    expect(user2Orgs[0]!.name).toBe('Org B');
+  });
+});
+
+describe('organizations.get', () => {
+  it('returns org for members', async () => {
+    const t = convexTest(schema);
+    const { authed } = await setupUser(t);
+
+    const orgId = await authed.mutation(api.organizations.create, {
+      name: 'My Org',
+      slug: 'my-org',
+    });
+
+    const org = await authed.query(api.organizations.get, { id: orgId });
+    expect(org).toMatchObject({ name: 'My Org', slug: 'my-org' });
+  });
+
+  it('rejects non-members', async () => {
+    const t = convexTest(schema);
+    const { authed: user1 } = await setupUser(t, 'User 1');
+    const { authed: user2 } = await setupUser(t, 'User 2');
+
+    const orgId = await user1.mutation(api.organizations.create, {
+      name: 'Private',
+      slug: 'private',
+    });
+
+    await expect(
+      user2.query(api.organizations.get, { id: orgId }),
+    ).rejects.toThrow('Not a member of this organization');
+  });
+});
+
+describe('organizations.update', () => {
+  it('allows admin to update', async () => {
+    const t = convexTest(schema);
+    const { userId, authed } = await setupUser(t);
+
+    const orgId = await authed.mutation(api.organizations.create, {
+      name: 'Old Name',
+      slug: 'old-slug',
+    });
+
+    await authed.mutation(api.organizations.update, {
+      id: orgId,
+      name: 'New Name',
+    });
+
+    const org = await authed.query(api.organizations.get, { id: orgId });
+    expect(org!.name).toBe('New Name');
+  });
+
+  it('rejects members without admin role', async () => {
+    const t = convexTest(schema);
+    const { authed: owner } = await setupUser(t, 'Owner');
+    const { userId: memberId, authed: member } = await setupUser(t, 'Member');
+
+    const orgId = await owner.mutation(api.organizations.create, {
+      name: 'Org',
+      slug: 'org',
+    });
+
+    // Add member with 'member' role
+    await t.run(async (ctx) => {
+      await ctx.db.insert('memberships', {
+        userId: memberId,
+        orgId,
+        role: 'member',
+      });
+    });
+
+    await expect(
+      member.mutation(api.organizations.update, { id: orgId, name: 'Nope' }),
+    ).rejects.toThrow('Requires admin role or higher');
+  });
+});
+
+describe('organizations.remove', () => {
+  it('allows owner to delete and cascades memberships', async () => {
+    const t = convexTest(schema);
+    const { authed } = await setupUser(t);
+
+    const orgId = await authed.mutation(api.organizations.create, {
+      name: 'To Delete',
+      slug: 'to-delete',
+    });
+
+    await authed.mutation(api.organizations.remove, { id: orgId });
+
+    const orgs = await authed.query(api.organizations.listByUser);
+    expect(orgs).toHaveLength(0);
+
+    // Memberships should be gone
+    const memberships = await t.run(async (ctx) => {
+      return await ctx.db
+        .query('memberships')
+        .withIndex('by_org', (q) => q.eq('orgId', orgId))
+        .collect();
+    });
+    expect(memberships).toHaveLength(0);
+  });
+
+  it('rejects non-owners', async () => {
+    const t = convexTest(schema);
+    const { authed: owner } = await setupUser(t, 'Owner');
+    const { userId: adminId, authed: admin } = await setupUser(t, 'Admin');
+
+    const orgId = await owner.mutation(api.organizations.create, {
+      name: 'Org',
+      slug: 'org',
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('memberships', {
+        userId: adminId,
+        orgId,
+        role: 'admin',
+      });
+    });
+
+    await expect(
+      admin.mutation(api.organizations.remove, { id: orgId }),
+    ).rejects.toThrow('Requires owner role or higher');
+  });
+});

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -1,0 +1,184 @@
+import { v } from 'convex/values';
+import { internalMutation, mutation, query } from './_generated/server';
+import { requireAuth, requireOrgMembership, requireRole } from './lib/auth';
+
+export const listByUser = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireAuth(ctx);
+    const memberships = await ctx.db
+      .query('memberships')
+      .withIndex('by_user', (q) => q.eq('userId', userId))
+      .collect();
+    const orgs = await Promise.all(
+      memberships.map(async (m) => {
+        const org = await ctx.db.get(m.orgId);
+        return org ? { ...org, role: m.role } : null;
+      }),
+    );
+    return orgs.filter((o) => o !== null);
+  },
+});
+
+export const get = query({
+  args: { id: v.id('organizations') },
+  handler: async (ctx, args) => {
+    await requireOrgMembership(ctx, args.id);
+    return await ctx.db.get(args.id);
+  },
+});
+
+export const create = mutation({
+  args: {
+    name: v.string(),
+    slug: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+    const existing = await ctx.db
+      .query('organizations')
+      .withIndex('by_slug', (q) => q.eq('slug', args.slug))
+      .first();
+    if (existing) throw new Error('Organization slug already taken');
+    if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(args.slug)) {
+      throw new Error(
+        'Slug must be lowercase alphanumeric with hyphens, 1-63 characters',
+      );
+    }
+    const orgId = await ctx.db.insert('organizations', {
+      name: args.name,
+      slug: args.slug,
+      personal: false,
+    });
+    await ctx.db.insert('memberships', {
+      userId,
+      orgId,
+      role: 'owner',
+    });
+    return orgId;
+  },
+});
+
+export const createPersonal = internalMutation({
+  args: { userId: v.id('users') },
+  handler: async (ctx, args) => {
+    const slug = `personal-${args.userId}`;
+    // Idempotency: return existing personal org if already created
+    const existing = await ctx.db
+      .query('organizations')
+      .withIndex('by_slug', (q) => q.eq('slug', slug))
+      .first();
+    if (existing) return existing._id;
+    const user = await ctx.db.get(args.userId);
+    const name = user?.name ?? 'Personal';
+    const orgId = await ctx.db.insert('organizations', {
+      name,
+      slug,
+      personal: true,
+    });
+    await ctx.db.insert('memberships', {
+      userId: args.userId,
+      orgId,
+      role: 'owner',
+    });
+    return orgId;
+  },
+});
+
+export const update = mutation({
+  args: {
+    id: v.id('organizations'),
+    name: v.optional(v.string()),
+    slug: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { membership } = await requireOrgMembership(ctx, args.id);
+    requireRole(membership, 'admin');
+    const updates: Record<string, string> = {};
+    if (args.name !== undefined) updates.name = args.name;
+    if (args.slug !== undefined) {
+      const slug = args.slug;
+      if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(slug)) {
+        throw new Error(
+          'Slug must be lowercase alphanumeric with hyphens, 1-63 characters',
+        );
+      }
+      const existing = await ctx.db
+        .query('organizations')
+        .withIndex('by_slug', (q) => q.eq('slug', slug))
+        .first();
+      if (existing && existing._id !== args.id) {
+        throw new Error('Organization slug already taken');
+      }
+      updates.slug = slug;
+    }
+    await ctx.db.patch(args.id, updates);
+  },
+});
+
+export const remove = mutation({
+  args: { id: v.id('organizations') },
+  handler: async (ctx, args) => {
+    const { membership } = await requireOrgMembership(ctx, args.id);
+    requireRole(membership, 'owner');
+
+    // Cascade: repos → tasks → sessions/subtasks/promptHistory
+    const repos = await ctx.db
+      .query('repos')
+      .withIndex('by_org', (q) => q.eq('orgId', args.id))
+      .collect();
+    for (const repo of repos) {
+      const tasks = await ctx.db
+        .query('tasks')
+        .withIndex('by_repo_status', (q) => q.eq('repoId', repo._id))
+        .collect();
+      for (const task of tasks) {
+        const sessions = await ctx.db
+          .query('sessions')
+          .withIndex('by_task', (q) => q.eq('taskId', task._id))
+          .collect();
+        for (const session of sessions) await ctx.db.delete(session._id);
+        const subtasks = await ctx.db
+          .query('subtasks')
+          .withIndex('by_task', (q) => q.eq('taskId', task._id))
+          .collect();
+        for (const subtask of subtasks) await ctx.db.delete(subtask._id);
+        const history = await ctx.db
+          .query('promptHistory')
+          .withIndex('by_task', (q) => q.eq('taskId', task._id))
+          .collect();
+        for (const entry of history) await ctx.db.delete(entry._id);
+        await ctx.db.delete(task._id);
+      }
+      const templates = await ctx.db
+        .query('promptTemplates')
+        .withIndex('by_repo', (q) => q.eq('repoId', repo._id))
+        .collect();
+      for (const tmpl of templates) await ctx.db.delete(tmpl._id);
+      await ctx.db.delete(repo._id);
+    }
+
+    // Cascade: labels
+    const labels = await ctx.db
+      .query('labels')
+      .withIndex('by_org', (q) => q.eq('orgId', args.id))
+      .collect();
+    for (const label of labels) await ctx.db.delete(label._id);
+
+    // Cascade: seeds
+    const seeds = await ctx.db
+      .query('seeds')
+      .withIndex('by_org', (q) => q.eq('orgId', args.id))
+      .collect();
+    for (const seed of seeds) await ctx.db.delete(seed._id);
+
+    // Cascade: memberships
+    const memberships = await ctx.db
+      .query('memberships')
+      .withIndex('by_org', (q) => q.eq('orgId', args.id))
+      .collect();
+    for (const m of memberships) await ctx.db.delete(m._id);
+
+    await ctx.db.delete(args.id);
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,3 +1,4 @@
+import { authTables } from '@convex-dev/auth/server';
 import { defineSchema, defineTable } from 'convex/server';
 import { v } from 'convex/values';
 
@@ -48,12 +49,39 @@ export const PRIORITY_CONFIG: Record<
   [TaskPriority.Urgent]: { label: 'Urgent', color: '#ef4444' },
 };
 
+export const roleValidator = v.union(
+  v.literal('owner'),
+  v.literal('admin'),
+  v.literal('member'),
+  v.literal('viewer'),
+);
+
 export default defineSchema({
+  ...authTables,
+
+  organizations: defineTable({
+    name: v.string(),
+    slug: v.string(),
+    personal: v.boolean(),
+  }).index('by_slug', ['slug']),
+
+  memberships: defineTable({
+    userId: v.id('users'),
+    orgId: v.id('organizations'),
+    role: roleValidator,
+  })
+    .index('by_user', ['userId'])
+    .index('by_org', ['orgId'])
+    .index('by_user_org', ['userId', 'orgId']),
+
   repos: defineTable({
     name: v.string(),
     path: v.string(),
     createdAt: v.number(),
-  }).index('by_path', ['path']),
+    orgId: v.optional(v.id('organizations')),
+  })
+    .index('by_path', ['path'])
+    .index('by_org', ['orgId']),
 
   tasks: defineTable({
     repoId: v.id('repos'),
@@ -76,6 +104,9 @@ export default defineSchema({
     priority: v.optional(priorityValidator),
     // Archive timestamp
     archivedAt: v.optional(v.number()),
+    // Auth: who created + private flag
+    createdBy: v.optional(v.id('users')),
+    private: v.optional(v.boolean()),
   })
     .index('by_repo_status', ['repoId', 'status'])
     .index('by_status', ['status']),
@@ -84,7 +115,11 @@ export default defineSchema({
     name: v.string(),
     color: v.string(),
     createdAt: v.number(),
-  }),
+    orgId: v.optional(v.id('organizations')),
+    userId: v.optional(v.id('users')),
+  })
+    .index('by_org', ['orgId'])
+    .index('by_user', ['userId']),
 
   subtasks: defineTable({
     taskId: v.id('tasks'),
@@ -100,7 +135,10 @@ export default defineSchema({
     status: v.union(v.literal('active'), v.literal('planted')),
     plantedToTaskId: v.optional(v.id('tasks')),
     createdAt: v.number(),
-  }).index('by_status', ['status']),
+    orgId: v.optional(v.id('organizations')),
+  })
+    .index('by_status', ['status'])
+    .index('by_org', ['orgId']),
 
   promptTemplates: defineTable({
     name: v.string(),
@@ -109,6 +147,7 @@ export default defineSchema({
     repoId: v.optional(v.id('repos')),
     createdAt: v.number(),
     updatedAt: v.number(),
+    userId: v.optional(v.id('users')),
   }).index('by_repo', ['repoId']),
 
   promptHistory: defineTable({

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@auth/core": "0.37.0",
+    "@convex-dev/auth": "^0.0.90",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- Add `organizations` and `memberships` tables with RBAC role system (owner/admin/member/viewer)
- Add auth helper functions: `requireAuth`, `requireOrgMembership`, `requireRole`, `getOrgIdFromTask`
- Extend existing tables with **optional** `orgId`/`createdBy`/`userId` fields (tightened to required in PR3)
- Full CRUD for organizations (create, update, delete with cascade) and memberships (invite, updateRole, remove, leave)
- Comprehensive unit tests for all new functions

## Context
This is **PR 1 of 4** splitting the large auth PR (#23) into reviewable chunks:
1. **Data model + org/membership tables** (this PR)
2. Auth setup (backend + frontend gates)
3. RBAC enforcement on existing mutations
4. Frontend org-awareness

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun run lint` passes (warnings only, no errors)
- [ ] `bun run test` — unit tests for organizations, memberships, and auth helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)