### PR TITLE
fix: use dynamic port assignment for companion server

### DIFF
--- a/src/companion.ts
+++ b/src/companion.ts
@@ -17,7 +17,7 @@ if (!process.env.ALLOWED_ORIGIN) {
 }
 
 const server = Bun.serve({
-  port: Number(process.env.PORT) || 8080,
+  port: Number(process.env.PORT) || 0,
   routes: {
     '/api/auth/*': async (req: Request) => handleAuthProxy(req),
 


### PR DESCRIPTION
Closes #143.

Changes `companion.ts` default port from `8080` to `0`, letting the OS assign a free port automatically. The actual assigned port is already read via `server.port` when building the heartbeat URL, so the frontend discovers the companion through Convex as before — no other changes needed.

Users who need a fixed port can still set `PORT=<n>` in their environment. The dev server (`src/server.ts`) is unaffected and keeps its fixed default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the companion server to support dynamic port assignment instead of being restricted to a fixed port, allowing the application to work in environments where port 8080 may be unavailable or already in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->