### PR TITLE
fix: log SDK error results in consumeIterator

### DIFF
--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -481,6 +481,10 @@ async function consumeIterator(
 
       // Detect error results
       if (event.type === 'result' && 'is_error' in event && event.is_error) {
+        console.error(
+          `[session ${sessionId}] SDK result error:`,
+          (event as Record<string, unknown>).error,
+        );
         finalStatus = 'failed';
       }
 


### PR DESCRIPTION
## Summary
- Add `console.error` logging when the SDK iterator yields a `result` event with `is_error: true` in `consumeIterator`
- Previously these error results were silently swallowed, making session failures invisible in server logs

Closes #64

## Test plan
- [ ] Start a session that triggers an SDK error result (e.g., invalid prompt or model error)
- [ ] Verify the error appears in server logs with the `[session <id>] SDK result error:` prefix
- [ ] Verify normal (non-error) result events are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)