### PR TITLE
fix: add loading skeletons to Sidebar repos list

### DIFF
--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -21,6 +21,7 @@ import Button from './ui/Button';
 import PageHeader from './ui/PageHeader';
 import ScrollArea from './ui/ScrollArea';
 import Separator from './ui/Separator';
+import Skeleton from './ui/Skeleton';
 
 export function Sidebar() {
   const selectedOrgId = useAppStore((s) => s.selectedOrgId);
@@ -110,6 +111,16 @@ export function Sidebar() {
       </div>
       <ScrollArea className="flex-1">
         <div className="p-2 space-y-1">
+          {repos === undefined && (
+            <>
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex items-center gap-2 px-3 py-2">
+                  <Skeleton className="h-4 w-4 shrink-0 rounded" />
+                  <Skeleton className="h-4 flex-1" />
+                </div>
+              ))}
+            </>
+          )}
           {repos?.map((repo) => {
             const repoActiveTasks =
               activeTasksByRepo.get(String(repo._id)) ?? [];


### PR DESCRIPTION
## Summary
- Shows three animated skeleton items in the sidebar Projects section while repos are loading
- Prevents a blank sidebar that makes the app look broken during initial page load

## Test plan
- [x] Hard refresh the app — verify skeleton items appear briefly in the sidebar before repos load
- [x] Verify skeletons disappear once repos are loaded
- [x] Verify "No projects added yet" message still shows for empty repos (not skeletons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)