### PR TITLE
fix: guard against race condition on simultaneous session resume

### DIFF
--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -172,6 +172,46 @@ export const updateStatus = mutation({
 });
 
 /**
+ * Atomically transitions an idle session to `running` for resume.
+ *
+ * Guards against the race condition where two browser tabs attempt to resume
+ * the same session simultaneously: the first caller wins and the second gets
+ * `{ ok: false }` instead of a thrown error, so the frontend can handle it
+ * gracefully without surfacing an error boundary.
+ *
+ * Requires at least `member` role in the session's parent org.
+ *
+ * @returns `{ ok: true }` if the transition succeeded, `{ ok: false }` if the
+ *   session was not in `idle` status (i.e. another tab already resumed it).
+ */
+export const resumeSession = mutation({
+  args: {
+    id: v.id('sessions'),
+  },
+  handler: async (ctx, args) => {
+    const session = await ctx.db.get(args.id);
+    if (!session) throw new Error('Session not found');
+    const task = await ctx.db.get(session.taskId);
+    if (!task) throw new Error('Task not found');
+    const repo = await ctx.db.get(task.repoId);
+    if (!repo) throw new Error('Repo not found');
+    const { membership } = await requireOrgMembership(ctx, repo.orgId);
+    requireRole(membership, 'member');
+
+    // Atomic guard: only transition from idle → running
+    if (session.status !== 'idle') {
+      return { ok: false };
+    }
+
+    await ctx.db.patch(args.id, {
+      status: 'running',
+      lastActivityAt: Date.now(),
+    });
+    return { ok: true };
+  },
+});
+
+/**
  * Bumps `lastActivityAt` to the current time.
  *
  * Called from the frontend when the user sends a message, so the session list

--- a/src/frontend/components/SessionPanel.tsx
+++ b/src/frontend/components/SessionPanel.tsx
@@ -27,6 +27,7 @@ export default function SessionPanel({ taskId }: SessionPanelProps) {
   const closeSession = useAppStore((s) => s.closeSession);
   const openSession = useAppStore((s) => s.openSession);
   const updateSessionStatus = useMutation(api.sessions.updateStatus);
+  const resumeSessionMutation = useMutation(api.sessions.resumeSession);
   const createSession = useMutation(api.sessions.create);
 
   // Load the session record so we can access sdkSessionId, etc.
@@ -193,8 +194,16 @@ export default function SessionPanel({ taskId }: SessionPanelProps) {
       sdkSessionId &&
       task?.repo?.path
     ) {
+      // Atomic guard: only one tab can transition idle → running
+      const result = await resumeSessionMutation({ id: session._id });
+      if (!result.ok) {
+        // Another tab already resumed this session — silently bail out.
+        // The Convex reactive query will update the UI to reflect the
+        // running state from the other tab.
+        return;
+      }
+
       try {
-        await updateSessionStatus({ id: session._id, status: 'running' });
         const res = await fetch('/api/sessions/start', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -214,7 +223,7 @@ export default function SessionPanel({ taskId }: SessionPanelProps) {
       } catch (err) {
         // Revert the status so the session doesn't stay stuck as 'running'
         try {
-          await updateSessionStatus({ id: session._id, status: 'failed' });
+          await updateSessionStatus({ id: session._id, status: 'idle' });
         } catch (cleanupErr) {
           console.error('Failed to revert session status:', cleanupErr);
         }


### PR DESCRIPTION
## Summary
- Add atomic `resumeSession` Convex mutation that only transitions `idle` → `running`, rejecting if the session is already in another state (e.g. another tab already resumed it)
- Frontend uses `resumeSession` instead of generic `updateStatus` for the resume path, silently bailing out when another tab wins the race
- Revert to `idle` (not `failed`) on server-side start failure, since the session data is still valid and resumable

## Test plan
- [ ] Open two browser tabs with the same idle session
- [ ] Click resume in both tabs simultaneously — only one should start, the other should silently no-op
- [ ] Verify the session shows as `running` in both tabs (via Convex reactive query)
- [ ] Verify that if the server rejects the start request after the atomic guard succeeds, the session reverts to `idle` (not `failed`)
- [ ] Existing resume flow from a single tab still works as before

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)