### PR TITLE
chore: load .env.companion for companion script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .env.test.local
 .env.production.local
 .env.local
+.env.companion
 
 # convex
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "worktree:create": "scripts/worktree-create.sh",
     "pr-comments": "scripts/pr-comments.sh",
     "storybook": "storybook dev -p 6006",
-    "companion": "bun run src/companion.ts",
+    "companion": "bun --no-env-file --env-file=.env.companion run src/companion.ts",
     "build-storybook": "storybook build",
     "docs:dev": "cd docs && bunx docusaurus start",
     "docs:build": "cd docs && bunx docusaurus build"


### PR DESCRIPTION
## Summary

- Use `--no-env-file` to prevent Bun from auto-loading `.env.local` (local dev Convex config) when running the companion
- Explicitly load `.env.companion` via `--env-file` for production env vars
- `.env.companion` already gitignored

## Context

`bun run companion` runs the headless companion process that connects to production Convex. Production env vars (`CONVEX_URL`, `CONVEX_SITE_URL`, `INTERNAL_API_SECRET`, `CLAUDE_CODE_OAUTH_TOKEN`) live in `.env.companion`. Bun only auto-loads `.env` and `.env.local`, not custom-named env files — and `.env.local` contains local dev Convex config that would conflict.

## Test plan

- [x] `bun run companion` loads env vars from `.env.companion`
- [ ] `bun run dev:local` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)