### PR TITLE
fix: align manual testing auth param and auto-enable ALLOW_ANONYMOUS_AUTH

### DIFF
--- a/docs/docs/testing/playwright-manual.md
+++ b/docs/docs/testing/playwright-manual.md
@@ -25,10 +25,9 @@ The Playwright MCP server is configured in the project. Claude Code can use it d
 
 **Prerequisites:**
 
-1. Start local Convex: `bun run convex:local`
-2. Set anonymous auth (once per Convex instance): `bunx convex env set ALLOW_ANONYMOUS_AUTH 1`
-3. Start the dev server: `bun run dev:local`
-4. Navigate to `http://localhost:<port>?auth` — the `?auth` query param triggers anonymous auth
+1. Start the dev server: `bun run dev:local` (auto-enables `ALLOW_ANONYMOUS_AUTH` for the Bun server)
+2. Ensure Convex has anonymous auth: `bunx convex env set ALLOW_ANONYMOUS_AUTH 1` (auto-set by `worktree:create`)
+3. Navigate to `http://localhost:<port>?auth` — the `?auth` query param triggers anonymous auth
 
 ## Testing Flow
 
@@ -118,13 +117,12 @@ pkill -f "chromium.*--headless"
 
 ### Anonymous auth not set up (manual testing)
 
-Manual testing requires `ALLOW_ANONYMOUS_AUTH=1` on the Convex environment. Without it, auth never completes and the app appears stuck. Run once per Convex instance:
+Manual testing requires `ALLOW_ANONYMOUS_AUTH=1` in two places:
 
-```bash
-bunx convex env set ALLOW_ANONYMOUS_AUTH 1
-```
+1. **Bun server process** — `bun run dev:local` sets this automatically. If running the server directly (`bun src/server.ts`), prefix with `ALLOW_ANONYMOUS_AUTH=1`.
+2. **Convex environment** — `bunx convex env set ALLOW_ANONYMOUS_AUTH 1`. Auto-set by `bun run worktree:create` for new worktrees.
 
-> **Note:** `bun run worktree:create` sets this automatically for new worktrees. E2E tests (`bun run test:e2e`) handle this automatically via the ephemeral backend.
+Without both, auth never completes and the app appears stuck. E2E tests (`bun run test:e2e`) handle both automatically via the ephemeral backend.
 
 ### Missing `?auth` query param
 

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -44,7 +44,8 @@ echo $$ > "$LOCKFILE"
 trap 'rm -f "$LOCKFILE"' EXIT
 
 export PORT="$DEV_PORT"
-export ALLOW_ANONYMOUS_AUTH="${ALLOW_ANONYMOUS_AUTH:-}"
+# Auto-enable anonymous auth for local dev (manual testing via ?auth query param)
+export ALLOW_ANONYMOUS_AUTH="${ALLOW_ANONYMOUS_AUTH:-1}"
 
 # Kill any lingering processes on dev ports (prevents Bun/Convex from auto-incrementing)
 for PORT_NUM in "$DEV_PORT" "$CONVEX_CLOUD_PORT" "$CONVEX_SITE_PORT"; do

--- a/src/frontend/layouts/RootLayout.tsx
+++ b/src/frontend/layouts/RootLayout.tsx
@@ -46,7 +46,7 @@ export default function RootLayout() {
   return (
     <>
       {(e2eTest ||
-        (allowAnonymousAuth && window.location.search.includes('anon'))) && (
+        (allowAnonymousAuth && window.location.search.includes('auth'))) && (
         <AutoAnonymousAuth />
       )}
       <AuthLoading>{spinner}</AuthLoading>

--- a/src/frontend/lib/config.ts
+++ b/src/frontend/lib/config.ts
@@ -1,7 +1,7 @@
 /** E2E test mode — set by init() from server config, skips auth gates. */
 export let e2eTest = false;
 
-/** Anonymous auth available — auto sign-in when `?anon` param is present. */
+/** Anonymous auth available — auto sign-in when `?auth` param is present. */
 export let allowAnonymousAuth = false;
 
 export function setE2eTest(value: boolean) {


### PR DESCRIPTION
## Summary
- **`?anon` → `?auth`**: RootLayout checked `?anon` in the query string but all docs (CLAUDE.md, playwright-manual.md) referenced `?auth`. Aligned the code to match docs.
- **Auto-enable `ALLOW_ANONYMOUS_AUTH` in `dev-local.sh`**: The env var was only set on the Convex backend by `worktree:create`, but the Bun server also needs it in `process.env` for `/api/config` to return `allowAnonymousAuth: true`. `dev-local.sh` now defaults it to `1`.
- **Updated manual testing docs**: Clarified that anonymous auth is needed in two places (Bun server + Convex env) and simplified the prerequisites.

## Test plan
- [x] Verified in a fresh worktree: `bun run dev:local` + `?auth` triggers anonymous auth and loads the app
- [x] E2E tests pass (33/34 — the 1 failure is a pre-existing locator collision unrelated to this change)
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)