### PR TITLE
test: add coverage for session/sessionMessages Convex mutations

### DIFF
--- a/convex/sessionMessages.test.ts
+++ b/convex/sessionMessages.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment edge-runtime
+import { convexTest } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+import { api, internal } from './_generated/api';
+import schema from './schema';
+
+/** Create a user and return an authenticated test client + userId. */
+async function setupUser(t: ReturnType<typeof convexTest>, name = 'Test User') {
+  const userId = await t.run(async (ctx) => {
+    return await ctx.db.insert('users', { name });
+  });
+  return { userId, authed: t.withIdentity({ subject: `${userId}|s1` }) };
+}
+
+/** Create user + org + repo + task + session, return everything needed for message tests. */
+async function setupSessionEnv(t: ReturnType<typeof convexTest>) {
+  const { userId, authed } = await setupUser(t, 'Owner');
+  const orgId = await authed.mutation(api.organizations.create, {
+    name: 'Test Org',
+    slug: 'test-org',
+  });
+  const repoId = await authed.mutation(api.repos.create, {
+    name: 'test-repo',
+    path: '/tmp/test-repo',
+    orgId,
+  });
+  const taskId = await authed.mutation(api.tasks.create, {
+    repoId,
+    title: 'Test Task',
+  });
+  const sessionId = await authed.mutation(api.sessions.create, { taskId });
+  return { userId, authed, orgId, repoId, taskId, sessionId };
+}
+
+describe('sessionMessages.send', () => {
+  it('creates a message with consumed: false', async () => {
+    const t = convexTest(schema);
+    const { authed, sessionId } = await setupSessionEnv(t);
+
+    const msgId = await authed.mutation(api.sessionMessages.send, {
+      sessionId,
+      text: 'Hello session',
+    });
+
+    const msg = await t.run(async (ctx) => {
+      return await ctx.db.get(msgId);
+    });
+    expect(msg).not.toBeNull();
+    expect(msg?.sessionId).toBe(sessionId);
+    expect(msg?.text).toBe('Hello session');
+    expect(msg?.consumed).toBe(false);
+  });
+
+  it('requires member role', async () => {
+    const t = convexTest(schema);
+    const { authed: ownerAuthed, orgId, sessionId } = await setupSessionEnv(t);
+
+    // Create a viewer
+    const viewerUserId = await t.run(async (ctx) => {
+      return await ctx.db.insert('users', { name: 'Viewer' });
+    });
+    const viewerAuthed = t.withIdentity({ subject: `${viewerUserId}|s2` });
+    await ownerAuthed.mutation(api.memberships.invite, {
+      orgId,
+      userId: viewerUserId,
+      role: 'viewer',
+    });
+
+    await expect(
+      viewerAuthed.mutation(api.sessionMessages.send, {
+        sessionId,
+        text: 'Should fail',
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('sessionMessages.listPending', () => {
+  it('returns unconsumed messages for running sessions', async () => {
+    const t = convexTest(schema);
+    const { authed, sessionId } = await setupSessionEnv(t);
+
+    // Transition session to running
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'running' });
+    });
+
+    await authed.mutation(api.sessionMessages.send, {
+      sessionId,
+      text: 'Pending message',
+    });
+
+    const pending = await t.query(internal.sessionMessages.listPending, {});
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.text).toBe('Pending message');
+    expect(pending[0]?.consumed).toBe(false);
+  });
+
+  it('excludes consumed messages', async () => {
+    const t = convexTest(schema);
+    const { authed, sessionId } = await setupSessionEnv(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'running' });
+    });
+
+    const msgId = await authed.mutation(api.sessionMessages.send, {
+      sessionId,
+      text: 'Will be consumed',
+    });
+
+    // Mark as consumed
+    await t.mutation(internal.sessionMessages.markConsumed, { id: msgId });
+
+    const pending = await t.query(internal.sessionMessages.listPending, {});
+    expect(pending).toHaveLength(0);
+  });
+
+  it('excludes messages for non-running sessions', async () => {
+    const t = convexTest(schema);
+    const { authed, sessionId } = await setupSessionEnv(t);
+
+    // Session is in 'queued' status (default from create)
+    await authed.mutation(api.sessionMessages.send, {
+      sessionId,
+      text: 'Message for queued session',
+    });
+
+    const pending = await t.query(internal.sessionMessages.listPending, {});
+    expect(pending).toHaveLength(0);
+  });
+});
+
+describe('sessionMessages.markConsumed', () => {
+  it('sets consumed to true', async () => {
+    const t = convexTest(schema);
+    const { authed, sessionId } = await setupSessionEnv(t);
+
+    const msgId = await authed.mutation(api.sessionMessages.send, {
+      sessionId,
+      text: 'Mark me consumed',
+    });
+
+    await t.mutation(internal.sessionMessages.markConsumed, { id: msgId });
+
+    const msg = await t.run(async (ctx) => {
+      return await ctx.db.get(msgId);
+    });
+    expect(msg?.consumed).toBe(true);
+  });
+
+  it('no-ops for nonexistent message ID', async () => {
+    const t = convexTest(schema);
+    const { authed, sessionId } = await setupSessionEnv(t);
+
+    // Create and delete a message to get a valid-format but nonexistent ID
+    const msgId = await authed.mutation(api.sessionMessages.send, {
+      sessionId,
+      text: 'Temporary',
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.delete(msgId);
+    });
+
+    // Should not throw
+    await t.mutation(internal.sessionMessages.markConsumed, { id: msgId });
+  });
+});

--- a/convex/sessions.test.ts
+++ b/convex/sessions.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment edge-runtime
 import { convexTest } from 'convex-test';
 import { describe, expect, it } from 'vitest';
-import { api } from './_generated/api';
+import { api, internal } from './_generated/api';
 import schema from './schema';
 
 /** Create a user and return an authenticated test client + userId. */
@@ -213,5 +213,295 @@ describe('sessions.updateLastActivity', () => {
 
     const updated = await authed.query(api.sessions.get, { id: sessionId });
     expect(updated?.lastActivityAt).toBeGreaterThan(originalActivity ?? 0);
+  });
+});
+
+describe('sessions.requestStop', () => {
+  it('stops a running session', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'running' });
+    });
+
+    await authed.mutation(api.sessions.requestStop, { id: sessionId });
+
+    const session = await authed.query(api.sessions.get, { id: sessionId });
+    expect(session?.status).toBe('stopped');
+  });
+
+  it('stops a queued session', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    // create() already sets 'queued', no patch needed
+
+    await authed.mutation(api.sessions.requestStop, { id: sessionId });
+
+    const session = await authed.query(api.sessions.get, { id: sessionId });
+    expect(session?.status).toBe('stopped');
+  });
+
+  it('no-ops when session is idle', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'idle' });
+    });
+
+    await authed.mutation(api.sessions.requestStop, { id: sessionId });
+
+    const session = await authed.query(api.sessions.get, { id: sessionId });
+    expect(session?.status).toBe('idle');
+  });
+
+  it('no-ops when session is already stopped', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'stopped' });
+    });
+
+    await authed.mutation(api.sessions.requestStop, { id: sessionId });
+
+    const session = await authed.query(api.sessions.get, { id: sessionId });
+    expect(session?.status).toBe('stopped');
+  });
+
+  it('no-ops when session is failed', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'failed' });
+    });
+
+    await authed.mutation(api.sessions.requestStop, { id: sessionId });
+
+    const session = await authed.query(api.sessions.get, { id: sessionId });
+    expect(session?.status).toBe('failed');
+  });
+
+  it('requires member role', async () => {
+    const t = convexTest(schema);
+    const { authed: ownerAuthed, orgId, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await ownerAuthed.mutation(api.sessions.create, {
+      taskId,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'running' });
+    });
+
+    // Create a viewer
+    const viewerUserId = await t.run(async (ctx) => {
+      return await ctx.db.insert('users', { name: 'Viewer' });
+    });
+    const viewerAuthed = t.withIdentity({ subject: `${viewerUserId}|s2` });
+    await ownerAuthed.mutation(api.memberships.invite, {
+      orgId,
+      userId: viewerUserId,
+      role: 'viewer',
+    });
+
+    await expect(
+      viewerAuthed.mutation(api.sessions.requestStop, { id: sessionId }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('sessions.queueResume', () => {
+  it('resumes an idle session → queued with queuedPrompt set', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'idle' });
+    });
+
+    const result = await authed.mutation(api.sessions.queueResume, {
+      id: sessionId,
+      prompt: 'Continue the task',
+    });
+    expect(result).toEqual({ ok: true });
+
+    const session = await authed.query(api.sessions.get, { id: sessionId });
+    expect(session?.status).toBe('queued');
+    expect(session?.queuedPrompt).toBe('Continue the task');
+  });
+
+  it('returns { ok: false } when session is not idle', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'running' });
+    });
+
+    const result = await authed.mutation(api.sessions.queueResume, {
+      id: sessionId,
+      prompt: 'Continue',
+    });
+    expect(result).toEqual({ ok: false });
+
+    const session = await authed.query(api.sessions.get, { id: sessionId });
+    expect(session?.status).toBe('running');
+  });
+
+  it('requires member role', async () => {
+    const t = convexTest(schema);
+    const { authed: ownerAuthed, orgId, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await ownerAuthed.mutation(api.sessions.create, {
+      taskId,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'idle' });
+    });
+
+    // Create a viewer
+    const viewerUserId = await t.run(async (ctx) => {
+      return await ctx.db.insert('users', { name: 'Viewer' });
+    });
+    const viewerAuthed = t.withIdentity({ subject: `${viewerUserId}|s2` });
+    await ownerAuthed.mutation(api.memberships.invite, {
+      orgId,
+      userId: viewerUserId,
+      role: 'viewer',
+    });
+
+    await expect(
+      viewerAuthed.mutation(api.sessions.queueResume, {
+        id: sessionId,
+        prompt: 'Continue',
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('sessions.listQueued', () => {
+  it('returns queued sessions with repoPath enriched', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    // create() sets status to 'queued' — no patch needed
+
+    const queued = await t.query(internal.sessions.listQueued, {});
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?._id).toBe(sessionId);
+    expect(queued[0]?.repoPath).toBe('/tmp/test-repo');
+  });
+
+  it('excludes non-queued sessions', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'running' });
+    });
+
+    const queued = await t.query(internal.sessions.listQueued, {});
+    expect(queued).toHaveLength(0);
+  });
+
+  it('skips orphaned sessions (missing task/repo)', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+
+    // Delete the task to orphan the session
+    await t.run(async (ctx) => {
+      await ctx.db.delete(taskId);
+    });
+
+    const queued = await t.query(internal.sessions.listQueued, {});
+    // The session is queued but its task is gone — should be skipped
+    expect(queued.every((s) => s._id !== sessionId)).toBe(true);
+  });
+});
+
+describe('sessions.claimQueued', () => {
+  it('claims a queued session → running', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+
+    const result = await t.mutation(internal.sessions.claimQueued, {
+      id: sessionId,
+    });
+    expect(result).toEqual({ ok: true });
+
+    const session = await authed.query(api.sessions.get, { id: sessionId });
+    expect(session?.status).toBe('running');
+  });
+
+  it('returns { ok: false } if session is no longer queued', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(sessionId, { status: 'running' });
+    });
+
+    const result = await t.mutation(internal.sessions.claimQueued, {
+      id: sessionId,
+    });
+    expect(result).toEqual({ ok: false });
+  });
+
+  it('returns { ok: false } for nonexistent session', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    // Create a session just to get a valid-format ID, then delete it
+    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    await t.run(async (ctx) => {
+      await ctx.db.delete(sessionId);
+    });
+
+    const result = await t.mutation(internal.sessions.claimQueued, {
+      id: sessionId,
+    });
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+describe('sessions.listStopped', () => {
+  it('returns only stopped sessions', async () => {
+    const t = convexTest(schema);
+    const { authed, taskId } = await setupTaskEnv(t);
+
+    const stoppedId = await authed.mutation(api.sessions.create, { taskId });
+    const runningId = await authed.mutation(api.sessions.create, { taskId });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(stoppedId, { status: 'stopped' });
+      await ctx.db.patch(runningId, { status: 'running' });
+    });
+
+    const stopped = await t.query(internal.sessions.listStopped, {});
+    expect(stopped).toHaveLength(1);
+    expect(stopped[0]?._id).toBe(stoppedId);
+  });
+
+  it('returns empty array when none exist', async () => {
+    const t = convexTest(schema);
+
+    const stopped = await t.query(internal.sessions.listStopped, {});
+    expect(stopped).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Add tests for 8 untested Convex functions from the fetch-to-mutations refactor
- **sessions.ts**: `requestStop`, `queueResume`, `listQueued`, `claimQueued`, `listStopped` (11 tests)
- **sessionMessages.ts**: `send`, `listPending`, `markConsumed` (7 tests, new file)

Closes #96

## Test plan
- [x] `bunx vitest run convex/sessions.test.ts convex/sessionMessages.test.ts` — all 35 tests pass
- [x] Pre-commit hooks pass (codegen + lint + typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)