### PR TITLE
refactor: move worktrees to ~/.holophyte-dev

### DIFF
--- a/.claude/skills/branch-status/SKILL.md
+++ b/.claude/skills/branch-status/SKILL.md
@@ -58,7 +58,7 @@ Organize branches into categories:
 ### Active Worktrees
 | Directory | Branch | Status |
 |-----------|--------|--------|
-| ../holophyte-feature-x | feat/feature-x | 2 ahead of main |
+| ~/.holophyte-dev/feature-x | feat/feature-x | 2 ahead of main |
 
 ### Branches with Open PRs
 | Branch | PR | Status | Review |

--- a/.claude/skills/worktree-cleanup/SKILL.md
+++ b/.claude/skills/worktree-cleanup/SKILL.md
@@ -49,8 +49,7 @@ Always ask for explicit confirmation before proceeding, especially if warnings a
 ### 5. Remove Worktree and Branch
 
 ```bash
-REPO=$(basename "$(git rev-parse --show-toplevel)")
-git worktree remove ../$REPO-<feature-name>
+git worktree remove ~/.holophyte-dev/<feature-name>
 git branch -D feat/<feature-name>
 ```
 

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -40,11 +40,11 @@ This handles everything: worktree creation, branch setup, dependency installatio
 ### 3. Verify Setup
 
 ```bash
-REPO=$(basename "$(git rev-parse --show-toplevel)")
-cd ../$REPO-<feature-name> && ls -la .env* .dev-ports CLAUDE.md
+cd ~/.holophyte-dev/<feature-name> && ls -la .env* .dev-ports CLAUDE.md
 ```
 
 ## After Creation
 
 - Run `bun run dev:local` in the new worktree (uses isolated local Convex)
 - The main directory remains on its current branch
+- Worktrees are stored in `~/.holophyte-dev/`

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -18,8 +18,8 @@ if [[ ! "$FEATURE_NAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then
 fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-REPO="$(basename "$REPO_ROOT")"
-WORKTREE_PATH="$REPO_ROOT/../$REPO-$FEATURE_NAME"
+WORKTREE_DIR="$HOME/.holophyte-dev"
+WORKTREE_PATH="$WORKTREE_DIR/$FEATURE_NAME"
 BRANCH="feat/$FEATURE_NAME"
 
 # Check if branch already exists
@@ -34,8 +34,11 @@ if [ -d "$WORKTREE_PATH" ]; then
   exit 1
 fi
 
+# Ensure worktree directory exists
+mkdir -p "$WORKTREE_DIR"
+
 # Create worktree
-echo "Creating worktree at ../$REPO-$FEATURE_NAME on branch $BRANCH..."
+echo "Creating worktree at ~/.holophyte-dev/$FEATURE_NAME on branch $BRANCH..."
 git worktree add "$WORKTREE_PATH" -b "$BRANCH"
 
 # Copy env files — .env.local gives Convex the project context so
@@ -80,9 +83,9 @@ cd "$WORKTREE_PATH" && bunx convex dev --local \
   --once
 
 echo ""
-echo "Worktree created: ../$REPO-$FEATURE_NAME"
+echo "Worktree created: ~/.holophyte-dev/$FEATURE_NAME"
 echo "Ports: dev=$DEV_PORT, convex=$CONVEX_CLOUD_PORT/$CONVEX_SITE_PORT"
 echo ""
 echo "To start dev:"
-echo "  cd ../$REPO-$FEATURE_NAME"
+echo "  cd ~/.holophyte-dev/$FEATURE_NAME"
 echo "  bun run dev:local"


### PR DESCRIPTION
## Summary
- Worktrees were created as sibling directories next to the repo (e.g. `~/Development/holophyte-my-feature`), cluttering the Development folder
- Moved worktree storage to `~/.holophyte-dev/<name>` — a dedicated hidden directory in the user's home
- Updated the creation script, worktree/worktree-cleanup/branch-status skills to use the new path

## Test plan
- [ ] Run `bun run worktree:create test-feature` and verify it creates `~/.holophyte-dev/test-feature`
- [ ] Run `bun run dev:local` from the new worktree
- [ ] Clean up with `git worktree remove ~/.holophyte-dev/test-feature && git branch -D feat/test-feature`

🤖 Generated with [Claude Code](https://claude.com/claude-code)