### PR TITLE
chore: add setup:local script and env var reference docs

### DIFF
--- a/docs/docs/local-development.md
+++ b/docs/docs/local-development.md
@@ -126,6 +126,80 @@ What it does:
 
 Your main repo's `.env.local` is never modified and your dev Convex keeps running throughout.
 
+## First-Time Setup
+
+If you're setting up a fresh clone, run:
+
+```bash
+bun run setup:local
+```
+
+This interactive script creates `.dev-ports`, provisions a local Convex backend, generates auth keys, and sets all required environment variables. You can re-run it at any time to fix a broken configuration.
+
+For worktrees, use `bun run worktree:create <name>` instead — it handles setup automatically.
+
+## Environment Variable Reference
+
+### `.dev-ports` (per-workspace, gitignored)
+
+Every workspace (main repo or worktree) needs this file. Created automatically by `bun run setup:local` or `bun run worktree:create`.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DEV_PORT` | Yes | `8080` | Bun app server port |
+| `CONVEX_CLOUD_PORT` | Yes | `3210` | Local Convex cloud port |
+| `CONVEX_SITE_PORT` | Yes | `3211` | Local Convex site / HTTP actions port |
+| `CONVEX_TEAM` | Yes | — | Convex team slug (prevents [silent cloud connection](#convex-dev---local-silently-connects-to-cloud)) |
+| `CONVEX_PROJECT` | Yes | — | Convex project name |
+
+### `.env.local` (managed by `convex dev`, do not edit manually)
+
+| Variable | Set By | Description |
+|----------|--------|-------------|
+| `CONVEX_DEPLOYMENT` | `convex dev` | Local deployment identity (e.g. `local:local-ko_vial-holophyte-1`) |
+| `CONVEX_URL` | `convex dev` | Convex cloud URL (e.g. `http://127.0.0.1:3210`) |
+| `CONVEX_SITE_URL` | `convex dev` | Convex site URL (e.g. `http://127.0.0.1:3211`) |
+
+Non-Convex vars (API keys, secrets) are preserved across reconfiguration — `convex-local.sh` and `worktree-create.sh` both save and restore them when `convex dev` overwrites this file.
+
+### `.env` (shared config, gitignored)
+
+| Variable | Set By | Description |
+|----------|--------|-------------|
+| `INTERNAL_API_SECRET` | `setup:local`, `convex-local.sh`, `worktree-create.sh` | Shared secret for companion server to Convex internal HTTP auth |
+
+### Convex Deployment Environment Variables
+
+These are set on the Convex deployment itself (via `bunx convex env set`), not in local files.
+
+| Variable | Set By | Description |
+|----------|--------|-------------|
+| `ALLOW_ANONYMOUS_AUTH` | `setup:local`, `dev-local.sh` (process env), `worktree-create.sh` (Convex env) | Enables anonymous auth for local dev / manual testing via `?auth` |
+| `INTERNAL_API_SECRET` | `setup:local`, `convex-local.sh`, `worktree-create.sh` | Must match the value in `.env` — used to authenticate companion HTTP calls |
+| `SITE_URL` | `setup:local`, `worktree-create.sh` | OAuth redirect base URL (e.g. `http://localhost:8082`) |
+| `JWT_PRIVATE_KEY` | `bunx @convex-dev/auth` | Auth token signing key |
+| `JWKS` | `bunx @convex-dev/auth` | JSON Web Key Set for token verification |
+
+### Optional: OAuth Credentials (Convex deployment env)
+
+Only needed if you're testing OAuth login locally. Set these in `.dev-ports` to have `setup:local` or `worktree-create.sh` forward them automatically, or set them manually with `bunx convex env set`.
+
+| Variable | Description |
+|----------|-------------|
+| `AUTH_GITHUB_ID` | GitHub OAuth app client ID |
+| `AUTH_GITHUB_SECRET` | GitHub OAuth app client secret |
+| `AUTH_GOOGLE_ID` | Google OAuth app client ID |
+| `AUTH_GOOGLE_SECRET` | Google OAuth app client secret |
+
+### Which Scripts Set What
+
+| Script | What it configures |
+|--------|-------------------|
+| `setup:local` | `.dev-ports`, local Convex provisioning, `INTERNAL_API_SECRET`, auth keys, `ALLOW_ANONYMOUS_AUTH`, `SITE_URL`, OAuth credentials |
+| `convex-local.sh` | `INTERNAL_API_SECRET` (in `.env` + Convex env), stale deployment detection/reconfiguration |
+| `dev-local.sh` | `ALLOW_ANONYMOUS_AUTH` (process env), starts app server + Convex via `convex-local.sh` |
+| `worktree-create.sh` | `.dev-ports` (port allocation), Convex provisioning, `INTERNAL_API_SECRET`, `SITE_URL`, `ALLOW_ANONYMOUS_AUTH`, auth keys, OAuth credentials |
+
 ## Troubleshooting
 
 ### `convex dev --local` silently connects to cloud

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "check": "bun run lint && bunx tsc --noEmit && bun run test",
     "convex:dev": "convex dev",
     "convex:local": "scripts/convex-local.sh",
+    "setup:local": "scripts/setup-local.sh",
     "convex:deploy": "convex deploy",
     "worktree:create": "scripts/worktree-create.sh",
     "pr-comments": "scripts/pr-comments.sh",

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-time setup for local Convex development (idempotent — safe to re-run)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEV_PORTS="$REPO_ROOT/.dev-ports"
+ENV_FILE="$REPO_ROOT/.env"
+
+# ── Colors ───────────────────────────────────────────────────────────
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+info()  { echo -e "${GREEN}✓${NC} $1"; }
+warn()  { echo -e "${YELLOW}⚠${NC} $1"; }
+error() { echo -e "${RED}✗${NC} $1"; }
+
+# ── Step 1: Check/create .dev-ports ──────────────────────────────────
+
+if [ -f "$DEV_PORTS" ]; then
+  info ".dev-ports already exists"
+  # shellcheck source=/dev/null
+  source "$DEV_PORTS"
+else
+  echo "Creating .dev-ports with default values..."
+
+  # Prompt for CONVEX_TEAM and CONVEX_PROJECT (no sensible defaults)
+  read -rp "CONVEX_TEAM (e.g. ko-vial): " CONVEX_TEAM
+  read -rp "CONVEX_PROJECT (e.g. holophyte): " CONVEX_PROJECT
+
+  if [ -z "$CONVEX_TEAM" ] || [ -z "$CONVEX_PROJECT" ]; then
+    error "CONVEX_TEAM and CONVEX_PROJECT are required"
+    exit 1
+  fi
+
+  DEV_PORT=8080
+  CONVEX_CLOUD_PORT=3210
+  CONVEX_SITE_PORT=3211
+
+  cat > "$DEV_PORTS" <<EOF
+DEV_PORT=$DEV_PORT
+CONVEX_CLOUD_PORT=$CONVEX_CLOUD_PORT
+CONVEX_SITE_PORT=$CONVEX_SITE_PORT
+CONVEX_TEAM=$CONVEX_TEAM
+CONVEX_PROJECT=$CONVEX_PROJECT
+EOF
+  info "Created .dev-ports (dev=$DEV_PORT, convex=$CONVEX_CLOUD_PORT/$CONVEX_SITE_PORT)"
+fi
+
+# ── Step 2: Validate required values ────────────────────────────────
+
+if [ -z "${CONVEX_TEAM:-}" ] || [ -z "${CONVEX_PROJECT:-}" ]; then
+  error ".dev-ports is missing CONVEX_TEAM and/or CONVEX_PROJECT"
+  echo "  Add them to $DEV_PORTS and re-run."
+  exit 1
+fi
+
+if ! [[ "${DEV_PORT:-}" =~ ^[0-9]+$ ]] || \
+   ! [[ "${CONVEX_CLOUD_PORT:-}" =~ ^[0-9]+$ ]] || \
+   ! [[ "${CONVEX_SITE_PORT:-}" =~ ^[0-9]+$ ]]; then
+  error ".dev-ports is missing port variables (DEV_PORT, CONVEX_CLOUD_PORT, CONVEX_SITE_PORT)"
+  exit 1
+fi
+
+info "Config: team=$CONVEX_TEAM project=$CONVEX_PROJECT dev=$DEV_PORT convex=$CONVEX_CLOUD_PORT/$CONVEX_SITE_PORT"
+
+# ── Step 3: Provision local Convex deployment ────────────────────────
+
+# Check if .env.local already has a local deployment at the right ports
+ALREADY_CONFIGURED=false
+ENV_LOCAL="$REPO_ROOT/.env.local"
+if [ -f "$ENV_LOCAL" ]; then
+  CURRENT_DEPLOYMENT=$(grep '^CONVEX_DEPLOYMENT=' "$ENV_LOCAL" | cut -d= -f2 | cut -d' ' -f1 | sed 's/^"\(.*\)"$/\1/' || true)
+  ENV_CONVEX_URL=$(grep '^CONVEX_URL=' "$ENV_LOCAL" | cut -d= -f2 | tr -d '"' || true)
+  EXPECTED_URL="http://127.0.0.1:$CONVEX_CLOUD_PORT"
+
+  if [[ "$CURRENT_DEPLOYMENT" == local:* ]] && [ "$ENV_CONVEX_URL" = "$EXPECTED_URL" ]; then
+    ALREADY_CONFIGURED=true
+  fi
+fi
+
+if [ "$ALREADY_CONFIGURED" = true ]; then
+  info "Local Convex deployment already configured in .env.local"
+else
+  echo "Provisioning local Convex deployment..."
+
+  # Save non-Convex vars — convex dev --configure existing overwrites .env.local
+  NON_CONVEX_VARS=""
+  if [ -f "$ENV_LOCAL" ]; then
+    NON_CONVEX_VARS=$(grep -vE '^(CONVEX_DEPLOYMENT|CONVEX_URL|CONVEX_SITE_URL|# Deployment used by|$)' \
+      "$ENV_LOCAL" || true)
+  fi
+
+  cd "$REPO_ROOT" && bunx convex dev --configure existing \
+    --team "$CONVEX_TEAM" \
+    --project "$CONVEX_PROJECT" \
+    --dev-deployment local \
+    --local-cloud-port "$CONVEX_CLOUD_PORT" \
+    --local-site-port "$CONVEX_SITE_PORT" \
+    --once
+
+  # Restore non-Convex vars (API keys, secrets) that Convex overwrote
+  if [ -n "$NON_CONVEX_VARS" ]; then
+    printf '\n%s\n' "$NON_CONVEX_VARS" >> "$ENV_LOCAL"
+  fi
+
+  info "Local Convex deployment provisioned"
+fi
+
+# ── Step 4: Start temp backend, set env vars, configure auth ─────────
+
+# Check if env vars are already set by looking for markers in .env
+INTERNAL_SECRET_EXISTS=false
+if [ -f "$ENV_FILE" ] && grep -q '^INTERNAL_API_SECRET=' "$ENV_FILE"; then
+  INTERNAL_SECRET_EXISTS=true
+fi
+
+# We need a running backend to set env vars and run auth setup.
+# Check if one is already running on the expected port.
+CONVEX_BG_PID=""
+STARTED_TEMP_BACKEND=false
+
+if curl -sf "http://127.0.0.1:$CONVEX_CLOUD_PORT" >/dev/null 2>&1; then
+  info "Convex backend already running on port $CONVEX_CLOUD_PORT"
+else
+  echo "Starting temporary Convex backend for env var setup..."
+  cd "$REPO_ROOT" && bunx convex dev --local \
+    --local-cloud-port "$CONVEX_CLOUD_PORT" \
+    --local-site-port "$CONVEX_SITE_PORT" &
+  CONVEX_BG_PID=$!
+  STARTED_TEMP_BACKEND=true
+
+  # Wait for the backend to be ready
+  for i in $(seq 1 30); do
+    if ! kill -0 "$CONVEX_BG_PID" 2>/dev/null; then
+      error "Convex backend crashed during startup"
+      exit 1
+    fi
+    if curl -sf "http://127.0.0.1:$CONVEX_CLOUD_PORT" >/dev/null 2>&1; then
+      break
+    fi
+    if [ "$i" -eq 30 ]; then
+      error "Timed out waiting for Convex backend"
+      exit 1
+    fi
+    sleep 1
+  done
+
+  info "Temporary Convex backend is running"
+fi
+
+# Ensure we clean up the background process on exit (if we started one)
+cleanup() {
+  if [ -n "$CONVEX_BG_PID" ] && kill -0 "$CONVEX_BG_PID" 2>/dev/null; then
+    kill "$CONVEX_BG_PID" 2>/dev/null || true
+    wait "$CONVEX_BG_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Set SITE_URL (app server port for OAuth callback proxying)
+cd "$REPO_ROOT" && bunx convex env set SITE_URL "http://localhost:$DEV_PORT"
+info "Set SITE_URL=http://localhost:$DEV_PORT"
+
+# Set ALLOW_ANONYMOUS_AUTH for manual testing via ?auth
+cd "$REPO_ROOT" && bunx convex env set ALLOW_ANONYMOUS_AUTH 1
+info "Set ALLOW_ANONYMOUS_AUTH=1"
+
+# Generate and set INTERNAL_API_SECRET
+if [ "$INTERNAL_SECRET_EXISTS" = true ]; then
+  INTERNAL_API_SECRET=$(grep '^INTERNAL_API_SECRET=' "$ENV_FILE" | cut -d= -f2)
+  info "INTERNAL_API_SECRET already exists in .env"
+else
+  INTERNAL_API_SECRET=$(openssl rand -hex 32)
+  echo "INTERNAL_API_SECRET=$INTERNAL_API_SECRET" >> "$ENV_FILE"
+  info "Generated INTERNAL_API_SECRET and added to .env"
+fi
+cd "$REPO_ROOT" && bunx convex env set INTERNAL_API_SECRET "$INTERNAL_API_SECRET"
+info "Set INTERNAL_API_SECRET on Convex deployment"
+
+# Generate JWT keys for Convex Auth (skip if already configured)
+AUTH_KEYS_EXIST=false
+if cd "$REPO_ROOT" && bunx convex env get JWT_PRIVATE_KEY >/dev/null 2>&1; then
+  AUTH_KEYS_EXIST=true
+fi
+
+if [ "$AUTH_KEYS_EXIST" = true ]; then
+  info "Convex Auth keys already configured"
+else
+  echo "Setting up Convex Auth keys..."
+  cd "$REPO_ROOT" && bunx @convex-dev/auth
+  info "Convex Auth keys configured"
+fi
+
+# Forward OAuth credentials from .dev-ports (if present)
+if [ -n "${AUTH_GITHUB_ID:-}" ] && [ -n "${AUTH_GITHUB_SECRET:-}" ]; then
+  cd "$REPO_ROOT" && bunx convex env set AUTH_GITHUB_ID "$AUTH_GITHUB_ID"
+  cd "$REPO_ROOT" && bunx convex env set AUTH_GITHUB_SECRET "$AUTH_GITHUB_SECRET"
+  info "Set GitHub OAuth credentials"
+fi
+if [ -n "${AUTH_GOOGLE_ID:-}" ] && [ -n "${AUTH_GOOGLE_SECRET:-}" ]; then
+  cd "$REPO_ROOT" && bunx convex env set AUTH_GOOGLE_ID "$AUTH_GOOGLE_ID"
+  cd "$REPO_ROOT" && bunx convex env set AUTH_GOOGLE_SECRET "$AUTH_GOOGLE_SECRET"
+  info "Set Google OAuth credentials"
+fi
+
+# Stop the temporary backend (only if we started one)
+if [ "$STARTED_TEMP_BACKEND" = true ] && [ -n "$CONVEX_BG_PID" ]; then
+  kill "$CONVEX_BG_PID" 2>/dev/null || true
+  wait "$CONVEX_BG_PID" 2>/dev/null || true
+fi
+
+# ── Done ─────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Local setup complete!${NC}"
+echo ""
+echo "  .dev-ports:  dev=$DEV_PORT  convex=$CONVEX_CLOUD_PORT/$CONVEX_SITE_PORT"
+echo "  team=$CONVEX_TEAM  project=$CONVEX_PROJECT"
+echo ""
+echo "Next steps:"
+echo "  bun run dev:local          # Start the dev server + local Convex"
+echo "  http://localhost:$DEV_PORT?auth   # Open in browser (anonymous auth)"


### PR DESCRIPTION
## Summary

- **New `bun run setup:local` script** — idempotent one-time setup for local Convex development. Creates `.dev-ports`, provisions a local Convex backend, generates `INTERNAL_API_SECRET`, sets `ALLOW_ANONYMOUS_AUTH`/`SITE_URL`, and runs `@convex-dev/auth` for JWT keys. Detects already-configured state and skips gracefully.
- **Env var reference in docs** — comprehensive "Environment Variable Reference" section in `docs/docs/local-development.md` with tables for `.dev-ports`, `.env.local`, `.env`, Convex deployment vars, optional OAuth credentials, and a script-to-variable mapping.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)