### PR TITLE
chore: add PostToolUse lint hook for auto-formatting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,18 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run lint:fix 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds a Claude Code `PostToolUse` hook that runs `bun run lint:fix` after every `Write` or `Edit` tool call
- Fixes lint issues inline during development instead of catching them at commit time

🤖 Generated with [Claude Code](https://claude.com/claude-code)