### PR TITLE
fix: strip trailing slash from CONVEX_URL + cursor-pointer on buttons

### DIFF
--- a/src/frontend/components/ui/Button.tsx
+++ b/src/frontend/components/ui/Button.tsx
@@ -4,7 +4,7 @@ import type React from 'react';
 import { cn } from '../../lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ const server = Bun.serve({
     '/config.js': {
       GET() {
         const config = {
-          convexUrl: process.env.CONVEX_URL ?? '',
+          convexUrl: (process.env.CONVEX_URL ?? '').replace(/\/+$/, ''),
           e2eTest:
             !!process.env.E2E_TEST && process.env.NODE_ENV !== 'production',
           allowAnonymousAuth:


### PR DESCRIPTION
## Summary
- Strip trailing slashes from `CONVEX_URL` in `/config.js` to prevent double-slash WebSocket URLs (`cloud//api`) that break the Convex connection on production
- Add `cursor-pointer` to Button base styles — browsers default `<button>` to `cursor: default`

## Test plan
- [x] Verified OAuth login works on production after fixing env var
- [ ] Confirm buttons show pointer cursor on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)