### PR TITLE
chore: remove project-level permission overrides

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,31 +2,5 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
-  },
-  "permissions": {
-    "allow": [
-      "Bash(bun install *)",
-      "Bash(bun run *)",
-      "Bash(bunx *)",
-      "Bash(git status *)",
-      "Bash(git diff *)",
-      "Bash(git log *)",
-      "Bash(git branch *)",
-      "Bash(git add *)",
-      "Bash(git commit *)",
-      "Bash(git push *)",
-      "Bash(git pull *)",
-      "Bash(git checkout *)",
-      "Bash(git worktree *)",
-      "Bash(git -C *)",
-      "Bash(gh pr *)",
-      "Bash(gh api *)",
-      "Bash(ls *)",
-      "Bash(cp *)",
-      "Bash(mkdir *)",
-      "Bash(basename *)",
-      "Bash(timeout * bun run *)",
-      "Bash(timeout * bunx *)"
-    ]
   }
 }


### PR DESCRIPTION
## Summary
- Remove redundant project-level permission allow-list from `.claude/settings.json`
- These granular entries (e.g. `git status *`, `git diff *`) were overriding broader global wildcards (`git *`), causing unnecessary permission prompts for subagents working in worktrees

## Test plan
- [x] Verify Claude Code inherits global permissions without prompting for `git`, `gh`, `bun`, `cp`, etc.
- [x] Verify agent teams still work (env var preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)