### PR TITLE
fix: git repo detection in directory picker

### DIFF
--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1,3 +1,4 @@
+import { exists } from 'node:fs/promises';
 import { basename } from 'node:path';
 
 export async function handlePickDirectory(): Promise<Response> {
@@ -23,8 +24,7 @@ export async function handlePickDirectory(): Promise<Response> {
     const raw = await new Response(proc.stdout).text();
     const dirPath = raw.trim().replace(/\/$/, '');
 
-    const gitDir = Bun.file(`${dirPath}/.git`);
-    const isGitRepo = await gitDir.exists();
+    const isGitRepo = await exists(`${dirPath}/.git`);
 
     return Response.json({
       cancelled: false,


### PR DESCRIPTION
## Summary
- `Bun.file().exists()` only detects files, not directories — `.git` is a directory in standard repos, so the picker always returned `isGitRepo: false`
- Replaced with `exists()` from `node:fs/promises` which handles both files and directories

Closes #138

## Test plan
- [x] Open Add Repo dialog, pick a valid git repository → no error shown
- [x] Pick a non-git directory → "not a git repository" error shown
- [x] Pick a worktree directory (where `.git` is a file) → no error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)