### PR TITLE
chore: add .playwright-mcp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ convex/_generated
 test-results
 playwright-report
 e2e/.auth/
+.playwright-mcp/
 
 # storybook
 storybook-static


### PR DESCRIPTION
## Summary
- Add `.playwright-mcp/` directory to `.gitignore` under the playwright section

🤖 Generated with [Claude Code](https://claude.com/claude-code)