### PR TITLE
fix: poll Greptile at 5m, 7.5m, 10m instead of every 30s

### DIFF
--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -107,7 +107,7 @@ Wait for Greptile to post review comments using the polling script:
 bun run pr-comments -- --poll <PR_NUMBER>
 ```
 
-This records existing comment IDs, polls every 30s for up to 5 minutes, and outputs only new comments.
+This records existing comment IDs, then checks at 5m, 7.5m, and 10m for new comments.
 
 - If timeout with no new comments, exit successfully — Greptile found nothing new
 

--- a/scripts/pr-comments.sh
+++ b/scripts/pr-comments.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Usage:
 #   bun run pr-comments                      # show all comments (auto-detect PR)
 #   bun run pr-comments -- 42                # show comments on PR #42
-#   bun run pr-comments -- --poll            # poll for new comments
+#   bun run pr-comments -- --poll            # poll for new comments (checks at 5m, 7.5m, 10m)
 #   bun run pr-comments -- --poll 42         # poll specific PR
 #   bun run pr-comments -- --resolve         # resolve all Greptile threads
 #   bun run pr-comments -- --resolve 42      # resolve threads on specific PR
@@ -126,20 +126,20 @@ if [ "$POLL" = false ]; then
   exit 0
 fi
 
-# Poll mode: record existing comment IDs, poll for new ones
+# Poll mode: record existing comment IDs, then check at fixed intervals
 echo "Recording existing Greptile comments..."
 SEEN_IDS=$(gh api "repos/$OWNER_REPO/pulls/$PR_NUMBER/comments" \
   --jq '[.[] | select(.user.login == "greptile-apps[bot]") | .id]')
 
-echo "Polling for new Greptile comments (every 30s, timeout 5min)..."
+# Greptile typically takes 5-10 minutes to review — check at 5m, 7.5m, 10m
+POLL_DELAYS=(300 150 150)  # seconds to sleep before each check (5m, +2.5m, +2.5m)
+POLL_LABELS=("5m" "7.5m" "10m")
 
-ELAPSED=0
-TIMEOUT=300
+echo "Waiting for Greptile review (checks at 5m, 7.5m, 10m)..."
 
-while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
-  sleep 30
-  ELAPSED=$((ELAPSED + 30))
-  echo "  Checking... (${ELAPSED}s / ${TIMEOUT}s)"
+for i in "${!POLL_DELAYS[@]}"; do
+  sleep "${POLL_DELAYS[$i]}"
+  echo "  Checking at ${POLL_LABELS[$i]}..."
 
   ALL_COMMENTS=$(fetch_greptile_comments)
   if [ -z "$ALL_COMMENTS" ]; then
@@ -160,5 +160,5 @@ while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
   fi
 done
 
-echo "Timeout: no new Greptile comments after ${TIMEOUT}s"
+echo "No new Greptile comments after 10 minutes"
 exit 0


### PR DESCRIPTION
## Summary

- Replace the every-30s polling loop (5min timeout) in `scripts/pr-comments.sh` with 3 fixed checks at 5m, 7.5m, and 10m
- Greptile typically takes 5-10 minutes to review, so the previous approach wasted API calls checking too early and timed out before reviews were ready
- Update autopilot skill description to match the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)