### PR TITLE
fix: scope companion table by orgId

### DIFF
--- a/convex/companion.ts
+++ b/convex/companion.ts
@@ -1,15 +1,36 @@
-import { getAuthUserId } from '@convex-dev/auth/server';
 import { v } from 'convex/values';
 import { internalMutation, internalQuery, query } from './_generated/server';
+import { requireOrgMembership } from './lib/auth';
+
+const LOCALHOST_URL_RE = /^http:\/\/(localhost|127\.0\.0\.1):\d+$/;
 
 export const upsertHeartbeat = internalMutation({
   args: {
     activeSessionCount: v.number(),
     machineId: v.optional(v.string()),
     url: v.optional(v.string()),
+    orgId: v.id('organizations'),
   },
   handler: async (ctx, args) => {
-    const existing = await ctx.db.query('companion').first();
+    if (args.url != null && !LOCALHOST_URL_RE.test(args.url)) {
+      throw new Error(
+        `Companion URL must be http://localhost:<port> or http://127.0.0.1:<port>, got: ${args.url}`,
+      );
+    }
+
+    // Upsert by (orgId, machineId) so multiple companions can coexist across orgs
+    const existing = args.machineId
+      ? await ctx.db
+          .query('companion')
+          .withIndex('by_org_machine', (q) =>
+            q.eq('orgId', args.orgId).eq('machineId', args.machineId),
+          )
+          .first()
+      : await ctx.db
+          .query('companion')
+          .withIndex('by_org', (q) => q.eq('orgId', args.orgId))
+          .first();
+
     if (existing) {
       await ctx.db.patch(existing._id, {
         lastSeen: Date.now(),
@@ -19,6 +40,7 @@ export const upsertHeartbeat = internalMutation({
       });
     } else {
       await ctx.db.insert('companion', {
+        orgId: args.orgId,
         lastSeen: Date.now(),
         activeSessionCount: args.activeSessionCount,
         machineId: args.machineId,
@@ -29,9 +51,12 @@ export const upsertHeartbeat = internalMutation({
 });
 
 export const getLastSeen = internalQuery({
-  args: {},
-  handler: async (ctx) => {
-    const record = await ctx.db.query('companion').first();
+  args: { orgId: v.id('organizations') },
+  handler: async (ctx, args) => {
+    const record = await ctx.db
+      .query('companion')
+      .withIndex('by_org', (q) => q.eq('orgId', args.orgId))
+      .first();
     return record
       ? { lastSeen: record.lastSeen, machineId: record.machineId }
       : null;
@@ -39,10 +64,12 @@ export const getLastSeen = internalQuery({
 });
 
 export const getStatus = query({
-  args: {},
-  handler: async (ctx) => {
-    const userId = await getAuthUserId(ctx);
-    if (!userId) return null;
-    return await ctx.db.query('companion').first();
+  args: { orgId: v.id('organizations') },
+  handler: async (ctx, args) => {
+    await requireOrgMembership(ctx, args.orgId);
+    return await ctx.db
+      .query('companion')
+      .withIndex('by_org', (q) => q.eq('orgId', args.orgId))
+      .first();
   },
 });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -478,7 +478,12 @@ http.route({
     if (authError) return authError;
 
     try {
-      const status = await ctx.runQuery(internal.companion.getLastSeen, {});
+      const org = await ctx.runQuery(internal.organizations.getDefaultOrg, {});
+      if (!org) return jsonError('No organization configured', 500);
+
+      const status = await ctx.runQuery(internal.companion.getLastSeen, {
+        orgId: org._id,
+      });
       return new Response(JSON.stringify(status), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -504,13 +509,19 @@ http.route({
 
     try {
       const { activeSessionCount, machineId, url } = body;
-      if (url != null && !/^http:\/\/localhost:\d+$/.test(url)) {
+      // Client-side URL guard — the mutation also validates server-side
+      if (url != null && !/^http:\/\/(localhost|127\.0\.0\.1):\d+$/.test(url)) {
         return jsonError('url must be a localhost address', 400);
       }
+
+      const org = await ctx.runQuery(internal.organizations.getDefaultOrg, {});
+      if (!org) return jsonError('No organization configured', 500);
+
       await ctx.runMutation(internal.companion.upsertHeartbeat, {
         activeSessionCount,
         machineId,
         url,
+        orgId: org._id,
       });
       return jsonOk();
     } catch (err) {

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -1,5 +1,10 @@
 import { v } from 'convex/values';
-import { internalMutation, mutation, query } from './_generated/server';
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from './_generated/server';
 import { requireAuth, requireOrgMembership, requireRole } from './lib/auth';
 
 export const listByUser = query({
@@ -180,5 +185,13 @@ export const remove = mutation({
     for (const m of memberships) await ctx.db.delete(m._id);
 
     await ctx.db.delete(args.id);
+  },
+});
+
+/** Returns the first organization in the deployment (for companion orgId derivation). */
+export const getDefaultOrg = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query('organizations').first();
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -225,9 +225,12 @@ export default defineSchema({
   }).index('by_session_batch', ['sessionId', 'batchIndex']),
 
   companion: defineTable({
+    orgId: v.id('organizations'),
     lastSeen: v.number(),
     activeSessionCount: v.number(),
     machineId: v.optional(v.string()),
     url: v.optional(v.string()),
-  }),
+  })
+    .index('by_org', ['orgId'])
+    .index('by_org_machine', ['orgId', 'machineId']),
 });

--- a/src/frontend/components/AddRepoDialog.tsx
+++ b/src/frontend/components/AddRepoDialog.tsx
@@ -51,7 +51,8 @@ export function AddRepoDialog({ open, onOpenChange }: AddRepoDialogProps) {
   const [submitting, setSubmitting] = useState(false);
   const [picking, setPicking] = useState(false);
   const selectedOrgId = useAppStore((s) => s.selectedOrgId);
-  const { state: companionState, companionUrl } = useCompanionStatus();
+  const { state: companionState, companionUrl } =
+    useCompanionStatus(selectedOrgId);
   const createRepo = useMutation(api.repos.create);
 
   const handlePathChange = (value: string) => {
@@ -67,6 +68,8 @@ export function AddRepoDialog({ open, onOpenChange }: AddRepoDialogProps) {
     setError(null);
     try {
       const baseUrl = companionUrl ?? '';
+      // UX hint only — real localhost validation is enforced server-side
+      // in the companion heartbeat mutation (convex/companion.ts)
       if (baseUrl && !/^http:\/\/localhost:\d+$/.test(baseUrl)) {
         setError('Companion URL is invalid.');
         return;

--- a/src/frontend/components/ClaudeButton.tsx
+++ b/src/frontend/components/ClaudeButton.tsx
@@ -32,7 +32,8 @@ export function ClaudeButton({ task }: ClaudeButtonProps) {
   const [error, setError] = useState<string | null>(null);
   const [model, setModel] = useState<ClaudeModelId>(DEFAULT_MODEL);
   const [prevTaskId, setPrevTaskId] = useState(task._id);
-  const { state: companionState } = useCompanionStatus();
+  const selectedOrgId = useAppStore((s) => s.selectedOrgId);
+  const { state: companionState } = useCompanionStatus(selectedOrgId);
 
   // Reset model to default when switching to a different task
   if (task._id !== prevTaskId) {

--- a/src/frontend/components/CompanionStatus.tsx
+++ b/src/frontend/components/CompanionStatus.tsx
@@ -2,6 +2,7 @@ import { Monitor } from 'lucide-react';
 import type { CompanionState } from '@/frontend/hooks/useCompanionStatus';
 import { useCompanionStatus } from '@/frontend/hooks/useCompanionStatus';
 import { cn } from '@/frontend/lib/utils';
+import { useAppStore } from '@/frontend/stores/app';
 import Skeleton from './ui/Skeleton';
 import {
   Tooltip,
@@ -25,7 +26,8 @@ const labels: Record<CompanionState, string> = {
 };
 
 export default function CompanionStatus() {
-  const { state, status } = useCompanionStatus();
+  const selectedOrgId = useAppStore((s) => s.selectedOrgId);
+  const { state, status } = useCompanionStatus(selectedOrgId);
 
   if (state === 'loading') {
     return (

--- a/src/frontend/hooks/useCompanionStatus.ts
+++ b/src/frontend/hooks/useCompanionStatus.ts
@@ -1,4 +1,5 @@
 import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
 import { useQuery } from 'convex/react';
 import { useSyncExternalStore } from 'react';
 
@@ -46,11 +47,13 @@ function getSnapshot() {
   return now;
 }
 
-export function useCompanionStatus() {
-  const status = useQuery(api.companion.getStatus);
+export function useCompanionStatus(
+  orgId: Id<'organizations'> | null | undefined,
+) {
+  const status = useQuery(api.companion.getStatus, orgId ? { orgId } : 'skip');
   const currentTime = useSyncExternalStore(subscribe, getSnapshot);
 
-  // status === undefined means the query hasn't resolved yet
+  // status === undefined means the query hasn't resolved yet (or is skipped)
   const state: CompanionState =
     status === undefined
       ? 'loading'


### PR DESCRIPTION
## Summary
- Adds `orgId` to the `companion` table with `by_org` and `by_org_machine` indexes, storing one record per (orgId, machineId) pair instead of a single global record
- `getStatus` query now requires org membership — users only see companion status for their own org
- Server-side URL validation in the heartbeat mutation rejects non-localhost companion URLs
- HTTP endpoints derive orgId from the deployment's default organization (no new env vars needed)
- Frontend passes `selectedOrgId` through `useCompanionStatus` hook; AddRepoDialog's client-side URL check annotated as UX-only

Closes #149

## Test plan
- [x] `bun run check` (lint + typecheck + 366 unit tests pass)
- [x] `bun run test:e2e:isolated` (34 E2E tests pass)
- [ ] Manual: verify companion status indicator works with org-scoped query
- [ ] Manual: verify companion heartbeat registers with orgId

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Companion connection URL validation now accepts both localhost and 127.0.0.1 addresses.

* **Refactor**
  * Companion status is now properly scoped to the selected organization.
  * Companion heartbeat tracking now organization-aware.
  * Organization membership validation added to companion status endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->