### PR TITLE
feat: add useHolophyteChat hook and UIMessage transformation

### DIFF
--- a/src/frontend/hooks/useHolophyteChat.test.ts
+++ b/src/frontend/hooks/useHolophyteChat.test.ts
@@ -51,7 +51,6 @@ function makeProps(overrides: {
     sendMessage: vi.fn().mockResolvedValue(undefined),
     handleStop: vi.fn().mockResolvedValue(undefined),
     messageQueued: overrides.messageQueued ?? false,
-    sendMessageDirect: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/src/frontend/hooks/useHolophyteChat.test.ts
+++ b/src/frontend/hooks/useHolophyteChat.test.ts
@@ -1,0 +1,232 @@
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useHolophyteChat } from './useHolophyteChat';
+import type {
+  PendingApproval,
+  ProjectCommand,
+  SessionStatus,
+} from './useSession';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAssistantEvent(
+  text: string,
+  id = 'msg-1',
+  uuid = 'u-1',
+): SDKMessage {
+  return {
+    type: 'assistant',
+    message: { id, content: [{ type: 'text', text }] },
+    uuid,
+  } as unknown as SDKMessage;
+}
+
+function makeUserEvent(text: string, uuid = 'u-u1'): SDKMessage {
+  return {
+    type: 'user',
+    message: { content: text },
+    uuid,
+  } as unknown as SDKMessage;
+}
+
+function makeProps(overrides: {
+  events?: SDKMessage[];
+  sessionStatus?: SessionStatus | null;
+  pendingApprovals?: PendingApproval[];
+  projectCommands?: ProjectCommand[];
+  messageQueued?: boolean;
+}) {
+  return {
+    sessionId: 'sess-1',
+    events: overrides.events ?? [],
+    pendingApprovals: overrides.pendingApprovals ?? [],
+    sessionStatus: overrides.sessionStatus ?? null,
+    projectCommands: overrides.projectCommands ?? [],
+    approve: vi.fn(),
+    deny: vi.fn(),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    handleStop: vi.fn().mockResolvedValue(undefined),
+    messageQueued: overrides.messageQueued ?? false,
+    sendMessageDirect: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Status mapping
+// ---------------------------------------------------------------------------
+
+describe('useHolophyteChat — status mapping', () => {
+  it.each([
+    [null, 'ready'],
+    ['idle', 'ready'],
+    ['queued', 'submitted'],
+    ['running', 'streaming'],
+    ['waiting_input', 'streaming'],
+    ['failed', 'error'],
+  ] as const)('maps sessionStatus %s → status %s', (sessionStatus, expected) => {
+    const { result } = renderHook(() =>
+      useHolophyteChat(makeProps({ sessionStatus })),
+    );
+    expect(result.current.status).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+describe('useHolophyteChat — messages', () => {
+  it('returns SDK messages transformed to UIMessage[]', () => {
+    const events = [makeAssistantEvent('Hello')];
+    const { result } = renderHook(() =>
+      useHolophyteChat(makeProps({ events })),
+    );
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]?.role).toBe('assistant');
+  });
+
+  it('returns the sessionId as id', () => {
+    const { result } = renderHook(() => useHolophyteChat(makeProps({})));
+    expect(result.current.id).toBe('sess-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Optimistic messages
+// ---------------------------------------------------------------------------
+
+describe('useHolophyteChat — optimistic messages', () => {
+  it('addOptimisticMessage appends a user UIMessage immediately', () => {
+    const { result } = renderHook(() => useHolophyteChat(makeProps({})));
+    act(() => {
+      result.current.addOptimisticMessage('Optimistic text');
+    });
+    const lastMsg = result.current.messages.at(-1);
+    expect(lastMsg?.role).toBe('user');
+    expect(lastMsg?.parts[0]).toMatchObject({
+      type: 'text',
+      text: 'Optimistic text',
+    });
+  });
+
+  it('sendMessage adds an optimistic message and calls sendMessage prop', async () => {
+    const props = makeProps({});
+    const { result } = renderHook(() => useHolophyteChat(props));
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+    expect(props.sendMessage).toHaveBeenCalledWith('sess-1', 'Hello');
+    const lastMsg = result.current.messages.at(-1);
+    expect(lastMsg?.role).toBe('user');
+  });
+
+  it('clears optimistic messages when new events arrive', () => {
+    const initialEvents: SDKMessage[] = [];
+    const props = makeProps({ events: initialEvents });
+    const { result, rerender } = renderHook(
+      (p: typeof props) => useHolophyteChat(p),
+      { initialProps: props },
+    );
+
+    act(() => {
+      result.current.addOptimisticMessage('temp');
+    });
+    expect(result.current.messages).toHaveLength(1);
+
+    // Simulate new event arriving
+    const newProps = {
+      ...props,
+      events: [makeUserEvent('temp')],
+    };
+    rerender(newProps);
+
+    // Optimistic messages should be cleared
+    const optimisticMsgs = result.current.messages.filter((m) =>
+      m.id.startsWith('optimistic-'),
+    );
+    expect(optimisticMsgs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Available commands
+// ---------------------------------------------------------------------------
+
+describe('useHolophyteChat — availableCommands', () => {
+  it('returns projectCommands sorted by name', () => {
+    const projectCommands: ProjectCommand[] = [
+      { name: 'test', description: 'Run tests' },
+      { name: 'build', description: 'Build project' },
+    ];
+    const { result } = renderHook(() =>
+      useHolophyteChat(makeProps({ projectCommands })),
+    );
+    expect(result.current.availableCommands.map((c) => c.name)).toEqual([
+      'build',
+      'test',
+    ]);
+  });
+
+  it('merges skills from init event, deduplicating against projectCommands', () => {
+    const initEvent = {
+      type: 'system',
+      subtype: 'init',
+      skills: ['deploy', 'test'],
+    } as unknown as SDKMessage;
+    const projectCommands: ProjectCommand[] = [
+      { name: 'test', description: 'Run tests' },
+    ];
+    const { result } = renderHook(() =>
+      useHolophyteChat(makeProps({ events: [initEvent], projectCommands })),
+    );
+    const names = result.current.availableCommands.map((c) => c.name);
+    // 'test' from projectCommands + 'deploy' from skills (deduped)
+    expect(names).toContain('deploy');
+    expect(names.filter((n) => n === 'test')).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Passthrough props
+// ---------------------------------------------------------------------------
+
+describe('useHolophyteChat — passthrough', () => {
+  it('exposes approve and deny functions', () => {
+    const props = makeProps({});
+    const { result } = renderHook(() => useHolophyteChat(props));
+    result.current.approve('req-1');
+    result.current.deny('req-2', 'no thanks');
+    expect(props.approve).toHaveBeenCalledWith('req-1');
+    expect(props.deny).toHaveBeenCalledWith('req-2', 'no thanks');
+  });
+
+  it('exposes stop as handleStop', async () => {
+    const props = makeProps({});
+    const { result } = renderHook(() => useHolophyteChat(props));
+    await act(async () => {
+      await result.current.stop();
+    });
+    expect(props.handleStop).toHaveBeenCalled();
+  });
+
+  it('passes through messageQueued', () => {
+    const { result } = renderHook(() =>
+      useHolophyteChat(makeProps({ messageQueued: true })),
+    );
+    expect(result.current.messageQueued).toBe(true);
+  });
+
+  it('passes through pendingApprovals', () => {
+    const pendingApprovals: PendingApproval[] = [
+      { requestId: 'r-1', tool: 'Bash', input: {} },
+    ];
+    const { result } = renderHook(() =>
+      useHolophyteChat(makeProps({ pendingApprovals })),
+    );
+    expect(result.current.pendingApprovals).toBe(pendingApprovals);
+  });
+});

--- a/src/frontend/hooks/useHolophyteChat.ts
+++ b/src/frontend/hooks/useHolophyteChat.ts
@@ -1,0 +1,183 @@
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { UIMessage } from 'ai';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  PendingApproval,
+  ProjectCommand,
+  SessionStatus,
+} from '@/frontend/hooks/useSession';
+import {
+  extractPromptSuggestion,
+  sdkToUIMessages,
+} from '@/frontend/lib/sdkToUIMessages';
+
+export interface UseHolophyteChatProps {
+  sessionId: string;
+  events: SDKMessage[];
+  pendingApprovals: PendingApproval[];
+  sessionStatus: SessionStatus | null;
+  projectCommands: ProjectCommand[];
+  approve: (requestId: string) => void;
+  deny: (requestId: string, message?: string) => void;
+  sendMessage: (sessionId: string, text: string) => Promise<void>;
+  handleStop: () => Promise<void>;
+  messageQueued: boolean;
+  sendMessageDirect: (text: string) => Promise<void>;
+}
+
+export interface UseHolophyteChatReturn {
+  messages: UIMessage[];
+  status: 'ready' | 'submitted' | 'streaming' | 'error';
+  id: string;
+  sendMessage: (text: string) => Promise<void>;
+  stop: () => Promise<void>;
+  addOptimisticMessage: (text: string) => void;
+  approve: (requestId: string) => void;
+  deny: (requestId: string, message?: string) => void;
+  pendingApprovals: PendingApproval[];
+  sessionStatus: SessionStatus | null;
+  promptSuggestion: string | null;
+  availableCommands: ProjectCommand[];
+  messageQueued: boolean;
+}
+
+/**
+ * Data-layer hook for a Holophyte session thread.
+ *
+ * Absorbs the logic previously spread across `SessionRuntimeProvider` and
+ * `SessionActionsContext` and exposes it as a plain object compatible with the
+ * `ai` package's `UIMessage` type. Consumers can use this with any chat UI
+ * that accepts `UIMessage[]`.
+ */
+export function useHolophyteChat(
+  props: UseHolophyteChatProps,
+): UseHolophyteChatReturn {
+  const {
+    sessionId,
+    events,
+    pendingApprovals,
+    sessionStatus,
+    projectCommands,
+    approve,
+    deny,
+    sendMessage: sendMessageProp,
+    handleStop,
+    messageQueued,
+  } = props;
+
+  const isRunning =
+    sessionStatus === 'running' || sessionStatus === 'waiting_input';
+
+  // Map session lifecycle → useChat-compatible status
+  const status = useMemo((): UseHolophyteChatReturn['status'] => {
+    switch (sessionStatus) {
+      case 'queued':
+        return 'submitted';
+      case 'running':
+      case 'waiting_input':
+        return 'streaming';
+      case 'failed':
+        return 'error';
+      default:
+        return 'ready';
+    }
+  }, [sessionStatus]);
+
+  // Transform SDK events into UIMessage[]
+  const sdkMessages = useMemo(
+    () => sdkToUIMessages(events, isRunning, pendingApprovals),
+    [events, isRunning, pendingApprovals],
+  );
+
+  // Extract the latest prompt suggestion from the event stream
+  const promptSuggestion = useMemo(
+    () => extractPromptSuggestion(events),
+    [events],
+  );
+
+  // Merge persisted commands with dynamic skills from the init event.
+  // Commands are persisted to Convex; skills come from the event stream.
+  const availableCommands = useMemo(() => {
+    const initEvent = events.find(
+      (e) => e.type === 'system' && 'subtype' in e && e.subtype === 'init',
+    );
+    const skills: ProjectCommand[] = initEvent
+      ? (Array.isArray((initEvent as Record<string, unknown>).skills)
+          ? ((initEvent as Record<string, unknown>).skills as string[])
+          : []
+        ).map((name) => ({ name, description: '' }))
+      : [];
+    const commandNames = new Set(projectCommands.map((c) => c.name));
+    const uniqueSkills = skills.filter((s) => !commandNames.has(s.name));
+    return [...projectCommands, ...uniqueSkills].sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+  }, [events, projectCommands]);
+
+  // Queue of optimistic user messages — shown immediately when the user hits
+  // Enter, before the SDK streams back the real user events.
+  const [optimisticMsgs, setOptimisticMsgs] = useState<string[]>([]);
+  const msgsLenAtOptimistic = useRef(-1);
+
+  // Clear optimistic messages when new SDK events arrive after they were set.
+  useEffect(() => {
+    if (
+      optimisticMsgs.length > 0 &&
+      events.length > msgsLenAtOptimistic.current
+    ) {
+      setOptimisticMsgs([]);
+    }
+  }, [events.length, optimisticMsgs.length]);
+
+  /** Show a user message optimistically in the thread. */
+  const addOptimisticMessage = useCallback(
+    (text: string) => {
+      setOptimisticMsgs((prev) => [...prev, text]);
+      msgsLenAtOptimistic.current = events.length;
+    },
+    [events.length],
+  );
+
+  // Merge SDK messages with optimistic user messages.
+  const messages = useMemo((): UIMessage[] => {
+    if (optimisticMsgs.length === 0) return sdkMessages;
+    return [
+      ...sdkMessages,
+      ...optimisticMsgs.map((text, i) => ({
+        id: `optimistic-${i}`,
+        role: 'user' as const,
+        parts: [{ type: 'text' as const, text }],
+      })),
+    ];
+  }, [sdkMessages, optimisticMsgs]);
+
+  const sendMessage = useCallback(
+    async (text: string) => {
+      if (!text.trim()) return;
+      addOptimisticMessage(text);
+      try {
+        await sendMessageProp(sessionId, text);
+      } catch (err) {
+        console.error('[useHolophyteChat] sendMessage failed:', err);
+        setOptimisticMsgs([]);
+      }
+    },
+    [addOptimisticMessage, sendMessageProp, sessionId],
+  );
+
+  return {
+    messages,
+    status,
+    id: sessionId,
+    sendMessage,
+    stop: handleStop,
+    addOptimisticMessage,
+    approve,
+    deny,
+    pendingApprovals,
+    sessionStatus,
+    promptSuggestion,
+    availableCommands,
+    messageQueued,
+  };
+}

--- a/src/frontend/hooks/useHolophyteChat.ts
+++ b/src/frontend/hooks/useHolophyteChat.ts
@@ -22,7 +22,6 @@ export interface UseHolophyteChatProps {
   sendMessage: (sessionId: string, text: string) => Promise<void>;
   handleStop: () => Promise<void>;
   messageQueued: boolean;
-  sendMessageDirect: (text: string) => Promise<void>;
 }
 
 export interface UseHolophyteChatReturn {

--- a/src/frontend/lib/sdkToThreadMessages.ts
+++ b/src/frontend/lib/sdkToThreadMessages.ts
@@ -115,12 +115,23 @@ export function sdkToThreadMessages(
   pendingApprovals: PendingApproval[],
 ): ThreadMessageLike[] {
   const uiMessages = sdkToUIMessages(events, isRunning, pendingApprovals);
-  const assistantMessages = uiMessages.filter((m) => m.role === 'assistant');
-  const lastAssistantMsg = assistantMessages.at(-1);
 
+  // First pass: find which messages survive filtering to determine the real last assistant
+  const survivingAssistantIds = new Set<string>();
+  for (const msg of uiMessages) {
+    if (msg.role !== 'assistant') continue;
+    // Check if it would produce a non-null result (has renderable parts)
+    const hasRenderableParts = msg.parts.some(
+      (p) => p.type === 'text' || p.type === 'dynamic-tool',
+    );
+    if (hasRenderableParts) survivingAssistantIds.add(msg.id);
+  }
+  const lastSurvivingId = [...survivingAssistantIds].at(-1);
+
+  // Second pass: convert with correct isLast
   const result: ThreadMessageLike[] = [];
   for (const msg of uiMessages) {
-    const isLast = msg === lastAssistantMsg;
+    const isLast = msg.id === lastSurvivingId;
     const converted = uiMessageToThreadMessage(msg, isRunning, isLast);
     if (converted) result.push(converted);
   }

--- a/src/frontend/lib/sdkToThreadMessages.ts
+++ b/src/frontend/lib/sdkToThreadMessages.ts
@@ -1,11 +1,103 @@
+/**
+ * Backward-compatibility adapter for `sdkToThreadMessages`.
+ *
+ * The canonical implementation now lives in `sdkToUIMessages.ts` and produces
+ * `UIMessage[]` (from the `ai` package). This module re-exports
+ * `extractPromptSuggestion` and converts `UIMessage[]` back to
+ * `ThreadMessageLike[]` so that `SessionRuntimeProvider` keeps working without
+ * modification until it is removed in a future PR.
+ */
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { ThreadMessageLike } from '@assistant-ui/react';
+import type { UIMessage } from 'ai';
 import type { PendingApproval } from '@/frontend/hooks/useSession';
+import { sdkToUIMessages } from './sdkToUIMessages';
+
+export { extractPromptSuggestion } from './sdkToUIMessages';
 
 type ContentPart = Extract<
   ThreadMessageLike['content'],
   readonly unknown[]
 >[number];
+
+/** Convert a `UIMessage` into a `ThreadMessageLike` for assistant-ui. */
+function uiMessageToThreadMessage(
+  msg: UIMessage,
+  isRunning: boolean,
+  isLast: boolean,
+): ThreadMessageLike | null {
+  if (msg.role === 'user') {
+    const textParts = msg.parts.filter((p) => p.type === 'text');
+    if (textParts.length === 0) return null;
+    const text = textParts.map((p) => (p as { text: string }).text).join('');
+    if (!text) return null;
+    return {
+      id: msg.id,
+      role: 'user',
+      content: [{ type: 'text', text }],
+    };
+  }
+
+  if (msg.role === 'assistant') {
+    const parts: ContentPart[] = [];
+
+    for (const part of msg.parts) {
+      if (part.type === 'text') {
+        const text = (part as { text: string }).text;
+        if (text) parts.push({ type: 'text', text });
+      } else if (part.type === 'dynamic-tool') {
+        const p = part as {
+          toolName: string;
+          toolCallId: string;
+          state: string;
+          input: unknown;
+          output?: unknown;
+          errorText?: string;
+          approval?: { id: string };
+        };
+
+        const isUnresolved = p.state === 'approval-requested';
+        const hasResult =
+          p.state === 'output-available' || p.state === 'output-error';
+        const isError = p.state === 'output-error';
+
+        parts.push({
+          type: 'tool-call',
+          toolCallId: p.toolCallId,
+          toolName: p.toolName,
+          // biome-ignore lint/suspicious/noExplicitAny: SDK input is untyped; assistant-ui expects ReadonlyJSONObject
+          args: p.input as any,
+          result: hasResult ? String(p.output ?? p.errorText ?? '') : undefined,
+          isError: isError || undefined,
+          ...(isUnresolved
+            ? {
+                status: {
+                  type: 'requires-action' as const,
+                  reason: 'interrupt' as const,
+                },
+              }
+            : undefined),
+        });
+      }
+    }
+
+    if (parts.length === 0) return null;
+
+    const status: ThreadMessageLike['status'] =
+      isRunning && isLast
+        ? { type: 'running' }
+        : { type: 'complete', reason: 'stop' };
+
+    return {
+      id: msg.id,
+      role: 'assistant',
+      content: parts as ThreadMessageLike['content'],
+      status,
+    };
+  }
+
+  return null;
+}
 
 /**
  * Transforms an array of SDK events into `ThreadMessageLike[]` for use with
@@ -22,194 +114,15 @@ export function sdkToThreadMessages(
   isRunning: boolean,
   pendingApprovals: PendingApproval[],
 ): ThreadMessageLike[] {
-  // Set of requestIds that still need user action
-  const unresolvedIds = new Set(
-    pendingApprovals.filter((a) => !a.resolved).map((a) => a.requestId),
-  );
+  const uiMessages = sdkToUIMessages(events, isRunning, pendingApprovals);
+  const assistantMessages = uiMessages.filter((m) => m.role === 'assistant');
+  const lastAssistantMsg = assistantMessages.at(-1);
 
-  // First pass: collect tool results keyed by tool_use_id
-  const toolResults = new Map<string, { result: string; isError: boolean }>();
-
-  for (const event of events) {
-    if (event.type === 'user') {
-      const msg = event.message as { content?: unknown[] };
-      if (Array.isArray(msg.content)) {
-        for (const block of msg.content) {
-          const b = block as Record<string, unknown>;
-          if (b.type === 'tool_result') {
-            const toolUseId = String(b.tool_use_id ?? '');
-            const content = b.content;
-            let resultText = '';
-            if (typeof content === 'string') {
-              resultText = content;
-            } else if (Array.isArray(content)) {
-              resultText = (content as Array<Record<string, unknown>>)
-                .filter((c) => c.type === 'text')
-                .map((c) => String(c.text ?? ''))
-                .join('');
-            }
-            toolResults.set(toolUseId, {
-              result: resultText,
-              isError: b.is_error === true,
-            });
-          }
-        }
-      }
-    }
+  const result: ThreadMessageLike[] = [];
+  for (const msg of uiMessages) {
+    const isLast = msg === lastAssistantMsg;
+    const converted = uiMessageToThreadMessage(msg, isRunning, isLast);
+    if (converted) result.push(converted);
   }
-
-  // Deduplicate assistant events by stable ID — the SDK sends progressive
-  // snapshots of the same message (e.g., first with thinking, then with
-  // tool_use). Keep the LAST snapshot for each stable ID since it has the
-  // most complete content. Use message.id when available, fall back to uuid.
-  const lastAssistantById = new Map<
-    string,
-    { event: SDKMessage; stableId: string }
-  >();
-  for (const event of events) {
-    if (event.type === 'assistant') {
-      const msg = event.message as { id?: string };
-      const uuid = (event as { uuid?: string }).uuid ?? '';
-      const stableId = String(msg.id ?? uuid);
-      if (stableId) {
-        lastAssistantById.set(stableId, { event, stableId });
-      }
-    }
-  }
-
-  const messages: ThreadMessageLike[] = [];
-  // Track which stable IDs we've already emitted to avoid duplicates
-  const emittedIds = new Set<string>();
-  const lastAssistantEvent = events
-    .filter((e) => e.type === 'assistant')
-    .at(-1);
-
-  // Second pass: build ThreadMessageLike entries
-  for (const event of events) {
-    if (event.type === 'assistant') {
-      const msg = event.message as { id?: string; content?: unknown[] };
-      const uuid = (event as { uuid?: string }).uuid ?? '';
-      const stableId = String(msg.id ?? uuid);
-
-      // Skip if we've already emitted this stable ID (use the latest snapshot)
-      if (emittedIds.has(stableId)) continue;
-
-      // Use the latest snapshot for this message
-      const latest = lastAssistantById.get(stableId);
-      if (!latest) continue;
-      emittedIds.add(stableId);
-
-      const latestMsg =
-        (latest.event as { message?: { content?: unknown[] } }).message ?? {};
-      const content = Array.isArray(latestMsg.content) ? latestMsg.content : [];
-
-      const parts: ContentPart[] = [];
-
-      for (const block of content) {
-        const b = block as Record<string, unknown>;
-
-        if (b.type === 'text') {
-          const text = String(b.text ?? '');
-          if (text) {
-            parts.push({ type: 'text', text });
-          }
-        } else if (b.type === 'tool_use') {
-          const toolCallId = String(b.id ?? '');
-          const toolName = String(b.name ?? '');
-          // biome-ignore lint/suspicious/noExplicitAny: SDK input is untyped; assistant-ui expects ReadonlyJSONObject which Record<string,unknown> can't satisfy
-          const args = (b.input ?? {}) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-          const toolResult = toolResults.get(toolCallId);
-          const isUnresolved = unresolvedIds.has(toolCallId);
-
-          parts.push({
-            type: 'tool-call',
-            toolCallId,
-            toolName,
-            args,
-            result: toolResult?.result,
-            isError: toolResult?.isError,
-            ...(isUnresolved
-              ? {
-                  status: {
-                    type: 'requires-action' as const,
-                    reason: 'interrupt' as const,
-                  },
-                }
-              : undefined),
-          });
-        }
-      }
-
-      if (parts.length === 0) continue;
-
-      const isLast = latest.event === lastAssistantEvent;
-      const status: ThreadMessageLike['status'] =
-        isRunning && isLast
-          ? { type: 'running' }
-          : { type: 'complete', reason: 'stop' };
-
-      messages.push({
-        id: latest.stableId,
-        role: 'assistant',
-        content: parts as ThreadMessageLike['content'],
-        status,
-      });
-    } else if (event.type === 'user') {
-      const msg = event.message as { content?: unknown[] | string };
-      const isSynthetic = (event as { isSynthetic?: boolean }).isSynthetic;
-      if (isSynthetic) continue;
-
-      let userText = '';
-      if (typeof msg.content === 'string') {
-        userText = msg.content;
-      } else if (Array.isArray(msg.content)) {
-        // Only include text blocks (not tool_result blocks)
-        for (const block of msg.content) {
-          const b = block as Record<string, unknown>;
-          if (b.type === 'text') {
-            userText += String(b.text ?? '');
-          }
-        }
-      }
-
-      if (!userText) continue;
-
-      const uuid = (event as { uuid?: string }).uuid;
-      messages.push({
-        id: uuid,
-        role: 'user',
-        content: [{ type: 'text', text: userText }],
-      });
-    }
-    // 'result', 'system/init' and other types are ignored
-  }
-
-  return messages;
-}
-
-/**
- * Extracts the most recent prompt suggestion from the SDK event stream.
- *
- * Returns the `suggestion` field from the last `prompt_suggestion` event,
- * but only if it appears after the final `user` or `assistant` event in the
- * stream. Both user and assistant events clear the suggestion. Empty or
- * whitespace-only suggestions are treated as noise (not clear signals) and
- * skipped — the SDK clears suggestions via the next user/assistant turn.
- *
- * Note: `prompt_suggestion` is not yet part of the official `SDKMessage` union
- * in `@anthropic-ai/claude-agent-sdk` types. The runtime events are emitted as
- * plain objects so the type check works, but TypeScript may flag `.suggestion`
- * access if the SDK types are tightened. Track for inclusion upstream.
- */
-export function extractPromptSuggestion(events: SDKMessage[]): string | null {
-  for (let i = events.length - 1; i >= 0; i--) {
-    // biome-ignore lint/style/noNonNullAssertion: index is within bounds (loop condition guarantees i >= 0 && i < events.length)
-    const event = events[i]!;
-    if (event.type === 'user' || event.type === 'assistant') return null;
-    if (event.type === 'prompt_suggestion') {
-      const suggestion = (event as { suggestion?: string }).suggestion;
-      if (suggestion?.trim()) return suggestion.trim();
-    }
-  }
-  return null;
+  return result;
 }

--- a/src/frontend/lib/sdkToThreadMessages.ts
+++ b/src/frontend/lib/sdkToThreadMessages.ts
@@ -120,9 +120,13 @@ export function sdkToThreadMessages(
   const survivingAssistantIds = new Set<string>();
   for (const msg of uiMessages) {
     if (msg.role !== 'assistant') continue;
-    // Check if it would produce a non-null result (has renderable parts)
+    // Check if it would produce a non-null result (has renderable parts).
+    // Text parts with empty strings are dropped by uiMessageToThreadMessage,
+    // so only count non-empty text.
     const hasRenderableParts = msg.parts.some(
-      (p) => p.type === 'text' || p.type === 'dynamic-tool',
+      (p) =>
+        (p.type === 'text' && (p as { text: string }).text !== '') ||
+        p.type === 'dynamic-tool',
     );
     if (hasRenderableParts) survivingAssistantIds.add(msg.id);
   }

--- a/src/frontend/lib/sdkToThreadMessages.ts
+++ b/src/frontend/lib/sdkToThreadMessages.ts
@@ -60,6 +60,7 @@ function uiMessageToThreadMessage(
         const hasResult =
           p.state === 'output-available' || p.state === 'output-error';
         const isError = p.state === 'output-error';
+        const isDenied = p.state === 'output-denied';
 
         parts.push({
           type: 'tool-call',
@@ -68,7 +69,7 @@ function uiMessageToThreadMessage(
           // biome-ignore lint/suspicious/noExplicitAny: SDK input is untyped; assistant-ui expects ReadonlyJSONObject
           args: p.input as any,
           result: hasResult ? String(p.output ?? p.errorText ?? '') : undefined,
-          isError: isError || undefined,
+          isError: isError || isDenied || undefined,
           ...(isUnresolved
             ? {
                 status: {

--- a/src/frontend/lib/sdkToUIMessages.test.ts
+++ b/src/frontend/lib/sdkToUIMessages.test.ts
@@ -1,0 +1,348 @@
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import { describe, expect, it } from 'vitest';
+import type { PendingApproval } from '@/frontend/hooks/useSession';
+import { extractPromptSuggestion, sdkToUIMessages } from './sdkToUIMessages';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAssistantEvent(
+  content: unknown[],
+  id = 'msg-1',
+  uuid = 'uuid-1',
+): SDKMessage {
+  return {
+    type: 'assistant',
+    message: { id, content },
+    uuid,
+  } as unknown as SDKMessage;
+}
+
+function makeUserEvent(
+  content: string | unknown[],
+  uuid = 'uuid-u1',
+  isSynthetic = false,
+): SDKMessage {
+  return {
+    type: 'user',
+    message: { content },
+    uuid,
+    isSynthetic,
+  } as unknown as SDKMessage;
+}
+
+function makeToolResultEvent(
+  toolUseId: string,
+  result: string,
+  isError = false,
+): SDKMessage {
+  return makeUserEvent([
+    {
+      type: 'tool_result',
+      tool_use_id: toolUseId,
+      content: result,
+      is_error: isError,
+    },
+  ]);
+}
+
+const noPending: PendingApproval[] = [];
+
+// ---------------------------------------------------------------------------
+// Text messages
+// ---------------------------------------------------------------------------
+
+describe('sdkToUIMessages — text-only assistant message', () => {
+  it('produces a UIMessage with a text part', () => {
+    const events = [
+      makeAssistantEvent([{ type: 'text', text: 'Hello world' }]),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.role).toBe('assistant');
+    expect(result[0]?.parts).toHaveLength(1);
+    expect(result[0]?.parts[0]).toMatchObject({
+      type: 'text',
+      text: 'Hello world',
+    });
+  });
+
+  it('sets text state to "streaming" when isRunning is true for the last message', () => {
+    const events = [
+      makeAssistantEvent([{ type: 'text', text: 'Streaming...' }]),
+    ];
+    const result = sdkToUIMessages(events, true, noPending);
+    expect(result[0]?.parts[0]).toMatchObject({
+      type: 'text',
+      state: 'streaming',
+    });
+  });
+
+  it('sets text state to "done" when isRunning is false', () => {
+    const events = [makeAssistantEvent([{ type: 'text', text: 'Done.' }])];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result[0]?.parts[0]).toMatchObject({ type: 'text', state: 'done' });
+  });
+
+  it('skips text blocks with empty content', () => {
+    const events = [makeAssistantEvent([{ type: 'text', text: '' }])];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool-use messages
+// ---------------------------------------------------------------------------
+
+describe('sdkToUIMessages — tool-use parts', () => {
+  it('produces a dynamic-tool part with output-available when a result exists', () => {
+    const events = [
+      makeAssistantEvent([
+        {
+          type: 'tool_use',
+          id: 'tool-1',
+          name: 'Bash',
+          input: { command: 'ls' },
+        },
+      ]),
+      makeToolResultEvent('tool-1', 'file1.txt'),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part).toMatchObject({
+      type: 'dynamic-tool',
+      toolName: 'Bash',
+      toolCallId: 'tool-1',
+      state: 'output-available',
+      input: { command: 'ls' },
+      output: 'file1.txt',
+    });
+  });
+
+  it('produces output-error state when is_error is true', () => {
+    const events = [
+      makeAssistantEvent([
+        { type: 'tool_use', id: 'tool-2', name: 'Edit', input: {} },
+      ]),
+      makeToolResultEvent('tool-2', 'Permission denied', true),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part).toMatchObject({
+      type: 'dynamic-tool',
+      state: 'output-error',
+      errorText: 'Permission denied',
+    });
+  });
+
+  it('produces input-available state when no result exists yet', () => {
+    const events = [
+      makeAssistantEvent([
+        {
+          type: 'tool_use',
+          id: 'tool-3',
+          name: 'Write',
+          input: { path: '/a' },
+        },
+      ]),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part).toMatchObject({
+      type: 'dynamic-tool',
+      toolName: 'Write',
+      state: 'input-available',
+    });
+  });
+
+  it('produces approval-requested state for pending (unresolved) approvals', () => {
+    const pending: PendingApproval[] = [
+      { requestId: 'tool-4', tool: 'Bash', input: {}, resolved: undefined },
+    ];
+    const events = [
+      makeAssistantEvent([
+        {
+          type: 'tool_use',
+          id: 'tool-4',
+          name: 'Bash',
+          input: { command: 'rm -rf' },
+        },
+      ]),
+    ];
+    const result = sdkToUIMessages(events, false, pending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part).toMatchObject({
+      type: 'dynamic-tool',
+      state: 'approval-requested',
+      approval: { id: 'tool-4' },
+    });
+  });
+
+  it('uses output-available (not approval-requested) for resolved approvals', () => {
+    const pending: PendingApproval[] = [
+      {
+        requestId: 'tool-5',
+        tool: 'Bash',
+        input: {},
+        resolved: { approved: true },
+      },
+    ];
+    const events = [
+      makeAssistantEvent([
+        { type: 'tool_use', id: 'tool-5', name: 'Bash', input: {} },
+      ]),
+      makeToolResultEvent('tool-5', 'ok'),
+    ];
+    const result = sdkToUIMessages(events, false, pending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part.state).toBe('output-available');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// User messages
+// ---------------------------------------------------------------------------
+
+describe('sdkToUIMessages — user messages', () => {
+  it('extracts text from a string content user message', () => {
+    const events = [makeUserEvent('Say hello')];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.role).toBe('user');
+    expect(result[0]?.parts[0]).toMatchObject({
+      type: 'text',
+      text: 'Say hello',
+    });
+  });
+
+  it('extracts text blocks from array content, skipping tool_result blocks', () => {
+    const events = [
+      makeUserEvent([
+        { type: 'text', text: 'User text' },
+        { type: 'tool_result', tool_use_id: 'x', content: 'result' },
+      ]),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.parts).toHaveLength(1);
+    expect(result[0]?.parts[0]).toMatchObject({
+      type: 'text',
+      text: 'User text',
+    });
+  });
+
+  it('skips synthetic user events', () => {
+    const events = [makeUserEvent('synthetic', 'uuid-s', true)];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips user events that produce no text', () => {
+    const events = [
+      makeUserEvent([{ type: 'tool_result', tool_use_id: 'x', content: 'r' }]),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Progressive snapshot deduplication
+// ---------------------------------------------------------------------------
+
+describe('sdkToUIMessages — deduplication', () => {
+  it('uses the last snapshot for a given message id', () => {
+    const snapshot1 = makeAssistantEvent(
+      [{ type: 'text', text: 'partial' }],
+      'msg-A',
+      'u1',
+    );
+    const snapshot2 = makeAssistantEvent(
+      [{ type: 'text', text: 'full response' }],
+      'msg-A',
+      'u1',
+    );
+    const result = sdkToUIMessages([snapshot1, snapshot2], false, noPending);
+    // Only one message emitted
+    expect(result).toHaveLength(1);
+    // Should use the second snapshot's content
+    expect(result[0]?.parts[0]).toMatchObject({
+      type: 'text',
+      text: 'full response',
+    });
+  });
+
+  it('emits separate messages for different stable IDs', () => {
+    const events = [
+      makeAssistantEvent([{ type: 'text', text: 'First' }], 'msg-1', 'u1'),
+      makeAssistantEvent([{ type: 'text', text: 'Second' }], 'msg-2', 'u2'),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed message stream
+// ---------------------------------------------------------------------------
+
+describe('sdkToUIMessages — mixed stream', () => {
+  it('interleaves user and assistant messages in order', () => {
+    const events = [
+      makeUserEvent('Hello', 'u-1'),
+      makeAssistantEvent([{ type: 'text', text: 'Hi!' }], 'msg-1', 'a-1'),
+      makeUserEvent('Follow-up', 'u-2'),
+      makeAssistantEvent([{ type: 'text', text: 'Sure.' }], 'msg-2', 'a-2'),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(4);
+    expect(result[0]?.role).toBe('user');
+    expect(result[1]?.role).toBe('assistant');
+    expect(result[2]?.role).toBe('user');
+    expect(result[3]?.role).toBe('assistant');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractPromptSuggestion
+// ---------------------------------------------------------------------------
+
+describe('extractPromptSuggestion', () => {
+  it('returns null for an empty event stream', () => {
+    expect(extractPromptSuggestion([])).toBeNull();
+  });
+
+  it('returns the suggestion from the last prompt_suggestion event', () => {
+    const events = [
+      { type: 'prompt_suggestion', suggestion: 'Try this' },
+    ] as unknown as SDKMessage[];
+    expect(extractPromptSuggestion(events)).toBe('Try this');
+  });
+
+  it('returns null if a user/assistant event follows the suggestion', () => {
+    const events: SDKMessage[] = [
+      {
+        type: 'prompt_suggestion',
+        suggestion: 'Try this',
+      } as unknown as SDKMessage,
+      makeUserEvent('Hello'),
+    ];
+    expect(extractPromptSuggestion(events)).toBeNull();
+  });
+
+  it('returns null for empty/whitespace-only suggestions', () => {
+    const events = [
+      { type: 'prompt_suggestion', suggestion: '   ' },
+    ] as unknown as SDKMessage[];
+    expect(extractPromptSuggestion(events)).toBeNull();
+  });
+
+  it('trims the suggestion', () => {
+    const events = [
+      { type: 'prompt_suggestion', suggestion: '  do something  ' },
+    ] as unknown as SDKMessage[];
+    expect(extractPromptSuggestion(events)).toBe('do something');
+  });
+});

--- a/src/frontend/lib/sdkToUIMessages.test.ts
+++ b/src/frontend/lib/sdkToUIMessages.test.ts
@@ -199,6 +199,68 @@ describe('sdkToUIMessages — tool-use parts', () => {
     const part = result[0]?.parts[0] as Record<string, unknown>;
     expect(part.state).toBe('output-available');
   });
+
+  it('produces approval-responded state for approved-but-no-result-yet tool', () => {
+    const pending: PendingApproval[] = [
+      {
+        requestId: 'tool-6',
+        tool: 'Bash',
+        input: { command: 'ls' },
+        resolved: { approved: true },
+      },
+    ];
+    const events = [
+      makeAssistantEvent([
+        {
+          type: 'tool_use',
+          id: 'tool-6',
+          name: 'Bash',
+          input: { command: 'ls' },
+        },
+      ]),
+      // No tool_result event yet
+    ];
+    const result = sdkToUIMessages(events, false, pending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part).toMatchObject({
+      type: 'dynamic-tool',
+      toolName: 'Bash',
+      toolCallId: 'tool-6',
+      state: 'approval-responded',
+      approval: { id: 'tool-6', approved: true },
+    });
+  });
+
+  it('produces output-denied state for denied-but-no-result-yet tool', () => {
+    const pending: PendingApproval[] = [
+      {
+        requestId: 'tool-7',
+        tool: 'Bash',
+        input: { command: 'rm -rf /' },
+        resolved: { approved: false },
+      },
+    ];
+    const events = [
+      makeAssistantEvent([
+        {
+          type: 'tool_use',
+          id: 'tool-7',
+          name: 'Bash',
+          input: { command: 'rm -rf /' },
+        },
+      ]),
+      // No tool_result event yet
+    ];
+    const result = sdkToUIMessages(events, false, pending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part).toMatchObject({
+      type: 'dynamic-tool',
+      toolName: 'Bash',
+      toolCallId: 'tool-7',
+      state: 'output-denied',
+      approval: { id: 'tool-7', approved: false },
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/frontend/lib/sdkToUIMessages.ts
+++ b/src/frontend/lib/sdkToUIMessages.ts
@@ -1,0 +1,278 @@
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { UIMessage } from 'ai';
+import type { PendingApproval } from '@/frontend/hooks/useSession';
+
+/**
+ * A `DynamicToolUIPart` as defined by the `ai` package.
+ * We use the dynamic variant because Claude tools have arbitrary names.
+ */
+type DynamicToolUIPart =
+  | {
+      type: 'dynamic-tool';
+      toolName: string;
+      toolCallId: string;
+      state: 'input-streaming';
+      input: unknown;
+    }
+  | {
+      type: 'dynamic-tool';
+      toolName: string;
+      toolCallId: string;
+      state: 'input-available';
+      input: unknown;
+    }
+  | {
+      type: 'dynamic-tool';
+      toolName: string;
+      toolCallId: string;
+      state: 'approval-requested';
+      input: unknown;
+      approval: { id: string };
+    }
+  | {
+      type: 'dynamic-tool';
+      toolName: string;
+      toolCallId: string;
+      state: 'output-available';
+      input: unknown;
+      output: unknown;
+    }
+  | {
+      type: 'dynamic-tool';
+      toolName: string;
+      toolCallId: string;
+      state: 'output-error';
+      input: unknown;
+      errorText: string;
+    };
+
+/**
+ * Transforms an array of SDK events into `UIMessage[]` for use with the `ai`
+ * package's UI primitives.
+ *
+ * @param events - Accumulated SDK events from `useSession`.
+ * @param isRunning - When `true`, the last assistant message is marked as
+ *   streaming (text parts get `state: 'streaming'`); otherwise `'done'`.
+ * @param pendingApprovals - Unresolved approval requests annotate tool parts
+ *   with `approval-requested` state.
+ */
+export function sdkToUIMessages(
+  events: SDKMessage[],
+  isRunning: boolean,
+  pendingApprovals: PendingApproval[],
+): UIMessage[] {
+  // Set of requestIds that still need user action
+  const unresolvedIds = new Set(
+    pendingApprovals.filter((a) => !a.resolved).map((a) => a.requestId),
+  );
+
+  // First pass: collect tool results keyed by tool_use_id
+  const toolResults = new Map<string, { result: string; isError: boolean }>();
+
+  for (const event of events) {
+    if (event.type === 'user') {
+      const msg = event.message as { content?: unknown[] };
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          const b = block as Record<string, unknown>;
+          if (b.type === 'tool_result') {
+            const toolUseId = String(b.tool_use_id ?? '');
+            const content = b.content;
+            let resultText = '';
+            if (typeof content === 'string') {
+              resultText = content;
+            } else if (Array.isArray(content)) {
+              resultText = (content as Array<Record<string, unknown>>)
+                .filter((c) => c.type === 'text')
+                .map((c) => String(c.text ?? ''))
+                .join('');
+            }
+            toolResults.set(toolUseId, {
+              result: resultText,
+              isError: b.is_error === true,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Deduplicate assistant events by stable ID — the SDK sends progressive
+  // snapshots of the same message (e.g., first with thinking, then with
+  // tool_use). Keep the LAST snapshot for each stable ID since it has the
+  // most complete content. Use message.id when available, fall back to uuid.
+  const lastAssistantById = new Map<
+    string,
+    { event: SDKMessage; stableId: string }
+  >();
+  for (const event of events) {
+    if (event.type === 'assistant') {
+      const msg = event.message as { id?: string };
+      const uuid = (event as { uuid?: string }).uuid ?? '';
+      const stableId = String(msg.id ?? uuid);
+      if (stableId) {
+        lastAssistantById.set(stableId, { event, stableId });
+      }
+    }
+  }
+
+  const messages: UIMessage[] = [];
+  // Track which stable IDs we've already emitted to avoid duplicates
+  const emittedIds = new Set<string>();
+  const lastAssistantEvent = events
+    .filter((e) => e.type === 'assistant')
+    .at(-1);
+
+  // Second pass: build UIMessage entries
+  for (const event of events) {
+    if (event.type === 'assistant') {
+      const msg = event.message as { id?: string; content?: unknown[] };
+      const uuid = (event as { uuid?: string }).uuid ?? '';
+      const stableId = String(msg.id ?? uuid);
+
+      // Skip if we've already emitted this stable ID (use the latest snapshot)
+      if (emittedIds.has(stableId)) continue;
+
+      // Use the latest snapshot for this message
+      const latest = lastAssistantById.get(stableId);
+      if (!latest) continue;
+      emittedIds.add(stableId);
+
+      const latestMsg =
+        (latest.event as { message?: { content?: unknown[] } }).message ?? {};
+      const content = Array.isArray(latestMsg.content) ? latestMsg.content : [];
+
+      const isLast = latest.event === lastAssistantEvent;
+      const textState = isRunning && isLast ? 'streaming' : 'done';
+
+      // biome-ignore lint/suspicious/noExplicitAny: UIMessage parts union is complex; cast via any to satisfy the generic
+      const parts: any[] = [];
+
+      for (const block of content) {
+        const b = block as Record<string, unknown>;
+
+        if (b.type === 'text') {
+          const text = String(b.text ?? '');
+          if (text) {
+            parts.push({ type: 'text', text, state: textState });
+          }
+        } else if (b.type === 'tool_use') {
+          const toolCallId = String(b.id ?? '');
+          const toolName = String(b.name ?? '');
+          // biome-ignore lint/suspicious/noExplicitAny: SDK input is untyped
+          const input = (b.input ?? {}) as any;
+          const toolResult = toolResults.get(toolCallId);
+          const isUnresolved = unresolvedIds.has(toolCallId);
+
+          let part: DynamicToolUIPart;
+
+          if (isUnresolved) {
+            part = {
+              type: 'dynamic-tool',
+              toolName,
+              toolCallId,
+              state: 'approval-requested',
+              input,
+              approval: { id: toolCallId },
+            };
+          } else if (toolResult !== undefined) {
+            if (toolResult.isError) {
+              part = {
+                type: 'dynamic-tool',
+                toolName,
+                toolCallId,
+                state: 'output-error',
+                input,
+                errorText: toolResult.result,
+              };
+            } else {
+              part = {
+                type: 'dynamic-tool',
+                toolName,
+                toolCallId,
+                state: 'output-available',
+                input,
+                output: toolResult.result,
+              };
+            }
+          } else {
+            // No result yet — tool call is waiting
+            part = {
+              type: 'dynamic-tool',
+              toolName,
+              toolCallId,
+              state: 'input-available',
+              input,
+            };
+          }
+
+          parts.push(part);
+        }
+      }
+
+      if (parts.length === 0) continue;
+
+      messages.push({
+        id: latest.stableId,
+        role: 'assistant',
+        parts,
+      });
+    } else if (event.type === 'user') {
+      const msg = event.message as { content?: unknown[] | string };
+      const isSynthetic = (event as { isSynthetic?: boolean }).isSynthetic;
+      if (isSynthetic) continue;
+
+      let userText = '';
+      if (typeof msg.content === 'string') {
+        userText = msg.content;
+      } else if (Array.isArray(msg.content)) {
+        // Only include text blocks (not tool_result blocks)
+        for (const block of msg.content) {
+          const b = block as Record<string, unknown>;
+          if (b.type === 'text') {
+            userText += String(b.text ?? '');
+          }
+        }
+      }
+
+      if (!userText) continue;
+
+      const uuid = (event as { uuid?: string }).uuid ?? crypto.randomUUID();
+      messages.push({
+        id: uuid,
+        role: 'user',
+        parts: [{ type: 'text', text: userText }],
+      });
+    }
+    // 'result', 'system/init' and other types are ignored
+  }
+
+  return messages;
+}
+
+/**
+ * Extracts the most recent prompt suggestion from the SDK event stream.
+ *
+ * Returns the `suggestion` field from the last `prompt_suggestion` event,
+ * but only if it appears after the final `user` or `assistant` event in the
+ * stream. Both user and assistant events clear the suggestion. Empty or
+ * whitespace-only suggestions are treated as noise (not clear signals) and
+ * skipped — the SDK clears suggestions via the next user/assistant turn.
+ *
+ * Note: `prompt_suggestion` is not yet part of the official `SDKMessage` union
+ * in `@anthropic-ai/claude-agent-sdk` types. The runtime events are emitted as
+ * plain objects so the type check works, but TypeScript may flag `.suggestion`
+ * access if the SDK types are tightened. Track for inclusion upstream.
+ */
+export function extractPromptSuggestion(events: SDKMessage[]): string | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    // biome-ignore lint/style/noNonNullAssertion: index is within bounds (loop condition guarantees i >= 0 && i < events.length)
+    const event = events[i]!;
+    if (event.type === 'user' || event.type === 'assistant') return null;
+    if (event.type === 'prompt_suggestion') {
+      const suggestion = (event as { suggestion?: string }).suggestion;
+      if (suggestion?.trim()) return suggestion.trim();
+    }
+  }
+  return null;
+}

--- a/src/frontend/lib/sdkToUIMessages.ts
+++ b/src/frontend/lib/sdkToUIMessages.ts
@@ -44,6 +44,22 @@ type DynamicToolUIPart =
       state: 'output-error';
       input: unknown;
       errorText: string;
+    }
+  | {
+      type: 'dynamic-tool';
+      toolName: string;
+      toolCallId: string;
+      state: 'approval-responded';
+      input: unknown;
+      approval: { id: string; approved: true };
+    }
+  | {
+      type: 'dynamic-tool';
+      toolName: string;
+      toolCallId: string;
+      state: 'output-denied';
+      input: unknown;
+      approval: { id: string; approved: false };
     };
 
 /**
@@ -64,6 +80,13 @@ export function sdkToUIMessages(
   // Set of requestIds that still need user action
   const unresolvedIds = new Set(
     pendingApprovals.filter((a) => !a.resolved).map((a) => a.requestId),
+  );
+
+  // Map of requestId → approved boolean for resolved approvals
+  const resolvedApprovals = new Map<string, boolean>(
+    pendingApprovals
+      .filter((a) => a.resolved !== undefined)
+      .map((a) => [a.requestId, a.resolved?.approved ?? false]),
   );
 
   // First pass: collect tool results keyed by tool_use_id
@@ -193,6 +216,28 @@ export function sdkToUIMessages(
                 state: 'output-available',
                 input,
                 output: toolResult.result,
+              };
+            }
+          } else if (resolvedApprovals.has(toolCallId)) {
+            // Approval was resolved but tool_result hasn't arrived yet
+            const approved = resolvedApprovals.get(toolCallId) ?? false;
+            if (approved) {
+              part = {
+                type: 'dynamic-tool',
+                toolName,
+                toolCallId,
+                state: 'approval-responded',
+                input,
+                approval: { id: toolCallId, approved: true },
+              };
+            } else {
+              part = {
+                type: 'dynamic-tool',
+                toolName,
+                toolCallId,
+                state: 'output-denied',
+                input,
+                approval: { id: toolCallId, approved: false },
               };
             }
           } else {


### PR DESCRIPTION
## Summary

- Add `sdkToUIMessages.ts` — transforms SDK events to `UIMessage[]` (AI SDK type) with `DynamicToolUIPart` for tool calls and proper state mapping (approval-requested, output-available, output-error, input-available)
- Add `useHolophyteChat.ts` — hook absorbing `SessionRuntimeProvider` logic: optimistic messages, command merging, prompt suggestions, session status → useChat-compatible status mapping
- Convert `sdkToThreadMessages.ts` to a thin backward-compat adapter — existing session UI keeps working unchanged
- 38 new unit tests covering transformation, deduplication, status mapping, optimistic messages, and command merging

**No visual changes.** This is PR 2 of 4 in the AI Elements migration. Stacked on #240.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean
- [x] `bun run test` — 693 tests pass (38 new)
- [x] Existing session UI works unchanged via backward-compat adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a chat hook exposing session status, composed messages (including optimistic messages), prompt suggestions, and merged/sorted available commands for the UI.

* **Tests**
  * Added comprehensive tests for status mapping, message conversion, optimistic messaging lifecycle, command composition/merging, and prompt-suggestion behavior.

* **Refactor**
  * Streamlined message-conversion pipeline to produce UI-friendly messages and centralized prompt-suggestion extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->