### PR TITLE
chore: add codex setup

### DIFF
--- a/.codex/skills/autopilot-team/SKILL.md
+++ b/.codex/skills/autopilot-team/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: autopilot-team
+description: Implement a feature using ephemeral agent teams with parallel per-task subagents, critic review, and verification
+---
+
+# Autopilot Team
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Like `/autopilot`, but uses ephemeral per-task subagents for complex features that
+benefit from parallel work and independent perspectives.
+
+Use this for larger features that touch multiple files or modules. For smaller,
+focused changes, prefer `/autopilot` (single-agent).
+
+## Usage
+
+/autopilot-team <description of what to implement>
+
+## Process
+
+### 1. Set Up Worktree
+
+Create a worktree for the team to work in (always — teams should never work on main):
+
+Derive a short feature name from `$ARGUMENTS`, then:
+
+```bash
+bun run worktree:create <feature-name>
+```
+
+Work from the new worktree directory after creation.
+
+### 2. Research
+
+Spawn the `researcher` agent to explore the codebase before planning. Pass the
+feature description from `$ARGUMENTS` as context.
+
+Wait for the researcher to finish before proceeding to step 3.
+
+### 3. Plan the Work
+
+Spawn the `planner` agent to design the implementation based on research findings.
+Pass the feature description from `$ARGUMENTS` as context.
+
+Wait for the planner to finish. Review `.autopilot/plan-<branch>.md` — adjust if needed.
+
+The plan should also group tasks by independence: which can parallelize vs which have dependencies.
+
+**Note:** `.autopilot/` is gitignored — do not commit research or plan files unless
+the feature spans multiple PRs and you need to preserve context across sessions.
+
+### 4. Critic Review
+
+Spawn the `critic` agent to adversarially review the plan:
+
+> The feature being built is: `<$ARGUMENTS>`. Review the implementation plan at `.autopilot/plan-<branch>.md` for this feature. Look for wrong assumptions, missed edge cases, simpler approaches, missing failure modes, and scope creep.
+
+If the critic finds **critical** issues (missed failure modes, wrong assumptions, simpler approaches that invalidate the plan), revise the plan before proceeding. Address **concerns** if valid. **Questions** are worth considering but don't block progress.
+
+### 5. Execute Tasks (Ephemeral Model)
+
+For each task group from the plan:
+
+1. **Identify independent tasks** that can run in parallel (no shared file ownership, no data dependencies)
+2. **Spawn implementers in parallel** — one ephemeral agent per task, each with a focused prompt:
+
+   ```text
+   Implement the following task from the plan at `.autopilot/plan-<branch>.md`:
+
+   **Task:** <task description from plan>
+   **Files to modify:** <file list from plan>
+   **Dependencies completed:** <list of prior tasks already done>
+   **Constraints:** <relevant constraints from plan>
+
+   Follow AGENTS.md conventions. DO NOT run `git add` or `git commit` — the orchestrator handles all git operations after parallel tasks complete to avoid index conflicts.
+   Do not modify files outside your assigned scope.
+   When done, report the list of files you created or modified in your completion message.
+
+   After implementing, if your task adds user-facing behavior:
+   - Write E2E tests for the new/changed flows
+   - If skipping E2E, state why in your completion message
+
+   After implementing, if your task adds new exports or components:
+   - Write unit tests for new logic
+   - Add TSDoc comments to new exported functions/interfaces
+   ```
+
+   Choose the right specialist for each task:
+   - **`frontend-implementer`** — tasks touching `src/frontend/`
+   - **`backend-implementer`** — tasks touching `src/server.ts` or `src/claude/`
+   - **`convex-implementer`** — tasks touching `convex/`
+   - **`devops-implementer`** — tasks touching infra, CI/CD, scripts, or config
+   - **`general-implementer`** — simple tasks or single-layer changes
+
+3. **Wait for all to complete** — each implementer reports its modified file list
+4. **Commit the batch** — the orchestrator uses each implementer's reported file list to `git add <files>` and commit separately, producing one atomic commit per task. After committing all tasks, run `git status --porcelain` to check for unreported files; if any appear, commit them separately (do not amend — amending would misattribute them to the wrong task).
+5. **Spawn `code-reviewer`** to review the batch's changes
+6. **Fix critical issues** — spawn a fresh implementer for fixes if needed
+7. **Proceed to next dependent task group**
+
+### 6. Simplify Pass
+
+Do a fresh simplification pass to clean up all changed code:
+
+> Review the changes on this branch (`git diff main...HEAD`) for code quality, duplication, and simplification opportunities. Fix any issues found.
+
+This cleans up implementation before reviewers see it.
+
+### 7. Documentation & Testing
+
+Spawn support agents as needed (all ephemeral):
+
+- **`test-writer`** — for new exports that need unit tests (if applicable)
+- **`e2e-tester`** — for UI behavior changes (if applicable). If skipping E2E, state why.
+- **`storybook-writer`** — for new reusable UI components (if applicable)
+- **`doc-writer`** — for doc-worthy changes (if applicable). If skipping docs, state why.
+
+### 8. Final Review
+
+Spawn reviewers in parallel:
+
+> Use the `code-reviewer` subagent to review all changes on the branch (`git diff main...HEAD`)
+> Use the `security-reviewer` subagent to audit the current changes
+> Use the `a11y-reviewer` subagent to audit accessibility of any new/changed UI components
+
+Optionally spawn the `critic` agent for a second adversarial review of the implementation — useful when step 5 required significant rework or the implementation diverged from the original plan.
+
+Fix any critical issues found.
+
+### 9. Exploratory Verification
+
+Verify the change works end-to-end beyond what automated tests cover. Step 10 runs lint, typecheck, unit tests, and E2E — do **not** duplicate those here. Focus on manual/exploratory checks:
+
+- Using available browser automation, such as Playwright tests or MCP browser tools when configured, to verify flows work visually
+- Curling API endpoints to check responses
+- Reading logs or Convex dashboard output
+- Running the app and exercising the changed behavior
+- Checking database state after mutations
+
+Use your judgment about what verification is appropriate. The goal is to confirm the change actually works, not just that tests pass.
+
+### 10. Quality Checks
+
+```bash
+bun run lint:fix
+bunx tsc --noEmit
+bun run test
+bun run test:e2e:isolated
+timeout 60s bun run build-storybook
+cd docs && bunx docusaurus build
+```
+
+Fix any remaining issues. Use the `test-fixer` subagent if tests fail.
+
+### 11. Commit and Push
+
+**Commit atomically** — each commit should be one logical change (e.g., schema
+change, then backend handler, then frontend component). Don't batch unrelated
+changes into a single commit. Task-implementation commits were created in step 5;
+this step commits any remaining changes from the simplify pass (step 6),
+documentation & testing (step 7), and review fixes (step 8).
+
+```bash
+git add <relevant files>
+git commit -m "<conventional commit message>"
+git push -u origin $(git branch --show-current)
+```
+
+### 12. Create PR
+
+```bash
+gh pr create --title "<type>: <description>" --body "<summary of changes>"
+```
+
+Use a conventional prefix in the title (`feat:`, `fix:`, `refactor:`, etc.).
+
+### 13. PR Review Loop
+
+Wait for all PR checks (including review bots) to complete, then iterate on comments:
+
+1. **Wait for checks and fetch new comments:**
+   ```bash
+   bun run pr-comments -- --poll <PR_NUMBER>
+   ```
+   This uses `gh pr checks --watch` to block until all checks finish, then shows any new review bot comments.
+2. **Triage new comments** as:
+   - **Actionable** (bugs, security, clear quality issues) — fix the code, reply with explanation
+   - **Dismissable** (style conflicts, false positives, over-engineering) — reply explaining why
+3. **Reply** to comments:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<PR>/comments/<COMMENT_ID>/replies \
+     -f body="<reply>"
+   ```
+4. **Push** — run quality checks, commit fixes, push
+5. **Repeat** from step 1 (max 3 iterations)
+6. **Exit** when no new comments appear or max iterations reached
+
+### 14. Summary
+
+When exiting, display:
+- Tasks completed and which specialist implementer handled each
+- Subagents spawned per task (implementer type, reviewer, support agents)
+- Critic findings addressed (from step 4 and optional step 8)
+- Review iterations with review bots
+- Comments addressed vs dismissed
+- Final PR URL
+
+#### Manual Testing
+
+Include a checklist of what the user should verify manually:
+- Visual design quality (spacing, alignment, colors, responsiveness)
+- UX feel (animations, transitions, loading states, focus behavior)
+- Edge cases with real data (large datasets, empty states, concurrent users)
+- Any flows that depend on external services (OAuth, Convex dashboard, etc.)

--- a/.codex/skills/autopilot/SKILL.md
+++ b/.codex/skills/autopilot/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: autopilot
+description: Implement a feature and iterate on PR review comments autonomously
+---
+
+# Autopilot
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Implement a feature, push a PR, and autonomously iterate on PR code review
+comments until resolved.
+
+## Usage
+
+/autopilot <description of what to implement>
+
+## Process
+
+### 0. Evaluate Complexity (Optional Brainstorm Gate)
+
+Before starting, assess whether the feature needs design discussion:
+
+**Use `/brainstorm` first if:**
+- New data model or schema changes with multiple valid approaches
+- New system boundary (new API endpoint, new Convex action/mutation, new external integration)
+- The feature description is ambiguous or underspecified
+- Multiple architectural approaches exist with meaningful trade-offs
+
+**Skip and proceed to step 1 if:**
+- The approach is obvious from existing patterns
+- The user has given specific, detailed instructions
+- It's a bug fix, refactor, or enhancement to existing behavior
+
+### 1. Set Up Worktree (if needed)
+
+If not already on a feature branch, create a worktree to avoid disrupting current work:
+
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+- If on `main`: derive a short feature name from `$ARGUMENTS` (e.g., "add drag reordering" becomes `drag-reordering`), then run `bun run worktree:create <feature-name>` and work from the new worktree directory
+- If already on a `feat/` branch: continue in the current directory
+
+### 2. Research the Codebase
+
+Before writing any code, spawn the `researcher` agent to explore the codebase.
+Pass the feature description from `$ARGUMENTS` as context.
+
+### 3. Plan the Implementation
+
+Based on the research, write an implementation plan to `.autopilot/plan-<branch>.md` (same branch suffix as the research file):
+
+- List the files to create or modify (in order)
+- For each file, describe the approach and include **code snippet examples** showing how it should look — reference existing patterns from the research (e.g., "follow the same pattern as `SessionDropdown.tsx` lines 20-35")
+- Be **descriptive** — explain the _why_ and show the _shape_ of the code, not a line-by-line prescription. The implementer (you) should understand the intent and adapt.
+- Use prescriptive step-by-step instructions only for mechanical/boilerplate changes (schema migrations, config edits, etc.)
+- Identify risks or edge cases
+- If the plan has multiple valid approaches, pick the simplest one (KISS)
+
+Write the plan file, then proceed with implementation.
+
+**Note:** `.autopilot/` is gitignored — do not commit research or plan files unless
+the feature spans multiple PRs and you need to preserve context across sessions.
+
+### 4. Critic Review
+
+Spawn the `critic` agent to adversarially review the plan before implementation:
+
+> The feature being built is: `<$ARGUMENTS>`. Review the implementation plan at `.autopilot/plan-<branch>.md` for this feature. Look for wrong assumptions, missed edge cases, simpler approaches, missing failure modes, and scope creep.
+
+If the critic finds **critical** issues (missed failure modes, wrong assumptions, simpler approaches that invalidate the plan), revise the plan before proceeding. Address **concerns** if they're valid. **Questions** are worth considering but don't block progress.
+
+### 5. Implement the Feature
+
+Implement the feature described in `$ARGUMENTS`, following `.autopilot/plan-<branch>.md`.
+
+**Commit atomically** — each commit should be one logical change (e.g., schema
+change, then backend handler, then frontend component). Don't batch unrelated
+changes into a single commit.
+
+- Follow all patterns and conventions in AGENTS.md
+- Run quality checks when implementation is complete:
+
+```bash
+bun run lint:fix
+bunx tsc --noEmit
+bun run test
+```
+
+- If tests fail, use the `test-fixer` subagent to analyze and fix failures
+- Fix lint/type errors directly
+
+### 6. Simplify Pass
+
+Do a fresh simplification pass to review changed code for reuse, quality, and efficiency:
+
+> Review the changes on this branch (`git diff main...HEAD`) for code quality, duplication, and simplification opportunities. Fix any issues found.
+
+This cleans up the implementation before reviewers see it.
+
+### 7. Self-Review with Subagents
+
+Before committing, run reviewers in parallel:
+
+> Use the `code-reviewer` subagent to review the current changes
+> Use the `security-reviewer` subagent to audit the current changes
+> Use the `a11y-reviewer` subagent to audit accessibility of any new/changed UI components
+
+- Fix any **critical** issues from any reviewer (including critical a11y issues)
+- Evaluate **warnings** and fix if valid
+- **Suggestions** are optional — skip unless clearly beneficial
+- Run quality checks again if changes were made
+
+### 8. Documentation, Testing, and Accessibility for New Code
+
+Check for new and changed files on the branch:
+
+```bash
+git diff main...HEAD --name-only --diff-filter=A   # new files
+git diff main...HEAD --name-only                     # all changed files
+```
+
+For each new file:
+- **New reusable UI components or components with multiple visual states** → use the `storybook-writer` subagent to generate a co-located `.stories.tsx`. Skip Storybook for page-level layouts, data-coupled feature components that need extensive Convex mocking, and thin wrappers with no visual complexity.
+- **New `.ts`/`.tsx` exports** → use the `test-writer` subagent to generate co-located tests
+- **New/changed UI components** → use the `a11y-reviewer` subagent to audit accessibility (already done in step 7 — review results here)
+- Add TSDoc `/** */` comments to all new exported functions and interfaces
+
+Skip Storybook/test generation if no new files were added (only modifications to existing files).
+
+#### E2E Tests
+
+Write E2E tests for this change. If skipping, state the reason.
+
+Valid skip reasons: backend-only change, config-only change, test-only change, no new user-facing behavior.
+
+If writing E2E tests, use the `e2e-tester` subagent:
+
+> Write Playwright E2E tests for the new/changed user-facing features on this branch.
+> Tests go in `e2e/` directory with pattern `*.spec.ts`.
+> Follow the existing E2E patterns in `e2e/app.spec.ts` and `e2e/all-tasks-create.spec.ts`:
+> - Import `{ expect, test }` from `@playwright/test`
+> - Use `waitForApp(page)` helper: `page.goto('/')` + `page.waitForSelector('text=Holophyte', { timeout: 30000 })`
+> - Global setup auto-signs-in via `AutoTestAuth` (password auth with `dev@holophyte.test`), creates an e2e repo (name matches `/e2e-/`), and saves auth state via `storageState`
+> - Use generous timeouts for visibility checks (5-10s) — Convex queries are async
+> - Scope dialog assertions to `[role="dialog"]` to avoid strict mode collisions
+> - Use `{ exact: true }` for ambiguous text matches
+> - Each test run gets a fresh Convex database — no cleanup needed, but use unique names (e.g. `Date.now()`) to avoid collisions within a run
+> - Do NOT start Convex or the dev server manually — `bun run test:e2e:isolated` handles the full lifecycle
+> Review existing specs in `e2e/` for reference patterns.
+
+#### Docusaurus Documentation
+
+Evaluate docs and state your decision. If skipping, explain why.
+
+The changes are **doc-worthy** if ANY of these are true:
+
+- New public hook, utility, or API endpoint was added
+- New component with non-trivial behavior or complex props was added
+- Existing documented architecture or data flow changed meaningfully
+- New Convex table, query, or mutation was added
+- New agent, skill, or automation pattern was introduced
+
+If doc-worthy, use the `doc-writer` subagent:
+
+> Review the changes on this branch (`git diff main...HEAD --name-only`) and update the relevant Docusaurus documentation in `docs/docs/`. Only update pages that are affected by the changes — do not regenerate unrelated docs. Add TSDoc comments to any new exported functions/interfaces that lack them. Verify with `cd docs && bunx docusaurus build`.
+
+#### Pre-Commit Verification Checklist
+
+Before proceeding to commit, verify:
+- [ ] E2E tests: written, or reason for skipping stated
+- [ ] Documentation: updated, or reason for skipping stated
+- [ ] All quality checks pass (lint, typecheck, tests, E2E)
+
+Use `bun run test:e2e:isolated` to run E2E tests without stopping the dev Convex backend — this runs in a temp worktree and avoids port conflicts.
+
+After generating stories, tests, and docs, verify:
+
+```bash
+bunx vitest run
+bun run test:e2e:isolated
+timeout 60s bun run build-storybook
+cd docs && bunx docusaurus build
+```
+
+Fix any failures before proceeding.
+
+### 9. Exploratory Verification
+
+Verify the change works end-to-end beyond what automated tests cover. Steps 5 and 8 already ran lint, typecheck, unit tests, and E2E — do **not** re-run those here. Focus on manual/exploratory checks:
+
+- Using available browser automation, such as Playwright tests or MCP browser tools when configured, to verify flows work visually
+- Curling API endpoints to check responses
+- Reading logs or Convex dashboard output
+- Running the app and exercising the changed behavior
+- Checking database state after mutations
+
+Use your judgment about what verification is appropriate. The goal is to confirm the change actually works, not just that tests pass.
+
+### 10. Commit and Push
+
+```bash
+git add <relevant files>
+git commit -m "<conventional commit message>"
+git push -u origin $(git branch --show-current)
+```
+
+### 11. Create or Update PR
+
+Check if a PR already exists for this branch:
+
+```bash
+gh pr list --head $(git branch --show-current) --json number --jq '.[0].number'
+```
+
+- If no PR exists, create one with `gh pr create` — use a conventional prefix in the title (e.g., `feat: add drag reordering to kanban columns`)
+- If PR exists, it's already updated by the push
+
+### 12. Poll for PR Review
+
+Wait for all PR checks to complete, then fetch new comments:
+
+```bash
+bun run pr-comments -- --poll <PR_NUMBER>
+```
+
+This uses `gh pr checks --watch` to block until all checks finish, then shows any new review bot comments.
+
+- If no new comments after checks complete, exit successfully — review bots found nothing to flag
+
+### 13. Triage Comments
+
+Read the output from the polling script. Categorize each new comment:
+
+**Actionable** — fix the code:
+- Bug or correctness issues
+- Security concerns
+- Clear code quality improvements
+
+**Dismissable** — reply explaining why no change is needed:
+- Stylistic preferences that conflict with project conventions in AGENTS.md
+- False positives or misunderstandings of intent
+- Suggestions that would over-engineer the solution
+
+### 14. Address Comments
+
+For each actionable comment:
+1. Read the file at the referenced line
+2. Fix the issue
+3. Reply to the comment with a brief explanation of the fix
+
+For each dismissable comment:
+1. Reply to the comment explaining why no change is needed
+
+Reply to comments using:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<PR>/comments/<COMMENT_ID>/replies \
+  -f body="<reply>"
+```
+
+### 15. Push and Loop
+
+After addressing all comments:
+
+```bash
+bun run lint:fix
+bunx tsc --noEmit
+bun run test
+```
+
+- If tests fail, use the `test-fixer` subagent to fix them
+
+```bash
+git add <changed files>
+git commit -m "fix: address review feedback"
+git push
+```
+
+Return to **Step 12** for the next round.
+
+### 16. Exit Conditions
+
+Stop the loop when any of these are true:
+
+- **No new comments** — review bots found nothing new after the latest push (success)
+- **Max 3 iterations** — report remaining unresolved comments to the user
+- **Quality checks fail after 2 retries** — stop and report the errors
+
+### 17. Summary
+
+When exiting, display:
+- Total iterations completed
+- Comments addressed (with links) vs dismissed (with reasons)
+- Any unresolved comments remaining
+- Final PR URL
+
+#### Manual Testing
+
+Include a checklist of what the user should verify manually:
+- Visual design quality (spacing, alignment, colors, responsiveness)
+- UX feel (animations, transitions, loading states, focus behavior)
+- Edge cases with real data (large datasets, empty states, concurrent users)
+- Any flows that depend on external services (OAuth, Convex dashboard, etc.)

--- a/.codex/skills/brainstorm/SKILL.md
+++ b/.codex/skills/brainstorm/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: brainstorm
+description: Design gate before implementation — explore approaches and trade-offs before writing code
+---
+
+# Brainstorm
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Design gate before implementation. Use when a feature is architecturally complex — new data models, new system boundaries, or multiple valid approaches.
+
+## Usage
+
+/brainstorm <description of what to build>
+
+## Process
+
+### 1. Understand
+
+Restate the problem in your own words. Identify:
+- What exactly needs to happen (functional requirements)
+- What's ambiguous or underspecified
+- What constraints exist (existing patterns, performance, backwards compatibility)
+
+If something is genuinely unclear, ask **one** clarifying question. Wait for the answer before proceeding. Do not ask a wall of questions — one at a time.
+
+### 2. Research
+
+Spawn the `researcher` agent to explore the codebase. Pass the feature description from `$ARGUMENTS` as context. Ask it to find:
+- Existing patterns that this feature should follow or extend
+- Related features that solve similar problems
+- Constraints from the schema, API surface, or frontend state model
+- Files that will need to change
+
+### 3. Design
+
+Read `.autopilot/research-<branch>.md` (written by the researcher in step 2) and present **1-3 approaches** with trade-offs. For each approach:
+
+- **Files to modify** — which files change and roughly how
+- **Data model changes** — new tables, fields, indexes (if any)
+- **Key code shapes** — pseudocode or interface sketches showing the approach, not full implementations
+- **Risks** — what could go wrong, what's hard, what's uncertain
+- **Trade-offs** — what you gain vs what you give up compared to the other approaches
+
+**Recommend one** with a clear reason. Prefer the simplest approach that meets the requirements (KISS).
+
+### 4. Gate
+
+Wait for explicit user approval before proceeding. Present the options clearly and ask:
+
+> Which approach would you like to go with? Or would you like to explore a different direction?
+
+After approval, offer to hand off to:
+- `/autopilot` for single-agent implementation
+- `/autopilot-team` for parallel team implementation
+- Or let the user implement manually with the design as a guide
+
+## When to Use
+
+**Use `/brainstorm` when:**
+- New data model or schema changes with multiple valid approaches
+- New system boundary (API endpoint, Convex action/mutation, external integration)
+- Feature description is ambiguous or underspecified
+- Multiple architectural approaches exist with meaningful trade-offs
+
+**Skip and implement directly when:**
+- The approach is obvious from existing patterns
+- The user has given specific, detailed instructions
+- It's a bug fix, refactor, or enhancement to existing behavior

--- a/.codex/skills/branch-status/SKILL.md
+++ b/.codex/skills/branch-status/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: branch-status
+description: Overview of all branches, PRs, and worktrees
+---
+
+# Branch Status Overview
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Show a comprehensive overview of all branches, their PR status, and active worktrees.
+
+## Usage
+
+/branch-status
+
+## Process
+
+### 1. Fetch Latest
+
+```bash
+git fetch --all --prune
+```
+
+### 2. List All Local Branches
+
+```bash
+git branch -vv
+git for-each-ref --sort=-committerdate --format='%(refname:short) %(committerdate:iso8601) %(committerdate:relative)' refs/heads
+```
+
+Capture: branch name, last commit, tracking status (ahead/behind/gone), last commit date.
+
+### 3. List Worktrees
+
+```bash
+git worktree list
+```
+
+### 4. List Open PRs
+
+```bash
+gh pr list --json number,title,headRefName,state,url,isDraft,reviewDecision --limit 50
+```
+
+### 5. Check Merge Status
+
+For each local branch (excluding main), check if merged:
+```bash
+git branch --merged origin/main
+```
+
+### 6. Present Report
+
+Organize branches into categories:
+
+```markdown
+## Branch Status
+
+### Active Worktrees
+| Directory | Branch | Status |
+|-----------|--------|--------|
+| ~/.holophyte-dev/feature-x | feat/feature-x | 2 ahead of main |
+
+### Branches with Open PRs
+| Branch | PR | Status | Review |
+|--------|-----|--------|--------|
+| feat/feature-y | #12 — Add feature Y | Open | Approved |
+| feat/feature-z | #13 — Fix bug Z | Draft | Pending |
+
+### Merged (safe to clean up)
+- `feat/old-feature` — merged into main, remote deleted
+
+### Stale (no PR, not merged)
+- `feat/abandoned` — last commit 3 weeks ago, 5 ahead of main
+
+### Current Branch
+`main` — clean, up to date with origin/main
+```
+
+## Notes
+
+- Always run `git fetch --all --prune` first to get accurate remote status
+- Flag branches where the remote has been deleted (`gone` in tracking status)
+- For branches with PRs, show the review decision (approved, changes requested, pending)
+- Sort stale branches by last commit date
+- This is read-only — never delete branches or worktrees automatically
+- If the user wants to clean up, suggest `/worktree-cleanup` for worktrees (destructive — removes worktrees and deletes branches, requires confirmation)

--- a/.codex/skills/changelog/SKILL.md
+++ b/.codex/skills/changelog/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: changelog
+description: Generate a changelog or update CHANGELOG.md with new commits
+---
+
+# Generate / Update Changelog
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Generate a human-readable changelog from git commits, grouped by date and conventional commit type. Can either display a summary or update `CHANGELOG.md` with new entries.
+
+## Usage
+
+/changelog [range | update]
+
+- No argument: display commits since last tag, or last 20 commits if no tags exist
+- With range argument: use as git log range (e.g., `v1.0..HEAD`, `main..feat/branch`)
+- `update`: update `CHANGELOG.md` with commits since its latest entry
+
+## Mode: Update CHANGELOG.md
+
+When `$ARGUMENTS` is `update` (or contains "update"):
+
+### 1. Find the Latest Entry Date
+
+Read `CHANGELOG.md` and find the most recent `## YYYY-MM-DD` heading. This is the cutoff date.
+
+### 2. Fetch New Commits
+
+```bash
+git log --pretty=format:"%h %ad %s" --date=short --no-merges --after=<day-before-cutoff-date>
+```
+
+If no `CHANGELOG.md` exists or it has no date entries, fetch all commits:
+```bash
+git log --pretty=format:"%h %ad %s" --date=short --no-merges
+```
+
+### 3. Group by Date, Then by Type
+
+Group commits first by date (newest first), then within each date by conventional commit prefix:
+
+- **Added** (`feat:`)
+- **Fixed** (`fix:`)
+- **Changed** (commits without a recognized prefix that describe changes)
+- **Refactored** (`refactor:`)
+- **Tests** (`test:`)
+- **Chores** (`chore:`)
+- **Docs** (`docs:`)
+- **Style** (`style:`)
+
+### 4. Insert into CHANGELOG.md
+
+- If `CHANGELOG.md` doesn't exist, create it with the header:
+  ```markdown
+  # Changelog
+
+  All notable changes to this project will be documented in this file.
+  Grouped by date, following [Keep a Changelog](https://keepachangelog.com/) categories.
+  ```
+- Insert new date sections **after the header** and **before existing entries**
+- If the latest date in new commits matches the latest date already in the file, **merge** the new entries into that existing date section (append to existing categories or add new categories)
+- Skip empty categories — only show categories that have commits
+- Do NOT duplicate entries that already exist in the file (match by commit hash or message)
+
+### 5. Show Summary
+
+After updating, display a brief summary:
+```text
+Updated CHANGELOG.md: added X entries across Y dates
+```
+
+## Mode: Display Only (default)
+
+When no argument or a range argument is provided:
+
+### 1. Determine Range
+
+If `$ARGUMENTS` is provided (and not "update"), use it as the range.
+
+Otherwise, find the latest tag:
+```bash
+git describe --tags --abbrev=0 2>/dev/null
+```
+
+- If a tag exists, use `<tag>..HEAD`
+- If no tags, use `--max-count 20` (no range, safe for repos with fewer than 20 commits)
+
+### 2. Fetch Commits
+
+If a range was determined:
+```bash
+git log <range> --pretty=format:"%h %s" --no-merges
+```
+
+If no tags and no argument (fallback):
+```bash
+git log --max-count 20 --pretty=format:"%h %s" --no-merges
+```
+
+Exclude merge commits to keep the changelog clean.
+
+### 3. Group by Type
+
+Parse conventional commit prefixes and group:
+
+- **Features** (`feat:`)
+- **Bug Fixes** (`fix:`)
+- **Refactoring** (`refactor:`)
+- **Tests** (`test:`)
+- **Chores** (`chore:`)
+- **Documentation** (`docs:`)
+- **Other** (commits without a recognized prefix)
+
+### 4. Format Output
+
+```markdown
+## Changelog
+
+**Range**: `v1.0..HEAD` (12 commits)
+
+### Features
+- Add session resume support (a1b2c3d)
+- Add repo deletion with cascade (d4e5f6a)
+
+### Bug Fixes
+- Fix WebSocket reconnection on timeout (b7c8d9e)
+
+### Refactoring
+- Refactor session manager for multi-session support (f0a1b2c)
+
+### Chores
+- Update dependencies (c3d4e5f)
+```
+
+## Notes
+
+- Strip the prefix from commit messages in the output (e.g., `feat: Add X` becomes `Add X`)
+- Include the short commit hash for reference in display mode; omit hashes in `CHANGELOG.md` (use PR numbers like `(#52)` when present)
+- Skip empty sections — only show categories that have commits
+- If all commits lack prefixes, just list them under **Changed**
+- The update mode is idempotent — running it twice with no new commits makes no changes

--- a/.codex/skills/debugger/SKILL.md
+++ b/.codex/skills/debugger/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: debugger
+description: Systematic root cause investigation — reproduce, investigate, hypothesize, fix
+---
+
+# Debugger
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Systematic root cause investigation. Use instead of guessing at fixes.
+
+## Usage
+
+/debugger <description of the bug or unexpected behavior>
+
+## Process
+
+### 1. Reproduce
+
+Get a consistent reproduction before doing anything else.
+
+- Read error messages **fully** — don't skim
+- Check recent changes: `git log --oneline -10`, `git diff`
+- Identify the exact steps to trigger the bug
+- Confirm: can you reproduce it reliably?
+
+If you can't reproduce, gather more information before proceeding. Ask the user for steps, logs, or screenshots.
+
+### 2. Investigate
+
+Trace data flow **backward** from the failure point.
+
+- Start at the error/symptom and work toward the root cause
+- Find a **working** example of similar functionality and compare — what's different?
+- Check logs: server console, browser console, Convex dashboard
+- Read the relevant code paths in full — don't rely on assumptions
+
+### 3. Hypothesize
+
+Form a **specific** hypothesis about the root cause.
+
+- "The Convex mutation fails because the session doc is missing the `status` field after the schema migration"
+- Not: "Something is wrong with the session"
+
+Test your hypothesis with **minimal, reversible changes**:
+- Add a log statement or console.log — not a fix
+- Check a value at runtime — don't assume
+- Verify the hypothesis is correct before writing any fix
+
+### 4. Fix
+
+Once the root cause is confirmed:
+
+1. **Write a failing test** that captures the bug (when feasible)
+2. **Implement the minimal fix** — don't refactor adjacent code
+3. **Verify the test passes**
+4. **Run the full suite**: `bun run test`, and `bun run test:e2e:isolated` if UI-related
+5. **Verify the original reproduction** no longer triggers the bug
+
+## Checkpoint
+
+If **3+ fix attempts** each reveal new problems, **stop**. The architecture or approach may be wrong. Return to phase 1 with fresh eyes — or escalate to the user.
+
+## Red Flags
+
+Watch for these anti-patterns in yourself:
+- **"Quick fix for now"** — if you're saying this, you haven't found the root cause
+- **Proposing solutions before investigating** — understand first, fix second
+- **"One more try"** after multiple failures — step back and reconsider the approach
+- **Changing code you don't understand** — read it first, understand it, then change it
+
+## Holophyte-Specific Tips
+
+- `bun run --watch` swallows subprocess stderr — use `bun src/server.ts` directly for SDK debugging
+- Check Convex dashboard for function errors (queries, mutations, actions)
+- For real-time data issues, check **both** Convex dashboard logs and browser console
+- For E2E failures, check if `convex:local` is running (conflicts with test ephemeral Convex)
+- For auth issues, verify `ALLOW_PASSWORD_AUTH=1` is set on both the Bun server and Convex — when set, auto-login as `dev@holophyte.test` happens on any page load. Use `?signin` to suppress auto-login and see the sign-in page.
+- SDK sessions: strip `CLAUDECODE` env var from child processes — see `manager.ts`

--- a/.codex/skills/docs/SKILL.md
+++ b/.codex/skills/docs/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: docs
+description: Generate or update Docusaurus documentation
+---
+
+# Docs
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Generate or update Docusaurus documentation for the Holophyte project.
+
+## Usage
+
+```
+/docs                       → Update docs for recently changed files
+/docs architecture          → Generate architecture docs
+/docs components            → Generate component catalog
+/docs hooks                 → Generate hook API reference
+/docs convex                → Generate Convex schema reference
+/docs agents                → Generate agents and skills docs
+/docs --all                 → Generate all documentation
+```
+
+## Process
+
+### 1. Ensure Docusaurus Setup
+
+Check that `docs/` directory exists with Docusaurus config:
+
+```bash
+ls docs/docusaurus.config.ts
+```
+
+If missing, inform the user to run the setup first.
+
+### 2. Determine Scope
+
+Based on `$ARGUMENTS`:
+
+- **No args**: Find recently changed files and update relevant docs:
+  ```bash
+  git diff main...HEAD --name-only
+  ```
+  Map changed files to doc topics (e.g., changed components → update `components.md`).
+- **Specific topic**: Generate that topic's documentation page.
+- **`--all`**: Generate all documentation pages.
+
+### 3. Generate Documentation
+
+Use the `doc-writer` subagent:
+
+> Generate Docusaurus documentation for the `<scope>` topic. Read the relevant source files, write markdown to `docs/docs/`, add TSDoc comments to exported functions/interfaces that lack them, and update `docs/sidebars.ts`. See the agent instructions for conventions and format.
+
+For `--all`, generate each topic in sequence to avoid sidebar conflicts:
+1. `architecture`
+2. `components`
+3. `hooks`
+4. `convex`
+5. `agents-and-skills`
+
+### 4. Verify Build
+
+After documentation is generated:
+
+```bash
+cd docs && bunx docusaurus build
+```
+
+If the build fails, read the error and fix the failing page. Max 2 retries.
+
+### 5. Report
+
+Display:
+- Pages created/updated (with file paths)
+- TSDoc comments added
+- DRY recommendations (repeated Convex hooks to extract)
+- Build verification result (pass/fail)

--- a/.codex/skills/health/SKILL.md
+++ b/.codex/skills/health/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: health
+description: Run full-stack health checks on the project
+---
+
+# Project Health Check
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Run a comprehensive health check across the full stack and report any issues.
+
+## Usage
+
+/health
+
+## Checks
+
+Run all checks and collect results. Do NOT stop on first failure — run everything and present a full report.
+
+### 1. Lint
+
+```bash
+bun run lint
+```
+
+### 2. Type Check
+
+```bash
+bunx tsc --noEmit
+```
+
+### 3. Unit Tests
+
+```bash
+bun run test
+```
+
+### 4. Git Status
+
+```bash
+git status
+```
+
+Report: uncommitted changes, untracked files, and divergence from upstream tracking branch (based on local refs).
+
+### 5. Dependencies
+
+```bash
+bun install --dry-run --frozen-lockfile
+```
+
+Check whether the lockfile would change on install. A non-zero exit indicates a lockfile mismatch — does not verify on-disk `node_modules` state.
+
+### 6. Convex Status
+
+Check if Convex is configured (never print the actual values):
+```bash
+test -f .env.local && grep -q '^CONVEX_DEPLOYMENT=' .env.local
+```
+
+Report whether `CONVEX_DEPLOYMENT` is set or missing — do NOT print its value.
+
+## Report Format
+
+Present results as a checklist:
+
+```
+## Health Report
+
+- [x] Lint — passed
+- [x] Typecheck — passed
+- [ ] Tests — 2 failing (describe briefly)
+- [x] Git — clean, up to date with remote
+- [x] Dependencies — in sync
+- [x] Convex — configured
+```
+
+For any failing check, include a brief summary of what's wrong (first few lines of error output, not the full log).
+
+## Notes
+
+- Run all checks in parallel where possible for speed
+- This is read-only — never fix issues automatically
+- If the user wants to fix issues, suggest the appropriate command (e.g., `bun run lint:fix`, `/test`)

--- a/.codex/skills/holophyte-agent-playbooks/SKILL.md
+++ b/.codex/skills/holophyte-agent-playbooks/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: holophyte-agent-playbooks
+description: Use Holophyte specialist role playbooks adapted from the previous Claude agent setup. Use when Codex needs a focused reviewer, tester, implementer, planner, researcher, documentation, Storybook, accessibility, security, backend, frontend, Convex, or DevOps workflow for this repo.
+---
+
+# Holophyte Agent Playbooks
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Use these references when a task calls for a specialist workflow. They point at the existing `.claude/agents` files without assuming Codex has Claude's custom-agent runtime.
+
+## How to Use
+
+1. Pick the closest reference for the current task.
+2. Read only that `.claude/agents` reference, plus `AGENTS.md`.
+3. Apply the role guidance in the current Codex session or when writing prompts for Codex subagents.
+4. Ignore Claude-specific metadata fields such as `tools` and `model`; they describe the original Claude setup, not Codex capabilities.
+
+## References
+
+- `.claude/agents/researcher.md` - codebase research before implementation.
+- `.claude/agents/planner.md` - implementation planning from research.
+- `.claude/agents/critic.md` - adversarial review of plans or implementations.
+- `.claude/agents/code-reviewer.md` - one-shot branch review.
+- `.claude/agents/reviewer.md` - continuous review during team implementation.
+- `.claude/agents/frontend-implementer.md` - React, hooks, Zustand, Tailwind, and UI work.
+- `.claude/agents/backend-implementer.md` - Bun server routes, Claude Agent SDK, and companion polling.
+- `.claude/agents/convex-implementer.md` - Convex schema, queries, mutations, actions, and HTTP endpoints.
+- `.claude/agents/devops-implementer.md` - scripts, GitHub Actions, deployment, and worktree tooling.
+- `.claude/agents/general-implementer.md` - simple or single-layer implementation tasks.
+- `.claude/agents/test-writer.md` - new unit or E2E tests.
+- `.claude/agents/test-fixer.md` - failing test diagnosis and repair.
+- `.claude/agents/tester.md` - unit-test coverage during team implementation.
+- `.claude/agents/e2e-tester.md` - Playwright E2E coverage for user-facing behavior.
+- `.claude/agents/storybook-writer.md` - Storybook stories for React components.
+- `.claude/agents/doc-writer.md` - Docusaurus documentation and TSDoc.
+- `.claude/agents/documenter.md` - documentation work during team implementation.
+- `.claude/agents/a11y-reviewer.md` - accessibility review.
+- `.claude/agents/security-reviewer.md` - security review.

--- a/.codex/skills/pr/SKILL.md
+++ b/.codex/skills/pr/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: pr
+description: Create GitHub pull request with pre-flight quality checks
+---
+
+# Create GitHub Pull Request
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Create a GitHub pull request with pre-flight quality checks.
+
+## Usage
+
+/pr
+
+## Pre-flight Checks
+
+### 1. Verify Branch
+
+```bash
+git branch --show-current
+```
+
+Ensure not on `main` — warn and stop if so.
+
+### 2. Check for Uncommitted Changes
+
+```bash
+git status
+```
+
+Warn if there are uncommitted changes.
+
+### 3. Run Quality Checks
+
+```bash
+bun run lint
+bunx tsc --noEmit
+```
+
+Both must pass before creating PR.
+
+### 4. Review Changes
+
+```bash
+git diff main...HEAD
+git log main..HEAD --oneline
+```
+
+## PR Creation
+
+### Title Format
+
+Use a conventional commit prefix followed by a concise description. Choose the prefix based on the nature of the changes:
+
+- `feat:` — new functionality
+- `fix:` — bug fix
+- `refactor:` — code restructuring without behavior change
+- `test:` — adding or updating tests
+- `chore:` — tooling, config, dependencies
+- `docs:` — documentation only
+
+Examples:
+- `feat: add session resume support`
+- `fix: WebSocket reconnection on session timeout`
+- `refactor: extract session manager into separate module`
+
+### Description Guidelines
+
+- Summarize changes made in current branch vs main
+- Note any breaking changes or migration steps
+- Do not include a testing plan in the description
+
+### Create PR
+
+```bash
+gh pr create --title "<title>" --body "<description>"
+```
+
+## Post-Creation
+
+Display the PR URL for the user to review.

--- a/.codex/skills/review-pr-comments/SKILL.md
+++ b/.codex/skills/review-pr-comments/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: review-pr-comments
+description: Review and address comments on a GitHub pull request
+---
+
+# Review PR Comments
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Review all unresolved comments on a GitHub pull request, categorize them, and optionally address each one.
+
+## Usage
+
+/review-pr-comments [PR-NUMBER]
+
+- If no PR number provided, auto-detect from current branch
+- Explicit PR number overrides auto-detection
+
+## Process
+
+### 1. Identify PR
+
+If `$ARGUMENTS` is empty, auto-detect:
+```bash
+gh pr list --head $(git branch --show-current) --json number,title --jq '.[0]'
+```
+
+If `$ARGUMENTS` contains a PR number, use that directly.
+
+### 2. Fetch Comments
+
+Fetch review bot comments using the script:
+```bash
+bun run pr-comments -- <PR_NUMBER>
+```
+
+Also fetch general PR conversation comments:
+```bash
+gh api repos/{owner}/{repo}/issues/<PR>/comments
+```
+
+### 3. Filter and Categorize
+
+**Filter out resolved comments** - only process unresolved/pending comments.
+
+Categorize remaining comments into:
+
+**Required Changes**
+- Explicit requests for code changes
+- Bug fixes or correctness issues
+- Security concerns
+
+**Suggestions**
+- Optional improvements
+- Style preferences
+- Alternative approaches
+
+**Questions**
+- Clarification requests
+- Design decisions to discuss
+
+### 4. Present Summary
+
+Display organized summary with:
+- Comment author
+- File/line reference (if applicable)
+- Comment content
+- Category
+
+### 5. Address Comments
+
+After presenting the summary, ask: "Would you like me to address any of these comments?"
+
+For each comment to address:
+1. Read the relevant file
+2. Understand the requested change
+3. Implement the change
+4. Show the diff
+5. Ask for confirmation before moving to next comment
+
+**For comments that won't result in code changes** (intentional design decisions, already handled differently, disagree with the suggestion, etc.), reply to the review thread on GitHub explaining why:
+```bash
+gh api repos/{owner}/{repo}/pulls/<PR>/comments/<COMMENT_ID>/replies -f body="<explanation>"
+```
+This keeps the reviewer thread from being left hanging and documents the reasoning.
+
+### 6. Resolve Conversations
+
+After all comments have been addressed or replied to, resolve the review bot threads on GitHub **before pushing the fix commit** — threads must still be unresolved for the script to find them:
+```bash
+bun run pr-comments -- --resolve <PR_NUMBER>
+```
+
+This calls the GitHub GraphQL `resolveReviewThread` mutation on all unresolved threads from review bots.

--- a/.codex/skills/storybook/SKILL.md
+++ b/.codex/skills/storybook/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: storybook
+description: Generate Storybook stories for components
+---
+
+# Storybook
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Generate Storybook stories for React components in the Holophyte project.
+
+## Usage
+
+```
+/storybook                  → Stories for components changed on current branch
+/storybook TaskCard         → Story for a specific component
+/storybook --all            → Stories for all unstorified components
+```
+
+## Process
+
+### 1. Determine Targets
+
+Based on `$ARGUMENTS`:
+
+- **No args**: Find components changed on current branch:
+  ```bash
+  git diff main...HEAD --name-only --diff-filter=AM | grep '\.tsx$' | grep -v '\.stories\.' | grep -v '\.test\.'
+  ```
+- **`--all`**: Find all `.tsx` components without a corresponding `.stories.tsx`:
+  ```bash
+  # List all component files, exclude those that already have stories
+  ```
+  Use Glob to find `src/frontend/components/**/*.tsx` and filter out files that have a sibling `.stories.tsx`.
+- **Specific component name**: Find the component file by name using Glob.
+
+### 2. Generate Stories
+
+For each target component, use the `storybook-writer` subagent:
+
+> Generate a Storybook story for `<component-path>`. Follow the project's story conventions — see the agent instructions for the exact pattern. If the component should be skipped (Convex-connected wrapper, WebSocket-dependent, etc.), explain why and skip it.
+
+Run subagents in parallel for multiple components (max 4 concurrent).
+
+### 3. Verify Build
+
+After all stories are generated:
+
+```bash
+timeout 60s bun run build-storybook
+```
+
+If the build fails, read the error and fix the failing story. Max 2 retries.
+
+### 4. Report
+
+Display:
+- Stories created (with file paths)
+- Components skipped (with reasons)
+- Build verification result (pass/fail)

--- a/.codex/skills/worktree-cleanup/SKILL.md
+++ b/.codex/skills/worktree-cleanup/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: worktree-cleanup
+description: Clean up git worktree with safety checks
+---
+
+# Clean Up Git Worktree
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Remove a git worktree along with its associated branch and directory.
+
+**Warning**: This is a destructive operation. Always verify before deleting.
+
+## Usage
+
+/worktree-cleanup [worktree-name]
+
+- If no argument provided, list worktrees and ask user to select
+- Requires explicit confirmation before deletion
+
+## Process
+
+### 1. List Available Worktrees
+
+```bash
+git worktree list
+```
+
+Present worktrees to user (excluding main directory).
+
+### 2. Safety Checks
+
+Before deletion, verify:
+
+1. Check for uncommitted changes in worktree
+2. Check PR merge status via GitHub CLI (handles squash merges correctly):
+   ```bash
+   gh pr list --head "feat/<name>" --state merged --json number,title,mergedAt
+   ```
+   - If a merged PR exists → Check for unpushed local commits (see step 3) before declaring safe
+   - If an open PR exists (`--state open`) → **Caution** — PR still open
+   - If a closed (non-merged) PR exists (`--state closed`) → **Caution** — PR was closed without merging; work may be abandoned
+   - If no PR found → Check if branch has a remote (`git branch -vv`) and warn accordingly
+
+3. Check for unpushed local commits (even when PR is merged):
+   ```bash
+   git rev-parse --verify --quiet "origin/<branch>" > /dev/null && \
+     git log "origin/<branch>..HEAD" --oneline
+   ```
+   - If `origin/<branch>` doesn't exist (e.g. auto-deleted after merge) → **Safe to delete**
+   - If commits exist → **Caution** — local commits not included in the merged PR
+   - If no commits and PR is merged → **Safe to delete**
+
+**Why `gh pr list` instead of `git branch --merged`**: This repo uses squash merges, which create a new commit on main. Git doesn't recognize the original branch as merged since the commit SHAs differ. Checking GitHub PR status is the reliable way to detect squash merges.
+
+### 3. Display Merge Status
+
+- **Safe to delete**: PR was merged (squash-merged into main) and no unpushed local commits
+- **Caution**: PR was merged but there are unpushed local commits — work may be lost
+- **Caution**: PR is still open — work may not be reviewed/merged yet
+- **Caution**: PR was closed without merging — work may be abandoned
+- **Caution**: No PR found but remote branch exists — branch was pushed without a PR
+- **Caution**: No PR found and no remote branch — work may not be pushed
+
+### 4. Request Confirmation
+
+Always ask for explicit confirmation before proceeding, especially if warnings are present.
+
+### 5. Remove Worktree and Branch
+
+```bash
+git worktree remove ~/.holophyte-dev/<feature-name>
+git branch -D feat/<feature-name>
+```
+
+### 6. Verify Removal
+
+```bash
+git worktree list
+git branch -a
+```
+
+## Safety Rules
+
+- **Never** delete the main worktree
+- **Always** warn if PR may not be complete (unmerged remote branch)
+- **Always** warn if there are uncommitted changes
+- **Always** warn if there are unpushed local commits (even when PR is merged)
+- **Always** require explicit confirmation

--- a/.codex/skills/worktree/SKILL.md
+++ b/.codex/skills/worktree/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: worktree
+description: Create new git worktree for parallel feature development
+---
+
+# Create New Git Worktree
+
+## Codex Adaptation
+
+Treat slash-command examples as skill names or user intents, not literal Codex command syntax. Treat `$ARGUMENTS` as the user's request text for the skill. Use Codex subagents only when the user explicitly asks for delegation, parallel agents, or team work; otherwise perform the workflow locally and use the playbooks in `holophyte-agent-playbooks` as references.
+
+Set up a new git worktree for working on a feature in parallel.
+
+## Usage
+
+/worktree [feature-name]
+
+- If no argument provided, prompt for feature name
+- Automatically creates branch `feat/<feature-name>`
+
+## When to use
+
+- Features or refactors that touch multiple files
+- Work you want to run in parallel with other sessions
+- NOT needed for quick fixes, small changes, or single-file edits
+
+## Process
+
+### 1. Determine Feature Name
+
+Use `$ARGUMENTS` if provided, otherwise ask the user.
+
+### 2. Create Worktree
+
+Run the worktree creation script:
+
+```bash
+bun run worktree:create <feature-name>
+```
+
+This handles everything: worktree creation, branch setup, dependency installation, port assignment, and local Convex initialization.
+
+### 3. Verify Setup
+
+```bash
+cd ~/.holophyte-dev/<feature-name> && ls -la .env* .dev-ports
+```
+
+## After Creation
+
+- Run `bun run dev:local` in the new worktree (uses isolated local Convex)
+- The main directory remains on its current branch
+- Worktrees are stored in `~/.holophyte-dev/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,206 @@
+# AGENTS.md
+
+The role of this file is to describe common mistakes and confusion points that Codex agents might encounter as they work in this project. If you ever encounter something in the project that surprises you, please alert the developer working with you and indicate that this is the case in this file to help prevent future agents from having the same issue.
+
+## What is Holophyte?
+
+Project management app for running parallel Claude Code sessions. A kanban board UI lets you create tasks with prompts, launch Claude Code sessions via the Agent SDK per task, and stream structured events to the browser via Convex real-time queries.
+
+## Development Principles
+
+- **KISS** — Write simple, readable code over clever solutions. Prefer straightforward implementations that are easy to understand and maintain.
+- **DRY** — Eliminate code duplication through shared utilities and components. Use existing patterns from `src/frontend/lib/`, `src/frontend/hooks/`, and `src/frontend/components/`.
+- **Do what was asked; nothing more, nothing less** — Avoid over-engineering, premature optimization, and unsolicited refactoring.
+- **Challenge proposals, not instructions** — When the developer proposes a technical choice, product decision, or strategic direction (e.g. "Should we use X?", "I'm thinking of doing Y"): don't default to agreement. Identify reasoning flaws, implicit assumptions, and blind spots. If the reasoning is weak, break it down and show why. When the developer is clearly directing execution (e.g. "Add field Z to the schema"), just execute. Contrarianism isn't authenticity — only push back when you have substantive reasoning behind it.
+
+## Commands
+
+```bash
+bun run dev              # Start server with HMR (port 8080)
+bun run dev:all          # App server + cloud Convex dev (port 8080)
+bun run dev:local        # App server + local Convex (reads .dev-ports)
+bun run convex:dev       # Start cloud Convex dev
+bun run convex:local     # Start local Convex backend (reads .dev-ports)
+bun run test             # Run unit tests (vitest)
+bun run test:ui          # Vitest UI dashboard
+bun run test:e2e         # Playwright E2E tests (ephemeral Convex, fully self-contained)
+bun run test:e2e:isolated # E2E in a temp worktree (doesn't touch dev .env.local)
+bun run lint             # Biome check
+bun run lint:fix         # Biome auto-fix
+bun run check            # lint + typecheck + test (all-in-one)
+bun run convex:deploy    # Deploy Convex to production
+bun run worktree:create <name>  # Create worktree with isolated local Convex
+bun run worktree:cleanup <name> # Remove worktree, branch, and directory (--list, --stale)
+bun run pr-comments      # Show unresolved PR review comments (--all, --poll, --resolve)
+```
+
+Single test file: `bunx vitest run src/claude/manager.test.ts`
+
+## Codex Setup
+
+- Repo-level Codex instructions live in `AGENTS.md`; this file is adapted from `CLAUDE.md` and should stay in sync with project conventions.
+- Codex workflow skills adapted from `.claude/skills` live in `.codex/skills/`.
+- Claude custom-agent prompts remain in `.claude/agents/`; the Codex `holophyte-agent-playbooks` skill points to them as role playbooks, not as a separate runtime system.
+- Claude hooks and permission settings in `.claude/settings*.json` do not have direct repo-local Codex equivalents here. Run the relevant checks manually unless a Codex environment or user-level config provides automation.
+
+## Runtime
+
+Use **Bun** for everything — never Node.js, npm, vite, or express. Bun auto-loads `.env` files.
+
+- `Bun.serve()` for HTTP (not express)
+- `Bun.file()` over `node:fs` readFile/writeFile
+- `Bun.$\`cmd\`` over execa
+- `bun install`, `bun run`, `bunx` over npm/yarn/pnpm equivalents
+- HTML imports with `Bun.serve()` for frontend bundling (not vite/webpack)
+
+## Code Style
+
+Enforced by **Biome** — run `bun run lint:fix` before committing. Default exports for React components, named exports elsewhere. Use `import type` for type-only imports (`verbatimModuleSyntax` is on). Combine classNames with `cn()` from `@/frontend/lib/utils`.
+
+## TypeScript
+
+Strict mode with `noUncheckedIndexedAccess: true` — array/object indexing returns `T | undefined`.
+
+## Architecture
+
+```
+src/server.ts              → Bun.serve() with routes (auth proxy, directory picker, config)
+src/claude/manager.ts      → Claude Agent SDK session management (spawn/stop/approve)
+src/server/polling.ts      → Companion polling logic (reads from Convex, processes sessions)
+src/frontend/index.tsx     → React entry, Convex client setup
+src/frontend/App.tsx       → Main layout: Sidebar | KanbanBoard + SessionPanel | TaskDetailPanel
+src/frontend/stores/app.ts → Zustand store (selected repo/task, session state)
+src/frontend/hooks/        → useSession (Convex real-time subscriptions for session events)
+src/frontend/components/   → UI components (Kanban*, Task*, Session*, Sidebar, dialogs)
+src/frontend/components/ui → Radix UI primitives (Button, Dialog, Input, etc.)
+convex/schema.ts           → Data model (14 tables + auth tables)
+convex/*.ts                → Convex queries and mutations
+scripts/                   → Shared shell scripts (convex-local, dev-local, worktree-create, pr-comments)
+.githooks/pre-commit       → Pre-commit hook (codegen + stage + lint + typecheck)
+```
+
+**Data flow for SDK sessions:**
+1. Frontend calls Convex mutation `api.sessions.create` with taskId + prompt + model
+2. Companion process spawns Claude Code via Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`)
+3. SDK events are persisted to Convex `sessionEvents` table via `consumeIterator()` → `bufferEvent()` → Convex mutations
+4. Frontend subscribes to session events via `useSession()` hook using Convex real-time queries
+5. User approvals resolve via Convex mutation `api.pendingApprovals.resolve()` → companion reads and resumes SDK
+
+**Frontend ↔ backend communication:** Frontend communicates with the backend through Convex mutations/queries — no direct fetch() calls to localhost. The companion process polls Convex for work via internal HTTP endpoints. When adding new features that need backend interaction, create a Convex mutation and call it from the frontend with useMutation/useAction. The exception is operations that require local machine access (directory picker, filesystem operations, etc.) — those go through the companion's local API.
+
+**Path aliases:** `@/*` → `./src/*`, `@convex/*` → `./convex/*`
+
+## Convex (Real-time Database)
+
+- Multi-tenant with orgs; repos scoped to `orgId`; tasks/sessions cascade through repo
+- Repo/task/session deletions cascade manually
+- All functions use object-style with `args` (validated with `v` from `convex/values`) and `handler`
+- Timestamps stored as `v.number()` using `Date.now()`
+- Indexes named descriptively: `by_repo_status`, `by_task`, `by_path`
+- Import generated types: `import type { Doc, Id } from "@convex/_generated/dataModel"`
+- Convex URL is served via `/api/config` endpoint because browser bundles can't access env vars
+- **Adding fields to existing tables**: Use `v.optional()` in the schema to avoid blocking deploys, even if the field is logically required. Mark with a `// required` comment to distinguish from truly optional fields. Enforce the requirement in `args` validators and always set the field in mutations. New tables should use required fields since there's no existing data to conflict with.
+  ```typescript
+  // schema.ts
+  orgId: v.optional(v.id('organizations')), // required — added to existing table
+
+  // mutations — args validator enforces the requirement
+  args: { orgId: v.id('organizations') }
+  ```
+- **Schema tightening**: Optionally tighten `v.optional()` → required in a follow-up once all docs have the field. Verify with a one-off query before deploying.
+- **Dev escape hatch**: If a local Convex backend gets into a broken state, you can temporarily remove `schema.ts`, deploy with `--typecheck=disable`, clear data, and restore. Never use this on prod.
+
+**Local-first development:**
+- Development uses local Convex backends — each workspace (main repo + worktrees) gets its own isolated instance
+- Ports and project identity configured in `.dev-ports` (gitignored, per-workspace):
+  ```
+  DEV_PORT=8080
+  CONVEX_CLOUD_PORT=3210
+  CONVEX_SITE_PORT=3211
+  CONVEX_TEAM=ko-vial
+  CONVEX_PROJECT=holophyte
+  ```
+- `CONVEX_TEAM`/`CONVEX_PROJECT` are needed to switch from cloud to local deployment — `convex dev --local` silently connects to cloud if `.env.local` has a `dev:` deployment without these
+- Main repo: dev=8080, convex=3210/3211. Worktrees get auto-assigned ports via `bun run worktree:create`
+- `bun run dev:local` starts app server + local Convex from `.dev-ports`
+- `bun run convex:dev` (cloud) is still available for production deployment workflows
+- `.env.local` is managed by `convex dev` — scripts auto-reconfigure from cloud to local when needed
+- **Deployment isolation**: Each workspace gets a unique `CONVEX_DEPLOYMENT` name. `convex-local.sh` validates that `CONVEX_URL` ports match `.dev-ports` and auto-reconfigures on mismatch
+- See `docs/docs/local-development.md` for the full worktree guide and gotchas
+
+## Frontend Patterns
+
+- **Minimize `useEffect`** — Follow [You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect). Only use `useEffect` for synchronizing with external systems (DOM APIs, timers, keyboard listeners). Do NOT use `useEffect` for:
+  - **Deriving state**: Compute during render or use `useMemo` instead of `setState` inside an effect
+  - **Event responses**: Put logic in the event handler that triggers it, not in an effect that watches for the result
+  - **Resetting state on prop change**: Use the `key` prop to reset component state instead of `useEffect` + `setState`
+  - **Initializing state**: Use `useState(initialValue)` or lazy initializers, not `useEffect(fn, [])`
+  - **Notifying parents**: Call parent callbacks in event handlers, not in effects reacting to state changes
+  - **Data fetching**: Use Convex `useQuery` (already reactive) — never `fetch` inside `useEffect`
+- **React 19** with Convex `useQuery`/`useMutation` for real-time data
+- **Zustand** for UI-only state — persists `selectedRepoId`, `viewMode`, `backlogCollapsed` to localStorage (key: `"holophyte-app"`)
+- **Zustand selectors**: always use inline selectors for minimal re-renders: `useAppStore((s) => s.selectTask)`
+- **Tailwind v4** via CSS-first config in `src/frontend/styles.css` (`@theme inline {}` block) — no `tailwind.config.ts`
+- **Radix UI** (umbrella `radix-ui` package) + class-variance-authority for component variants
+- **Icons**: `lucide-react`
+- **Streamdown** (`streamdown` package) for markdown rendering, **Shiki** for syntax highlighting — messages rendered through AI Elements' `MessageResponse` component
+
+## Testing
+
+**Unit tests (Vitest):**
+- Test globals enabled — no need to import `describe`/`it`/`expect`
+- Default environment: `jsdom` (frontend), `edge-runtime` (convex/)
+- Override per-file with `// @vitest-environment node` at top
+- Convex tests use `convex-test`: `const t = convexTest(schema);`
+- Tests co-located with source: `manager.ts` → `manager.test.ts`
+
+**E2E tests (Playwright):**
+- Tests in `e2e/` directory, pattern `*.spec.ts`
+- `bun run test:e2e` — fully self-contained, spins up an ephemeral Convex backend automatically. Each run gets a fresh database — no cleanup needed
+- Dev Convex (`bun run convex:local`) must NOT be running — use `bun run test:e2e:isolated` to avoid stopping it
+- Use `waitForApp(page)` helper to wait for hydration before assertions
+- **E2E auth**: `AutoTestAuth` auto-signs-in with `dev@holophyte.test` / `password` (same credentials as `seed-dev-user.sh`, shared via `DEV_USER_EMAIL`/`DEV_USER_PASSWORD` in `src/constants.ts`). On fresh DB, falls back to sign-up. Password auth avoids the stale refresh token problem that anonymous auth had — re-authenticating always returns the same user.
+- Runs on CI automatically via `.github/workflows/e2e.yml` using `CONVEX_AGENT_MODE=anonymous` (no secrets needed). `CONVEX_DEPLOY_KEY` must NOT be in the env — it overrides local mode
+- **Manual testing**: when `ALLOW_PASSWORD_AUTH=1` is set, auto-login as `dev@holophyte.test` happens automatically on any page load. Use `?signin` to suppress auto-login and see the sign-in page.
+- See `docs/docs/testing/playwright-manual.md` for the full guide
+
+## Error Handling & Logging
+
+- **Server routes**: catch errors, `console.error` before returning `Response.json({ error: String(err) }, { status: 500 })`.
+- **Convex functions**: throw descriptive `Error` messages — Convex surfaces them to the client. No try/catch around db ops.
+- **Frontend**: Convex mutation errors surface via the error boundary; Bun API errors handled in UI state.
+- **Logging**: `console.error` for server errors. `console.log` only for startup/lifecycle. No logging in Convex functions. In frontend, avoid `console.log` (use React DevTools / Convex dashboard) — `console.error` is fine.
+
+## Git Workflow
+
+- **Features/refactors**: Use worktrees (`/worktree` skill) for parallel development on `feat/<name>` branches
+- **Quick fixes**: Work directly on a branch from main — no worktree needed
+- Worktrees are for multi-file features you want to run in parallel, not for every change
+
+## Commit Guidelines
+
+- Pre-commit hooks run automatically: `convex codegen` → `git add convex/_generated/` → `lint` → `typecheck`
+- Pre-commit hooks are mandatory for AI agents. Never use `--no-verify` or `--no-gpg-sign` to skip hooks.
+- Run `bun run lint:fix` to auto-fix lint issues before committing
+- Use conventional commit prefixes: `feat:`, `fix:`, `refactor:`, `test:`, `chore:`, `docs:`
+- **Commits MUST be atomic** — one logical change per commit. Each commit should be independently understandable and revertable. Examples of good atomic commits: a schema change, then its backend handler, then its frontend component. Bad: bundling a feature + docs update + lint fix into one commit.
+- Commit frequently with descriptive messages — incremental changes over large batches. Don't save all changes for one big commit at the end.
+- Stage specific files rather than `git add .`
+
+## Key Gotchas
+
+- **`convex/_generated/` is committed** — Convex codegen can't run in CI/Vercel, so generated types are checked into git. The pre-commit hook auto-runs codegen and stages the output. If you change `convex/schema.ts` or Convex functions, the hook keeps `_generated/` in sync.
+- Bun.serve() route handlers need explicit `Request` type annotation in strict mode
+- Bun.serve() generic type parameter types the server's context data
+- Biome doesn't understand CSS `theme()` function — use `var()` instead
+- `useSemanticElements` biome rule is set to "warn" (kanban board needs div-based drag-drop)
+- `bunfig.toml` configures `bun-plugin-tailwind` under `[serve.static]`
+- Pre-commit hooks configured via `.githooks/` — `prepare` script in package.json sets `core.hooksPath` on `bun install`
+- `bun run --watch` swallows subprocess stderr — run `bun src/server.ts` directly when debugging SDK session issues
+- **`CONVEX_DEPLOY_KEY` overrides `--dev-deployment local`** — if set in the environment, `convex dev --configure existing --dev-deployment local` silently provisions a cloud deployment instead. E2E scripts unset it before provisioning.
+- **`CONVEX_AGENT_MODE=anonymous`** — undocumented Convex CLI env var that enables anonymous local development without login prompts. Required for CI/non-interactive environments. Beta feature per CLI output.
+- **`convex dev --local` silently connects to cloud** if `.dev-ports` is missing `CONVEX_TEAM`/`CONVEX_PROJECT` — always include both
+- **Stop `convex:local` before running E2E tests** — `bun run test:e2e` spins up its own ephemeral Convex; the CLI refuses to provision if another local backend is active. Alternatively, use `bun run test:e2e:isolated` which runs in a temp worktree and doesn't touch the main repo's `.env.local`
+- **Manual testing requires `ALLOW_PASSWORD_AUTH=1`** on Convex env — `bunx convex env set ALLOW_PASSWORD_AUTH 1` (auto-set by `worktree:create` for new worktrees). When set, auto-login as `dev@holophyte.test` happens on any page load. Use `?signin` to suppress auto-login and see the sign-in page. `ALLOW_ANONYMOUS_AUTH` is still set as a fallback for the MCP server.
+- **`bunx @convex-dev/auth` needs a running backend** — start `convex:local` first, then run auth setup in another terminal
+- See `docs/docs/local-development.md` for the full worktree guide and troubleshooting


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` as the repo-level Codex instruction file adapted from the existing Claude project guidance.
- Add Codex workflow skills under `.codex/skills/` based on the existing `.claude/skills` workflows.
- Add a lightweight `holophyte-agent-playbooks` skill that references the existing `.claude/agents` files as role playbooks instead of duplicating them.

## Validation

- Pre-commit hook passed lint and typecheck.
- Skill frontmatter was checked with Ruby YAML parsing.
- Convex codegen warned that the local backend may not be running and was skipped by the pre-commit hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive suite of Codex skill and playbook docs covering autopilot/autopilot-team, brainstorming, PR creation/review, branch/worktree management and cleanup, changelog generation, Storybook story generation, testing/health checks, debugging, PR comment review, storybook, and related specialist playbooks.
  * Added a top-level agents/playbook document with project guidance: development principles, tooling/conventions, architecture notes, workflows, and key gotchas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->