### PR TITLE
fix: disable UserInput during running state and clean up biome suppressions

### DIFF
--- a/src/claude/manager.rethink.test.ts
+++ b/src/claude/manager.rethink.test.ts
@@ -16,8 +16,7 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
 global.fetch = vi.fn().mockResolvedValue({
   ok: true,
   text: async () => '',
-  // biome-ignore lint/suspicious/noExplicitAny: vi.fn mock doesn't satisfy strict fetch types
-} as Response) as any;
+} as Response) as unknown as typeof fetch;
 
 process.env.CONVEX_SITE_URL = 'http://localhost:3211';
 process.env.INTERNAL_API_SECRET = 'test-secret';

--- a/src/frontend/components/SessionPanel.tsx
+++ b/src/frontend/components/SessionPanel.tsx
@@ -145,6 +145,7 @@ export default function SessionPanel({ taskId }: SessionPanelProps) {
 
   // 'idle' is not finished from the user's perspective — they can still resume
   const isFinished = sessionStatus === 'failed';
+  const isRunning = sessionStatus === 'running';
   const isLoading =
     !isFinished &&
     sessionStatus !== 'idle' &&
@@ -268,7 +269,7 @@ export default function SessionPanel({ taskId }: SessionPanelProps) {
 
         <UserInput
           sessionId={sessionId ?? 'new'}
-          disabled={isFinished}
+          disabled={isFinished || isRunning}
           queued={messageQueued}
           onSend={handleSend}
         />

--- a/src/frontend/components/UserInput.test.tsx
+++ b/src/frontend/components/UserInput.test.tsx
@@ -24,11 +24,15 @@ describe('UserInput', () => {
       ).toBeInTheDocument();
     });
 
-    it('shows "Session failed" placeholder when disabled', () => {
+    it('shows waiting placeholder when disabled', () => {
       render(<UserInput sessionId="s1" onSend={vi.fn()} disabled />);
-      expect(screen.getByPlaceholderText('Session failed')).toBeInTheDocument();
       expect(
-        screen.getByText('Session failed — launch a new session to continue'),
+        screen.getByPlaceholderText('Waiting for session to become idle…'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Input is disabled while the session is busy or has ended',
+        ),
       ).toBeInTheDocument();
     });
   });

--- a/src/frontend/components/UserInput.tsx
+++ b/src/frontend/components/UserInput.tsx
@@ -8,7 +8,7 @@ interface UserInputProps {
   sessionId: string | null;
   /**
    * When `true`, disables the textarea and send button. Pass `true` when
-   * the session is completed, failed, or stopped.
+   * the session is running, failed, or otherwise not accepting input.
    */
   disabled?: boolean;
   /**
@@ -29,7 +29,7 @@ interface UserInputProps {
  *
  * - Supports Cmd+Enter (macOS) or Ctrl+Enter to submit.
  * - Clears the textarea on successful send.
- * - Shows "Session failed" as placeholder when `disabled` is `true`.
+ * - Shows a "waiting" placeholder when `disabled` is `true`.
  */
 export default function UserInput({
   sessionId,
@@ -44,7 +44,7 @@ export default function UserInput({
 
   const canSend = !disabled && !sending && text.trim().length > 0 && sessionId;
   const disabledReason = disabled
-    ? 'Session failed — launch a new session to continue'
+    ? 'Input is disabled while the session is busy or has ended'
     : null;
 
   const resizeTextarea = (textarea: HTMLTextAreaElement) => {
@@ -71,7 +71,7 @@ export default function UserInput({
   };
 
   const placeholder = disabled
-    ? 'Session failed'
+    ? 'Waiting for session to become idle…'
     : 'Send a message to Claude… (Cmd+Enter to send)';
 
   return (


### PR DESCRIPTION
## Summary
- Disable `UserInput` when `sessionStatus === 'running'` to prevent users from submitting messages that always 404 in single-turn mode
- Update placeholder and disabled reason text to be state-agnostic ("waiting for session to become idle" instead of "session failed")
- Fix misplaced `biome-ignore` suppression in `manager.rethink.test.ts` by replacing `as any` with `as unknown as typeof fetch`

Closes #53
Closes #56

## Test plan
- [x] `UserInput.test.tsx` updated to match new disabled text
- [x] `bun run lint` passes with no new warnings
- [x] All 161 unit tests pass (pre-existing Convex codegen failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)