### PR TITLE
fix: kill entire process group on dev-local exit

### DIFF
--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -42,9 +42,9 @@ fi
 
 echo $$ > "$LOCKFILE"
 cleanup() {
-  # Kill entire process group so grandchildren (bun server, convex-local) don't orphan
-  kill -- -$$ 2>/dev/null || true
   rm -f "$LOCKFILE"
+  # Kill entire process group so grandchildren (bun server, convex-local) don't orphan
+  kill 0 2>/dev/null || true
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Summary
- `bun run --watch` spawns a grandchild `bun src/server.ts` process that survives Ctrl+C because `concurrently` only signals its direct children
- The orphaned process holds port 8080, blocking the next `dev:local` startup
- Fix: replace the simple lockfile cleanup trap with `kill -- -$$` to kill the entire process group on exit

## Test plan
- [ ] Run `bun run dev:local`, wait for startup, Ctrl+C, verify no orphaned `bun` processes remain (`lsof -i :8080`)
- [ ] Run `bun run dev:local` again immediately — should start without port conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)