### PR TITLE
fix: resolve React setState-during-render warning in OrgSwitcher

### DIFF
--- a/src/frontend/components/OrgSwitcher.tsx
+++ b/src/frontend/components/OrgSwitcher.tsx
@@ -1,6 +1,7 @@
 import { api } from '@convex/_generated/api';
 import { useQuery } from 'convex/react';
 import { Building2, Check, ChevronsUpDown } from 'lucide-react';
+import { useEffect } from 'react';
 import { cn } from '@/frontend/lib/utils';
 import { useAppStore } from '@/frontend/stores/app';
 import Button from './ui/Button';
@@ -11,23 +12,20 @@ export default function OrgSwitcher() {
   const selectedOrgId = useAppStore((s) => s.selectedOrgId);
   const setSelectedOrgId = useAppStore((s) => s.setSelectedOrgId);
 
-  // Auto-select the first org, or reset if selected org is no longer valid
-  const stillValid =
-    orgs &&
-    orgs.length > 0 &&
-    selectedOrgId &&
-    orgs.some((o) => o._id === selectedOrgId);
-  if (
-    orgs &&
-    orgs.length > 0 &&
-    !stillValid &&
-    orgs[0] &&
-    selectedOrgId !== orgs[0]._id
-  ) {
-    setSelectedOrgId(orgs[0]._id);
-  }
+  // Derive the effective org ID synchronously — no render flash
+  const effectiveOrgId =
+    orgs && selectedOrgId && orgs.some((o) => o._id === selectedOrgId)
+      ? selectedOrgId
+      : (orgs?.[0]?._id ?? null);
 
-  const selectedOrg = orgs?.find((o) => o._id === selectedOrgId);
+  // Sync the Zustand store when derived value differs (external system sync)
+  useEffect(() => {
+    if (effectiveOrgId && effectiveOrgId !== selectedOrgId) {
+      setSelectedOrgId(effectiveOrgId);
+    }
+  }, [effectiveOrgId, selectedOrgId, setSelectedOrgId]);
+
+  const selectedOrg = orgs?.find((o) => o._id === effectiveOrgId);
 
   return (
     <Popover>
@@ -35,37 +33,56 @@ export default function OrgSwitcher() {
         <Button
           variant="ghost"
           className="w-full justify-between gap-2 text-sm px-2"
+          aria-label={
+            selectedOrg
+              ? `Current organization: ${selectedOrg.name}`
+              : 'Select organization'
+          }
         >
           <div className="flex items-center gap-2 min-w-0">
-            <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <Building2
+              className="h-4 w-4 shrink-0 text-muted-foreground"
+              aria-hidden="true"
+            />
             <span className="truncate">
               {selectedOrg?.name ?? 'Select org...'}
             </span>
           </div>
-          <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <ChevronsUpDown
+            className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-56 p-1" align="start">
-        <div className="space-y-0.5">
+        <div className="space-y-0.5" role="menu" aria-label="Organizations">
           {orgs?.map((org) => (
             <button
               key={org._id}
               type="button"
+              role="menuitemradio"
+              aria-checked={effectiveOrgId === org._id}
               onClick={() => setSelectedOrgId(org._id)}
               className={cn(
                 'w-full flex items-center gap-2 px-2 py-1.5 rounded text-sm hover:bg-muted/50 transition-colors text-left',
-                selectedOrgId === org._id && 'bg-muted',
+                effectiveOrgId === org._id && 'bg-muted',
               )}
             >
-              <Building2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <Building2
+                className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+                aria-hidden="true"
+              />
               <span className="truncate flex-1">{org.name}</span>
               {org.personal && (
                 <span className="text-[10px] text-muted-foreground">
                   Personal
                 </span>
               )}
-              {selectedOrgId === org._id && (
-                <Check className="h-3.5 w-3.5 shrink-0 text-primary" />
+              {effectiveOrgId === org._id && (
+                <Check
+                  className="h-3.5 w-3.5 shrink-0 text-primary"
+                  aria-hidden="true"
+                />
               )}
             </button>
           ))}


### PR DESCRIPTION
## Summary
- Fixes the React "Cannot update a component while rendering" warning in `OrgSwitcher` by deriving `effectiveOrgId` inline during render instead of calling `setSelectedOrgId` in the render path
- A minimal `useEffect` syncs the Zustand store only when the derived value differs — valid external system sync, no render flash
- Fixes critical a11y issues: `aria-hidden` on decorative icons, `role="menuitemradio"` + `aria-checked` for selection state, `aria-label` on the trigger button

Closes #103

## Test plan
- [x] Lint, typecheck, and 335 unit tests pass
- [x] Verify the React console warning no longer appears
- [x] Verify org auto-selection still works on first load
- [x] Verify org switcher popover shows correct selection state
- [x] Screen reader announces org selection state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)