### PR TITLE
fix: ensure Ctrl-C cleanly kills all dev processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepare": "git config core.hooksPath .githooks",
     "dev": "bun run --watch src/server.ts",
-    "dev:all": "concurrently -n server,convex -c blue,magenta 'bun run dev' 'bun run convex:dev'",
+    "dev:all": "concurrently -k --kill-signal SIGINT -n server,convex -c blue,magenta 'bun run dev' 'bun run convex:dev'",
     "dev:local": "scripts/dev-local.sh",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -46,6 +46,6 @@ trap 'rm -f "$LOCKFILE"' EXIT
 export PORT="$DEV_PORT"
 
 echo "Starting dev environment (app=$DEV_PORT, convex=$CONVEX_CLOUD_PORT/$CONVEX_SITE_PORT)..."
-bunx concurrently -n server,convex -c blue,magenta \
+bunx concurrently -k --kill-signal SIGINT -n server,convex -c blue,magenta \
   "bun run --watch src/server.ts" \
   "$SCRIPT_DIR/convex-local.sh"


### PR DESCRIPTION
## Summary
- Add `--kill-others` and `--kill-signal SIGINT` to `concurrently` in both `dev:all` (package.json) and `dev-local.sh`
- Without these flags, Ctrl-C only kills one child process while the other keeps running, leaving the terminal stuck

## Test plan
- [x] Run `bun run dev:all`, press Ctrl-C, verify both processes exit cleanly
- [x] Run `bun run dev:local`, press Ctrl-C, verify both processes exit cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)