### PR TITLE
docs: document Bun --watch stderr swallowing gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,4 +208,5 @@ Server configuration lives in environment variables with sensible defaults:
 - `useSemanticElements` biome rule is set to "warn" (kanban board needs div-based drag-drop)
 - `bunfig.toml` configures `bun-plugin-tailwind` under `[serve.static]`
 - Pre-commit hooks configured via `.githooks/` — `prepare` script in package.json sets `core.hooksPath` on `bun install`
+- `bun run --watch` swallows subprocess stderr — run `bun src/server.ts` directly when debugging SDK session issues
 - No CI/CD or Docker configured


### PR DESCRIPTION
## Summary
- Added a gotcha to the Key Gotchas section in CLAUDE.md documenting that `bun run --watch` swallows subprocess stderr, with the workaround of running `bun src/server.ts` directly when debugging SDK session issues

Closes #63

## Test plan
- [x] Verified CLAUDE.md renders correctly with the new bullet point
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)