### PR TITLE
fix: resolve race condition in dev:local startup serving stale CONVEX_URL

### DIFF
--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -47,6 +47,15 @@ export PORT="$DEV_PORT"
 # Auto-enable anonymous auth for local dev (manual testing via ?auth query param)
 export ALLOW_ANONYMOUS_AUTH="${ALLOW_ANONYMOUS_AUTH:-1}"
 
+# Pre-export the local Convex URLs so the Bun server gets the correct values
+# immediately, even if convex-local.sh hasn't reconfigured .env.local yet.
+# Without this, the server reads the stale cloud URL from .env.local because
+# concurrently starts both processes at the same time, and bun --watch doesn't
+# re-read env files after startup. Shell env vars take priority over .env files
+# in Bun's env loading, so this guarantees the right URL from the first request.
+export CONVEX_URL="http://127.0.0.1:$CONVEX_CLOUD_PORT"
+export CONVEX_SITE_URL="http://127.0.0.1:$CONVEX_SITE_PORT"
+
 # Kill any lingering processes on dev ports (prevents Bun/Convex from auto-incrementing)
 for PORT_NUM in "$DEV_PORT" "$CONVEX_CLOUD_PORT" "$CONVEX_SITE_PORT"; do
   if lsof -ti :"$PORT_NUM" >/dev/null 2>&1; then

--- a/src/server.ts
+++ b/src/server.ts
@@ -404,6 +404,8 @@ const server = Bun.serve<WsData>({
 });
 
 console.log(`Holophyte running at http://localhost:${server.port}`);
+console.log(`  Convex URL: ${process.env.CONVEX_URL || '(not set)'}`);
+console.log(`  Convex Site: ${process.env.CONVEX_SITE_URL || '(not set)'}`);
 
 // Start companion polling for queued/stopped sessions
 startCompanionPolling();


### PR DESCRIPTION
## Summary

- Pre-export `CONVEX_URL` and `CONVEX_SITE_URL` in `dev-local.sh` before starting `concurrently`, so the Bun server gets the correct local URLs from the first request — even if `convex-local.sh` hasn't reconfigured `.env.local` yet
- Add Convex URL logging at server startup for easier debugging of env issues

## Root cause

`dev-local.sh` starts both the Bun server and `convex-local.sh` concurrently. When `.env.local` has a stale cloud deployment, the server reads the cloud `CONVEX_URL` before Convex reconfigures it. Since `bun --watch` doesn't re-read env files, the stale URL persists until a manual restart.

## Fix

Export the expected local URLs (`http://127.0.0.1:$PORT`) in the shell before starting `concurrently`. Bun's env loading gives shell-inherited vars priority over `.env` file values, so the server always gets the correct URL regardless of `.env.local` state.

## Test plan

- [x] All 374 unit tests pass (`bun run check`)
- [x] Lint + typecheck clean
- [x] Verified Bun env precedence: shell vars override `.env.local` (tested with mock `.env.local` containing stale cloud URL + shell export of local URL)
- [x] Integration test: started server with `CONVEX_URL=http://127.0.0.1:9999` while `.env.local` had `http://127.0.0.1:3214` — `/config.js` correctly served `9999`

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)