### PR TITLE
chore: bump claude-agent-sdk to 0.2.71 + strip inherited env vars

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "holophyte",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.59",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.71",
         "@assistant-ui/react": "^0.12.12",
         "@auth/core": "0.37.0",
         "@convex-dev/auth": "^0.0.90",
@@ -58,7 +58,7 @@
 
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.59", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-xPOUZZimZI5ChaO791olWGXqaRvCwOfj9/1micu42EL9czdcwiDm0WK1OGsqb2mZ7LSCoYWBB0ZHVKOxehemDA=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.71", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-pIsQJnM7Y+cJHL7aFY6SCCW3FIni218gVEpPqG8XGowfYxboFNBbNssWiUNRwthT8bp9jypcX7q5kx0Xsw14xg=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.0.1", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.6" } }, "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.59",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.71",
     "@assistant-ui/react": "^0.12.12",
     "@auth/core": "0.37.0",
     "@convex-dev/auth": "^0.0.90",

--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -413,11 +413,13 @@ export async function startSession(opts: {
   }
 
   // Build SDK options.
-  // Strip CLAUDECODE env var — if the Holophyte server is itself launched from
-  // a Claude Code session, spawned SDK sessions inherit it and refuse to start
-  // ("cannot be launched inside another Claude Code session").
+  // Strip Claude Code env vars — if the Holophyte server is itself launched from
+  // a Claude Code session, spawned SDK sessions inherit these and may refuse to
+  // start or misidentify as third-party usage.
   const sdkEnv = { ...process.env };
   delete sdkEnv.CLAUDECODE;
+  delete sdkEnv.CLAUDE_CODE_ENTRYPOINT;
+  delete sdkEnv.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS;
 
   const sdkOptions: Parameters<typeof sdkQuery>[0]['options'] = {
     cwd: opts.repoPath,


### PR DESCRIPTION
## Summary
- Upgrade `@anthropic-ai/claude-agent-sdk` from 0.2.59 to 0.2.71
- Strip `CLAUDE_CODE_ENTRYPOINT` and `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` from SDK subprocess env (in addition to existing `CLAUDECODE` stripping) to prevent issues when Holophyte is launched from within a Claude Code session

## Test plan
- [ ] Start a session from within a Claude Code terminal and verify it spawns correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)