### PR TITLE
chore: add .vercel to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ docs/build
 
 # Finder (MacOS) folder config
 .DS_Store
+.vercel


### PR DESCRIPTION
## Summary
- Add `.vercel` directory to `.gitignore` to exclude Vercel CLI artifacts from version control

🤖 Generated with [Claude Code](https://claude.com/claude-code)