### PR TITLE
fix: stabilize worktree scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:e2e": "scripts/test-e2e.sh",
+    "test:e2e:worktree": "scripts/test-e2e-isolated.sh",
     "test:e2e:isolated": "scripts/test-e2e-isolated.sh",
     "lint": "biome check --error-on-warnings .",
     "lint:fix": "biome check --fix .",

--- a/scripts/lib/resolve-bun.sh
+++ b/scripts/lib/resolve-bun.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Resolve the real Bun binary, skipping any node_modules/.bin shim.
+# Source this file — it exports BUN_BIN and a shim-free PATH.
+
+path_without_node_modules_bins() {
+  local part
+  local result=""
+  while IFS= read -r part; do
+    case "$part" in
+      */node_modules/.bin) continue ;;
+    esac
+    if [ -z "$result" ]; then
+      result="$part"
+    else
+      result="$result:$part"
+    fi
+  done < <(printf '%s' "$PATH" | tr ':' '\n')
+  printf '%s' "$result"
+}
+
+REAL_PATH="$(path_without_node_modules_bins)"
+BUN_BIN="$(PATH="$REAL_PATH" command -v bun || true)"
+if [ -z "$BUN_BIN" ]; then
+  echo "Error: Could not find Bun outside node_modules/.bin"
+  exit 1
+fi
+export PATH="$REAL_PATH"

--- a/scripts/lib/resolve-bun.sh
+++ b/scripts/lib/resolve-bun.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Resolve the real Bun binary, skipping any node_modules/.bin shim.
-# Source this file — it exports BUN_BIN and a shim-free PATH.
+# Source this file — it sets BUN_BIN and exports a shim-free PATH.
 
 path_without_node_modules_bins() {
   local part

--- a/scripts/test-e2e-isolated.sh
+++ b/scripts/test-e2e-isolated.sh
@@ -14,29 +14,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 MAIN_DEV_PORTS="$REPO_ROOT/.dev-ports"
 
-path_without_node_modules_bins() {
-  local part
-  local result=""
-  while IFS= read -r part; do
-    case "$part" in
-      */node_modules/.bin) continue ;;
-    esac
-    if [ -z "$result" ]; then
-      result="$part"
-    else
-      result="$result:$part"
-    fi
-  done < <(printf '%s' "$PATH" | tr ':' '\n')
-  printf '%s' "$result"
-}
-
-REAL_PATH="$(path_without_node_modules_bins)"
-BUN_BIN="$(PATH="$REAL_PATH" command -v bun || true)"
-if [ -z "$BUN_BIN" ]; then
-  echo "Error: Could not find Bun outside node_modules/.bin"
-  exit 1
-fi
-export PATH="$REAL_PATH"
+# Resolve real Bun binary (skips node_modules/.bin shim) and export clean PATH
+# shellcheck source=lib/resolve-bun.sh
+source "$SCRIPT_DIR/lib/resolve-bun.sh"
 
 if [ ! -f "$MAIN_DEV_PORTS" ]; then
   echo "Error: .dev-ports not found in main repo"

--- a/scripts/test-e2e-isolated.sh
+++ b/scripts/test-e2e-isolated.sh
@@ -14,6 +14,30 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 MAIN_DEV_PORTS="$REPO_ROOT/.dev-ports"
 
+path_without_node_modules_bins() {
+  local part
+  local result=""
+  while IFS= read -r part; do
+    case "$part" in
+      */node_modules/.bin) continue ;;
+    esac
+    if [ -z "$result" ]; then
+      result="$part"
+    else
+      result="$result:$part"
+    fi
+  done < <(printf '%s' "$PATH" | tr ':' '\n')
+  printf '%s' "$result"
+}
+
+REAL_PATH="$(path_without_node_modules_bins)"
+BUN_BIN="$(PATH="$REAL_PATH" command -v bun || true)"
+if [ -z "$BUN_BIN" ]; then
+  echo "Error: Could not find Bun outside node_modules/.bin"
+  exit 1
+fi
+export PATH="$REAL_PATH"
+
 if [ ! -f "$MAIN_DEV_PORTS" ]; then
   echo "Error: .dev-ports not found in main repo"
   exit 1
@@ -65,7 +89,7 @@ EOF
 
 # Install dependencies (convex/_generated is already in the worktree via git)
 echo "Installing dependencies..."
-cd "$WORKTREE_PATH" && bun install --frozen-lockfile
+cd "$WORKTREE_PATH" && "$BUN_BIN" install --frozen-lockfile
 
 # Run E2E tests — capture exit code to return after cleanup
 echo ""

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -22,28 +22,9 @@ WORKTREE_DIR="$HOME/.holophyte-dev"
 WORKTREE_PATH="$WORKTREE_DIR/$FEATURE_NAME"
 BRANCH="feat/$FEATURE_NAME"
 
-path_without_node_modules_bins() {
-  local part
-  local result=""
-  while IFS= read -r part; do
-    case "$part" in
-      */node_modules/.bin) continue ;;
-    esac
-    if [ -z "$result" ]; then
-      result="$part"
-    else
-      result="$result:$part"
-    fi
-  done < <(printf '%s' "$PATH" | tr ':' '\n')
-  printf '%s' "$result"
-}
-
-REAL_PATH="$(path_without_node_modules_bins)"
-BUN_BIN="$(PATH="$REAL_PATH" command -v bun || true)"
-if [ -z "$BUN_BIN" ]; then
-  echo "Error: Could not find Bun outside node_modules/.bin"
-  exit 1
-fi
+# Resolve real Bun binary (skips node_modules/.bin shim) and export clean PATH
+# shellcheck source=lib/resolve-bun.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib/resolve-bun.sh"
 
 # Read team/project from main repo's .dev-ports
 MAIN_DEV_PORTS="$REPO_ROOT/.dev-ports"
@@ -105,7 +86,7 @@ echo "Creating worktree at ~/.holophyte-dev/$FEATURE_NAME on branch $BRANCH..."
 git worktree add "$WORKTREE_PATH" -b "$BRANCH"
 
 # From this point, failures should clean up the partial worktree
-trap cleanup ERR
+trap cleanup ERR INT TERM
 
 # Copy .env (shared config). Don't copy .env.local yet — Convex will create it
 # during provisioning. Non-Convex vars (API keys, secrets) are appended after.
@@ -295,7 +276,7 @@ lsof -ti "TCP:$CONVEX_CLOUD_PORT" 2>/dev/null | xargs kill 2>/dev/null || true
 lsof -ti "TCP:$CONVEX_SITE_PORT" 2>/dev/null | xargs kill 2>/dev/null || true
 
 # Disable the cleanup trap — we succeeded
-trap - ERR
+trap - ERR INT TERM
 
 echo ""
 echo "Worktree created: ~/.holophyte-dev/$FEATURE_NAME"

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -22,6 +22,29 @@ WORKTREE_DIR="$HOME/.holophyte-dev"
 WORKTREE_PATH="$WORKTREE_DIR/$FEATURE_NAME"
 BRANCH="feat/$FEATURE_NAME"
 
+path_without_node_modules_bins() {
+  local part
+  local result=""
+  while IFS= read -r part; do
+    case "$part" in
+      */node_modules/.bin) continue ;;
+    esac
+    if [ -z "$result" ]; then
+      result="$part"
+    else
+      result="$result:$part"
+    fi
+  done < <(printf '%s' "$PATH" | tr ':' '\n')
+  printf '%s' "$result"
+}
+
+REAL_PATH="$(path_without_node_modules_bins)"
+BUN_BIN="$(PATH="$REAL_PATH" command -v bun || true)"
+if [ -z "$BUN_BIN" ]; then
+  echo "Error: Could not find Bun outside node_modules/.bin"
+  exit 1
+fi
+
 # Read team/project from main repo's .dev-ports
 MAIN_DEV_PORTS="$REPO_ROOT/.dev-ports"
 if [ ! -f "$MAIN_DEV_PORTS" ]; then
@@ -68,6 +91,9 @@ cleanup() {
   if [ -n "${CONVEX_SITE_PORT:-}" ]; then
     lsof -ti "TCP:$CONVEX_SITE_PORT" 2>/dev/null | xargs kill 2>/dev/null || true
   fi
+  if [ -n "${CONVEX_ENV_FILE:-}" ]; then
+    rm -f "$CONVEX_ENV_FILE"
+  fi
   cd "$REPO_ROOT"
   git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || rm -rf "$WORKTREE_PATH"
   git worktree prune 2>/dev/null || true
@@ -97,7 +123,7 @@ fi
 # Install dependencies (frozen lockfile avoids modifying bun.lock, which would
 # make the worktree dirty and block `bunx @convex-dev/auth` later)
 echo "Installing dependencies..."
-cd "$WORKTREE_PATH" && bun install --frozen-lockfile
+cd "$WORKTREE_PATH" && "$BUN_BIN" install --frozen-lockfile
 
 # Assign ports — scan all existing .dev-ports files to avoid collisions with
 # other worktrees, even if they aren't currently running.
@@ -156,7 +182,7 @@ if [ ! -f "$WORKTREE_PATH/convex.json" ]; then
 fi
 
 echo "Initializing local Convex backend (cloud=$CONVEX_CLOUD_PORT, site=$CONVEX_SITE_PORT)..."
-cd "$WORKTREE_PATH" && bunx convex dev --configure existing \
+cd "$WORKTREE_PATH" && "$BUN_BIN" x convex dev --configure existing \
   --team "$CONVEX_TEAM" \
   --project "$CONVEX_PROJECT" \
   --dev-deployment local \
@@ -173,8 +199,8 @@ fi
 
 # `convex dev --once` exits after deploying, but `convex env set` needs a
 # running backend. Start one in the background, set env vars, then stop it.
-echo "Setting environment variables on local Convex..."
-cd "$WORKTREE_PATH" && bunx convex dev --local \
+echo "Starting local Convex for environment setup..."
+cd "$WORKTREE_PATH" && "$BUN_BIN" x convex dev --local \
   --local-cloud-port "$CONVEX_CLOUD_PORT" \
   --local-site-port "$CONVEX_SITE_PORT" &
 CONVEX_BG_PID=$!
@@ -196,24 +222,26 @@ for i in $(seq 1 30); do
   sleep 1
 done
 
-# Set env vars one at a time with a pause between each. Rapid-fire `env set`
-# while `convex dev --local` is running causes "Environment variables have
-# changed during push" errors because each set triggers a redeploy.
-set_convex_env() {
-  cd "$WORKTREE_PATH" && bunx convex env set -- "$1" "$2"
-  sleep 2
+CONVEX_ENV_FILE=$(mktemp)
+
+write_convex_env() {
+  local key="$1"
+  local value="$2"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s="%s"\n' "$key" "$value" >> "$CONVEX_ENV_FILE"
 }
 
 # Override SITE_URL (a Convex Auth env var) to point at the app server port.
 # The app server proxies /api/auth/* to the Convex site port so OAuth callbacks
 # work through a single origin (matches what's configured in GitHub/Google OAuth apps).
-set_convex_env SITE_URL "http://localhost:$DEV_PORT"
-set_convex_env ALLOW_ANONYMOUS_AUTH 1
-set_convex_env ALLOW_PASSWORD_AUTH 1
+write_convex_env SITE_URL "http://localhost:$DEV_PORT"
+write_convex_env ALLOW_ANONYMOUS_AUTH 1
+write_convex_env ALLOW_PASSWORD_AUTH 1
 
 # Generate and set INTERNAL_API_SECRET for companion ↔ Convex communication
 INTERNAL_API_SECRET=$(openssl rand -hex 32)
-set_convex_env INTERNAL_API_SECRET "$INTERNAL_API_SECRET"
+write_convex_env INTERNAL_API_SECRET "$INTERNAL_API_SECRET"
 # Store the secret in .env.local (Bun prioritizes .env.local over .env).
 # convex-local.sh reads from .env.local first to stay in sync with the server.
 ENV_LOCAL_FILE="$WORKTREE_PATH/.env.local"
@@ -227,7 +255,7 @@ fi
 # Uses jose directly instead of `bunx @convex-dev/auth` — that tool has
 # interactive prompts (SITE_URL, dirty tree) that break in automated scripts.
 echo "Generating Convex Auth JWT keys..."
-JWT_OUTPUT=$(cd "$WORKTREE_PATH" && bun --eval '
+JWT_OUTPUT=$(cd "$WORKTREE_PATH" && "$BUN_BIN" --eval '
 import { generateKeyPair, exportPKCS8, exportJWK } from "jose";
 const keys = await generateKeyPair("RS256", { extractable: true });
 const priv = (await exportPKCS8(keys.privateKey)).trimEnd().replaceAll("\n", " ");
@@ -237,23 +265,25 @@ console.log(JSON.stringify({ keys: [{ use: "sig", ...pub }] }));
 ')
 JWT_PRIVATE_KEY=$(echo "$JWT_OUTPUT" | head -1)
 JWKS=$(echo "$JWT_OUTPUT" | tail -1)
-set_convex_env JWT_PRIVATE_KEY "$JWT_PRIVATE_KEY"
-set_convex_env JWKS "$JWKS"
+write_convex_env JWT_PRIVATE_KEY "$JWT_PRIVATE_KEY"
+write_convex_env JWKS "$JWKS"
 
 # Forward OAuth credentials from main repo's .dev-ports (if present)
 if [ -n "${AUTH_GITHUB_ID:-}" ] && [ -n "${AUTH_GITHUB_SECRET:-}" ]; then
-  echo "Setting GitHub OAuth credentials..."
-  set_convex_env AUTH_GITHUB_ID "$AUTH_GITHUB_ID"
-  set_convex_env AUTH_GITHUB_SECRET "$AUTH_GITHUB_SECRET"
+  write_convex_env AUTH_GITHUB_ID "$AUTH_GITHUB_ID"
+  write_convex_env AUTH_GITHUB_SECRET "$AUTH_GITHUB_SECRET"
 fi
 if [ -n "${AUTH_GOOGLE_ID:-}" ] && [ -n "${AUTH_GOOGLE_SECRET:-}" ]; then
-  echo "Setting Google OAuth credentials..."
-  set_convex_env AUTH_GOOGLE_ID "$AUTH_GOOGLE_ID"
-  set_convex_env AUTH_GOOGLE_SECRET "$AUTH_GOOGLE_SECRET"
+  write_convex_env AUTH_GOOGLE_ID "$AUTH_GOOGLE_ID"
+  write_convex_env AUTH_GOOGLE_SECRET "$AUTH_GOOGLE_SECRET"
 fi
 
+echo "Setting environment variables on local Convex..."
+cd "$WORKTREE_PATH" && "$BUN_BIN" x convex env set --from-file "$CONVEX_ENV_FILE" --force
+rm -f "$CONVEX_ENV_FILE"
+
 # Seed dev user for email+password auth (idempotent)
-cd "$WORKTREE_PATH" && bun run seed:dev-user || echo "Warning: Could not seed dev user"
+cd "$WORKTREE_PATH" && "$BUN_BIN" run seed:dev-user || echo "Warning: Could not seed dev user"
 
 # Stop the background Convex backend (kill process group + port fallback,
 # because `bunx` spawns child processes that outlive the wrapper)


### PR DESCRIPTION
## Summary

- Batch local Convex environment variable setup in `worktree:create` through a single `convex env set --from-file ... --force` call.
- Make worktree scripts resolve the real Bun binary outside `node_modules/.bin`, avoiding the npm `bun` shim when commands are launched via `bun run`.
- Add `test:e2e:worktree` as an alias for the isolated worktree E2E flow.
- Clean up the temporary Convex env file if worktree creation fails.

## Root Cause

`worktree:create` previously called `convex env set` once per variable while `convex dev --local` was running. Each env update can trigger a push, so the background dev process could observe changing env state and emit repeated `Environment variables have changed during push` retry noise during provisioning.

While testing `bun run test:e2e:worktree`, the command was also missing from `package.json`. The existing isolated E2E script then exposed a PATH issue: `bun run` prepends `node_modules/.bin`, and this repo can contain the npm `bun` package shim there. Worktree scripts that run plain `bun` or `bunx` after changing directories can accidentally invoke that shim instead of the actual Bun installation.

## Validation

- `bash -n scripts/worktree-create.sh scripts/test-e2e-isolated.sh scripts/worktree-cleanup.sh`
- `bun run worktree:create codex-smoke-real-bun`
- `bun run test:e2e:worktree` - 73 passed
- Pre-commit hook: lint and typecheck passed. Convex codegen was skipped because no local backend was running, which the hook treats as non-blocking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new npm script as an additional isolated E2E testing entry point.
  * Improved test environment reliability by resolving and using the correct runtime binary and avoiding local tool shims.
  * Streamlined test setup by batching environment-variable application and enhancing cleanup, error handling, and signal trapping for more consistent runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->