### PR TITLE
chore: add Docusaurus evaluation and refine Storybook criteria in autopilot skills

### DIFF
--- a/.claude/skills/autopilot-team/SKILL.md
+++ b/.claude/skills/autopilot-team/SKILL.md
@@ -67,12 +67,29 @@ Spawn three teammates with specific roles:
 
 **Documenter** (use Sonnet):
 > You are the documentation specialist for the Holophyte project. Watch for
-> completed implementation tasks. For each new component, generate a Storybook
-> story (co-located `.stories.tsx`). Add TSDoc comments to all new exported
-> functions and interfaces. If you notice repeated Convex query patterns across
-> components, extract them into custom hooks in `src/frontend/hooks/`. Verify
-> stories build with `timeout 60000 bun run build-storybook`. Do not modify
-> implementation logic. Coordinate with the tester to avoid file conflicts.
+> completed implementation tasks. Your responsibilities:
+>
+> **Storybook**: For new reusable UI components or components with multiple visual
+> states, generate a co-located `.stories.tsx`. Skip Storybook for page-level
+> layouts, data-coupled feature components that need extensive Convex mocking, and
+> thin wrappers with no visual complexity. Verify with `timeout 60000 bun run
+> build-storybook`.
+>
+> **TSDoc**: Add TSDoc comments to all new exported functions and interfaces.
+>
+> **Docusaurus**: Evaluate whether changes warrant updating project docs in
+> `docs/docs/`. Changes are doc-worthy if they add new public hooks, utilities,
+> API endpoints, components with non-trivial behavior, Convex tables/queries, or
+> agents/skills. Changes are NOT doc-worthy if they are bug fixes, internal
+> refactors, style-only, config-only, or test-only changes. If doc-worthy, update
+> only the affected Docusaurus pages — do not regenerate unrelated docs. Verify
+> with `cd docs && bunx docusaurus build`.
+>
+> **DRY**: If you notice repeated Convex query patterns across components, extract
+> them into custom hooks in `src/frontend/hooks/`.
+>
+> Do not modify implementation logic. Coordinate with the tester to avoid file
+> conflicts.
 
 ### 4. Coordinate
 
@@ -93,6 +110,7 @@ bun run lint:fix
 bunx tsc --noEmit
 bun run test
 timeout 60000 bun run build-storybook
+cd docs && bunx docusaurus build
 ```
 
 Fix any remaining issues. Use the `test-fixer` subagent if tests fail.

--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -57,25 +57,48 @@ Before committing, run reviewers in parallel:
 
 ### 3.5. Documentation, Testing, and Accessibility for New Code
 
-Check for new files added on the branch:
+Check for new and changed files on the branch:
 
 ```bash
-git diff main...HEAD --name-only --diff-filter=A
+git diff main...HEAD --name-only --diff-filter=A   # new files
+git diff main...HEAD --name-only                     # all changed files
 ```
 
 For each new file:
-- **New `.tsx` components** → use the `storybook-writer` subagent to generate a co-located `.stories.tsx`
+- **New reusable UI components or components with multiple visual states** → use the `storybook-writer` subagent to generate a co-located `.stories.tsx`. Skip Storybook for page-level layouts, data-coupled feature components that need extensive Convex mocking, and thin wrappers with no visual complexity.
 - **New `.ts`/`.tsx` exports** → use the `test-writer` subagent to generate co-located tests
 - **New/changed UI components** → use the `a11y-reviewer` subagent to audit accessibility (already done in step 3 — review results here)
 - Add TSDoc `/** */` comments to all new exported functions and interfaces
 
-Skip this step if no new files were added (only modifications to existing files).
+Skip Storybook/test generation if no new files were added (only modifications to existing files).
 
-After generating stories and tests, verify:
+#### Docusaurus Documentation Evaluation
+
+Evaluate whether the changes warrant updating Docusaurus docs. The changes are **doc-worthy** if ANY of these are true:
+
+- New public hook, utility, or API endpoint was added
+- New component with non-trivial behavior or complex props was added
+- Existing documented architecture or data flow changed meaningfully
+- New Convex table, query, or mutation was added
+- New agent, skill, or automation pattern was introduced
+
+The changes are **NOT doc-worthy** if ALL of these are true:
+
+- Bug fix or minor refactor with no API surface change
+- Internal implementation detail changed (no public-facing impact)
+- Style-only or config-only changes
+- Test-only or story-only additions
+
+If doc-worthy, use the `doc-writer` subagent:
+
+> Review the changes on this branch (`git diff main...HEAD --name-only`) and update the relevant Docusaurus documentation in `docs/docs/`. Only update pages that are affected by the changes — do not regenerate unrelated docs. Add TSDoc comments to any new exported functions/interfaces that lack them. Verify with `cd docs && bunx docusaurus build`.
+
+After generating stories, tests, and docs, verify:
 
 ```bash
 bunx vitest run
 timeout 60000 bun run build-storybook
+cd docs && bunx docusaurus build
 ```
 
 Fix any failures before proceeding.


### PR DESCRIPTION
## Summary
- Autopilot and autopilot-team skills now evaluate whether changes warrant Docusaurus docs updates using doc-worthiness criteria (new APIs, hooks, non-trivial components, Convex tables, agents/skills — skip bug fixes, refactors, config/test-only changes)
- Narrowed Storybook story generation to reusable UI components and components with multiple visual states — no longer generates stories for page layouts, data-coupled feature components, or thin wrappers
- Expanded autopilot-team Documenter role with structured responsibilities: Storybook, TSDoc, Docusaurus, and DRY extraction
- Added `docusaurus build` to quality checks in autopilot-team

🤖 Generated with [Claude Code](https://claude.com/claude-code)