### PR TITLE
fix: unify dev + E2E Convex Auth setup and fix JWKS env parse

### DIFF
--- a/scripts/e2e-convex.sh
+++ b/scripts/e2e-convex.sh
@@ -16,6 +16,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEV_PORTS="$REPO_ROOT/.dev-ports"
 
+# Resolve real Bun binary (skips node_modules/.bin shim) and export clean PATH
+# shellcheck source=lib/resolve-bun.sh
+source "$SCRIPT_DIR/lib/resolve-bun.sh"
+# shellcheck source=lib/convex-auth-setup.sh
+source "$SCRIPT_DIR/lib/convex-auth-setup.sh"
+
 E2E_PID_FILE="$REPO_ROOT/.e2e-convex.pid"
 E2E_PORTS_FILE="$REPO_ROOT/.e2e-convex-ports"
 ENV_LOCAL="$REPO_ROOT/.env.local"
@@ -156,17 +162,18 @@ start_e2e_convex() {
     sleep 1
   done
 
-  # Set anonymous auth for E2E
-  cd "$REPO_ROOT" && bunx convex env set ALLOW_ANONYMOUS_AUTH 1
-  # Set password auth for E2E (password-auth tests)
-  cd "$REPO_ROOT" && bunx convex env set ALLOW_PASSWORD_AUTH 1
+  # Configure Convex Auth (JWT keys, SITE_URL, feature flags, dev user).
+  # Shared with scripts/worktree-create.sh via scripts/lib/convex-auth-setup.sh.
+  # Derive SITE_URL from the app server port used by Playwright
+  # (DEV_PORT+1, matching resolveE2ePort() in playwright.config.ts).
+  local e2e_port
+  e2e_port=$(( ${DEV_PORT:-8080} + 1 ))
+  cd "$REPO_ROOT"
+  export SITE_URL="http://localhost:$e2e_port"
+  setup_convex_auth
 
-  # Generate and set INTERNAL_API_SECRET for companion ↔ Convex communication
-  E2E_INTERNAL_API_SECRET=$(openssl rand -hex 32)
-  cd "$REPO_ROOT" && bunx convex env set INTERNAL_API_SECRET "$E2E_INTERNAL_API_SECRET"
-
-  # Generate JWT keys for @convex-dev/auth (fresh instances don't have them)
-  cd "$REPO_ROOT" && bunx @convex-dev/auth --skip-git-check --allow-dirty-git-state
+  # Expose the generated secret to Playwright via .e2e-convex-ports
+  local E2E_INTERNAL_API_SECRET="$INTERNAL_API_SECRET"
 
   # Write port config for test-e2e.sh / playwright.config.ts
   cat > "$E2E_PORTS_FILE" <<EOF

--- a/scripts/e2e-convex.sh
+++ b/scripts/e2e-convex.sh
@@ -169,6 +169,10 @@ start_e2e_convex() {
   local e2e_port
   e2e_port=$(( ${DEV_PORT:-8080} + 1 ))
   cd "$REPO_ROOT"
+  # Override CONVEX_URL so seed:dev-user hits the ephemeral backend rather
+  # than the (dummy, high-numbered) CONVEX_CLOUD_PORT from the worktree's
+  # .dev-ports — the latter is never actually listening in isolated mode.
+  export CONVEX_URL="http://127.0.0.1:$cloud_port"
   export SITE_URL="http://localhost:$e2e_port"
   setup_convex_auth
 

--- a/scripts/lib/convex-auth-setup.sh
+++ b/scripts/lib/convex-auth-setup.sh
@@ -93,6 +93,19 @@ console.log(JSON.stringify({ keys: [{ use: "sig", ...pub }] }));
   rm -f "$env_file"
 
   if [ "$SEED_DEV_USER" = "1" ]; then
-    "$BUN_BIN" run seed:dev-user || echo "Warning: Could not seed dev user"
+    # `convex env set` above causes a background `convex dev` wrapper (if any)
+    # to re-push functions, briefly taking the backend offline. Retry the seed
+    # so we tolerate that window without flakiness.
+    local seed_attempt
+    for seed_attempt in 1 2 3 4 5; do
+      if "$BUN_BIN" run seed:dev-user; then
+        break
+      fi
+      if [ "$seed_attempt" = "5" ]; then
+        echo "Warning: Could not seed dev user after $seed_attempt attempts"
+        break
+      fi
+      sleep 1
+    done
   fi
 }

--- a/scripts/lib/convex-auth-setup.sh
+++ b/scripts/lib/convex-auth-setup.sh
@@ -75,28 +75,37 @@ console.log(JSON.stringify({ keys: [{ use: "sig", ...pub }] }));
   priv=$(echo "$jwt_output" | head -1)
   jwks=$(echo "$jwt_output" | tail -1)
 
-  local env_file
+  # Write all env vars to a tempfile so `convex env set --from-file` can apply
+  # them in one round trip. The file holds JWT_PRIVATE_KEY and
+  # INTERNAL_API_SECRET in plaintext, so the subshell wrapper + unconditional
+  # cleanup below guarantees removal even if the caller's `set -e` aborts.
+  local env_file rc=0
   env_file=$(mktemp)
+  (
+    set -e
+    _cas_write_env "$env_file" SITE_URL "$SITE_URL"
+    _cas_write_env "$env_file" ALLOW_ANONYMOUS_AUTH "$ALLOW_ANONYMOUS_AUTH"
+    _cas_write_env "$env_file" ALLOW_PASSWORD_AUTH "$ALLOW_PASSWORD_AUTH"
+    _cas_write_env "$env_file" INTERNAL_API_SECRET "$INTERNAL_API_SECRET"
+    _cas_write_env "$env_file" JWT_PRIVATE_KEY "$priv"
+    _cas_write_env "$env_file" JWKS "$jwks"
 
-  _cas_write_env "$env_file" SITE_URL "$SITE_URL"
-  _cas_write_env "$env_file" ALLOW_ANONYMOUS_AUTH "$ALLOW_ANONYMOUS_AUTH"
-  _cas_write_env "$env_file" ALLOW_PASSWORD_AUTH "$ALLOW_PASSWORD_AUTH"
-  _cas_write_env "$env_file" INTERNAL_API_SECRET "$INTERNAL_API_SECRET"
-  _cas_write_env "$env_file" JWT_PRIVATE_KEY "$priv"
-  _cas_write_env "$env_file" JWKS "$jwks"
+    if [ -n "${AUTH_GITHUB_ID:-}" ] && [ -n "${AUTH_GITHUB_SECRET:-}" ]; then
+      _cas_write_env "$env_file" AUTH_GITHUB_ID "$AUTH_GITHUB_ID"
+      _cas_write_env "$env_file" AUTH_GITHUB_SECRET "$AUTH_GITHUB_SECRET"
+    fi
+    if [ -n "${AUTH_GOOGLE_ID:-}" ] && [ -n "${AUTH_GOOGLE_SECRET:-}" ]; then
+      _cas_write_env "$env_file" AUTH_GOOGLE_ID "$AUTH_GOOGLE_ID"
+      _cas_write_env "$env_file" AUTH_GOOGLE_SECRET "$AUTH_GOOGLE_SECRET"
+    fi
 
-  if [ -n "${AUTH_GITHUB_ID:-}" ] && [ -n "${AUTH_GITHUB_SECRET:-}" ]; then
-    _cas_write_env "$env_file" AUTH_GITHUB_ID "$AUTH_GITHUB_ID"
-    _cas_write_env "$env_file" AUTH_GITHUB_SECRET "$AUTH_GITHUB_SECRET"
-  fi
-  if [ -n "${AUTH_GOOGLE_ID:-}" ] && [ -n "${AUTH_GOOGLE_SECRET:-}" ]; then
-    _cas_write_env "$env_file" AUTH_GOOGLE_ID "$AUTH_GOOGLE_ID"
-    _cas_write_env "$env_file" AUTH_GOOGLE_SECRET "$AUTH_GOOGLE_SECRET"
-  fi
-
-  echo "Setting environment variables on local Convex..."
-  "$BUN_BIN" x convex env set --from-file "$env_file" --force
+    echo "Setting environment variables on local Convex..."
+    "$BUN_BIN" x convex env set --from-file "$env_file" --force
+  ) || rc=$?
   rm -f "$env_file"
+  if [ "$rc" -ne 0 ]; then
+    return "$rc"
+  fi
 
   if [ "$SEED_DEV_USER" = "1" ]; then
     # `convex env set` above causes a background `convex dev` wrapper (if any)

--- a/scripts/lib/convex-auth-setup.sh
+++ b/scripts/lib/convex-auth-setup.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Shared Convex Auth setup — configures JWT keys, SITE_URL, feature flags,
+# and (optionally) seeds the dev user on a running local Convex backend.
+#
+# Sourced by both scripts/worktree-create.sh and scripts/e2e-convex.sh.
+# Keep the two flows in sync by editing THIS file rather than forking
+# auth logic back into the callers.
+#
+# Caller contract:
+#   - Must `cd` into the target worktree/repo (so `convex env` targets
+#     the deployment from its local .env.local).
+#   - Must source scripts/lib/resolve-bun.sh first so BUN_BIN is set.
+#   - Must have a running local Convex backend (provisioned and listening).
+#   - Must export SITE_URL (the app server URL Convex Auth should trust
+#     for OAuth callbacks).
+#
+# Optional env inputs (with defaults):
+#   INTERNAL_API_SECRET       — reused if set; generated otherwise
+#   ALLOW_ANONYMOUS_AUTH=1
+#   ALLOW_PASSWORD_AUTH=1
+#   SEED_DEV_USER=1           — set to 0 to skip
+#   AUTH_GITHUB_ID/SECRET     — forwarded if both set
+#   AUTH_GOOGLE_ID/SECRET     — forwarded if both set
+#
+# Exports on success:
+#   INTERNAL_API_SECRET       — final value (input or generated)
+
+_cas_write_env() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s="%s"\n' "$key" "$value" >> "$file"
+}
+
+setup_convex_auth() {
+  if [ -z "${BUN_BIN:-}" ]; then
+    echo "setup_convex_auth: BUN_BIN must be set (source lib/resolve-bun.sh first)" >&2
+    return 1
+  fi
+  if [ -z "${SITE_URL:-}" ]; then
+    echo "setup_convex_auth: SITE_URL must be exported before calling" >&2
+    return 1
+  fi
+
+  : "${ALLOW_ANONYMOUS_AUTH:=1}"
+  : "${ALLOW_PASSWORD_AUTH:=1}"
+  : "${SEED_DEV_USER:=1}"
+
+  if [ -z "${INTERNAL_API_SECRET:-}" ]; then
+    INTERNAL_API_SECRET=$(openssl rand -hex 32)
+  fi
+  export INTERNAL_API_SECRET
+
+  # Generate JWT keys for Convex Auth (anonymous + OAuth login).
+  # Uses `jose` directly — `bunx @convex-dev/auth` has interactive prompts
+  # (SITE_URL confirm, dirty tree warning) that break in automated scripts.
+  echo "Generating Convex Auth JWT keys..."
+  local jwt_output priv jwks
+  jwt_output=$("$BUN_BIN" --eval '
+import { generateKeyPair, exportPKCS8, exportJWK } from "jose";
+const keys = await generateKeyPair("RS256", { extractable: true });
+const priv = (await exportPKCS8(keys.privateKey)).trimEnd().replaceAll("\n", " ");
+const pub = await exportJWK(keys.publicKey);
+console.log(priv);
+console.log(JSON.stringify({ keys: [{ use: "sig", ...pub }] }));
+')
+  priv=$(echo "$jwt_output" | head -1)
+  jwks=$(echo "$jwt_output" | tail -1)
+
+  local env_file
+  env_file=$(mktemp)
+
+  _cas_write_env "$env_file" SITE_URL "$SITE_URL"
+  _cas_write_env "$env_file" ALLOW_ANONYMOUS_AUTH "$ALLOW_ANONYMOUS_AUTH"
+  _cas_write_env "$env_file" ALLOW_PASSWORD_AUTH "$ALLOW_PASSWORD_AUTH"
+  _cas_write_env "$env_file" INTERNAL_API_SECRET "$INTERNAL_API_SECRET"
+  _cas_write_env "$env_file" JWT_PRIVATE_KEY "$priv"
+  _cas_write_env "$env_file" JWKS "$jwks"
+
+  if [ -n "${AUTH_GITHUB_ID:-}" ] && [ -n "${AUTH_GITHUB_SECRET:-}" ]; then
+    _cas_write_env "$env_file" AUTH_GITHUB_ID "$AUTH_GITHUB_ID"
+    _cas_write_env "$env_file" AUTH_GITHUB_SECRET "$AUTH_GITHUB_SECRET"
+  fi
+  if [ -n "${AUTH_GOOGLE_ID:-}" ] && [ -n "${AUTH_GOOGLE_SECRET:-}" ]; then
+    _cas_write_env "$env_file" AUTH_GOOGLE_ID "$AUTH_GOOGLE_ID"
+    _cas_write_env "$env_file" AUTH_GOOGLE_SECRET "$AUTH_GOOGLE_SECRET"
+  fi
+
+  echo "Setting environment variables on local Convex..."
+  "$BUN_BIN" x convex env set --from-file "$env_file" --force
+  rm -f "$env_file"
+
+  if [ "$SEED_DEV_USER" = "1" ]; then
+    "$BUN_BIN" run seed:dev-user || echo "Warning: Could not seed dev user"
+  fi
+}

--- a/scripts/lib/convex-auth-setup.sh
+++ b/scripts/lib/convex-auth-setup.sh
@@ -29,9 +29,15 @@ _cas_write_env() {
   local file="$1"
   local key="$2"
   local value="$3"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  printf '%s="%s"\n' "$key" "$value" >> "$file"
+  # Single-quote so JSON values (JWKS) survive dotenv parsing — dotenv does
+  # NOT unescape backslash sequences inside double-quoted values, which would
+  # leave `{\"keys\":...}` in place of `{"keys":...}` and break JWT
+  # verification. None of the values we write contain a literal single quote.
+  if [[ "$value" == *"'"* ]]; then
+    echo "_cas_write_env: value for $key contains single quote — unsupported" >&2
+    return 1
+  fi
+  printf "%s='%s'\n" "$key" "$value" >> "$file"
 }
 
 setup_convex_auth() {

--- a/scripts/worktree-cleanup.sh
+++ b/scripts/worktree-cleanup.sh
@@ -85,12 +85,19 @@ echo "Cleaning up '$FEATURE_NAME'..."
 # Run from the main repo root so the shell isn't inside a deleted directory
 cd "$REPO_ROOT"
 
-# Kill any Convex processes running on this worktree's ports
+# Kill any processes running in this worktree (dev server, `bunx convex dev`
+# wrapper, convex backend, etc). Matching by path catches everything whose
+# command line references the worktree, not just the port listener. SIGKILL
+# avoids shutdown sequences that try to re-read package.json after the
+# worktree is removed and spam errors back to the terminal.
+pgrep -f "$WORKTREE_PATH" 2>/dev/null | xargs kill -9 2>/dev/null || true
+
+# Fallback: anything still holding the worktree's Convex ports
 if [ -f "$WORKTREE_PATH/.dev-ports" ]; then
   # shellcheck source=/dev/null
   source "$WORKTREE_PATH/.dev-ports"
   for port in "${CONVEX_CLOUD_PORT:-}" "${CONVEX_SITE_PORT:-}"; do
-    [ -n "$port" ] && lsof -ti "TCP:$port" 2>/dev/null | xargs kill 2>/dev/null || true
+    [ -n "$port" ] && lsof -ti "TCP:$port" 2>/dev/null | xargs kill -9 2>/dev/null || true
   done
 fi
 

--- a/scripts/worktree-cleanup.sh
+++ b/scripts/worktree-cleanup.sh
@@ -90,7 +90,12 @@ cd "$REPO_ROOT"
 # command line references the worktree, not just the port listener. SIGKILL
 # avoids shutdown sequences that try to re-read package.json after the
 # worktree is removed and spam errors back to the terminal.
-pgrep -f "$WORKTREE_PATH" 2>/dev/null | xargs kill -9 2>/dev/null || true
+#
+# Anchor the match with a trailing `/` so sibling worktrees with shared
+# prefixes (e.g. cleaning `foo` doesn't match `foo2`) aren't killed. Escape
+# regex metacharacters in the path so `.holophyte-dev` doesn't match `X`.
+ESCAPED_PATH="${WORKTREE_PATH//./\\.}"
+pgrep -f "${ESCAPED_PATH}/" 2>/dev/null | xargs kill -9 2>/dev/null || true
 
 # Fallback: anything still holding the worktree's Convex ports
 if [ -f "$WORKTREE_PATH/.dev-ports" ]; then

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -25,6 +25,8 @@ BRANCH="feat/$FEATURE_NAME"
 # Resolve real Bun binary (skips node_modules/.bin shim) and export clean PATH
 # shellcheck source=lib/resolve-bun.sh
 source "$(cd "$(dirname "$0")" && pwd)/lib/resolve-bun.sh"
+# shellcheck source=lib/convex-auth-setup.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib/convex-auth-setup.sh"
 
 # Read team/project from main repo's .dev-ports
 MAIN_DEV_PORTS="$REPO_ROOT/.dev-ports"
@@ -71,9 +73,6 @@ cleanup() {
   fi
   if [ -n "${CONVEX_SITE_PORT:-}" ]; then
     lsof -ti "TCP:$CONVEX_SITE_PORT" 2>/dev/null | xargs kill 2>/dev/null || true
-  fi
-  if [ -n "${CONVEX_ENV_FILE:-}" ]; then
-    rm -f "$CONVEX_ENV_FILE"
   fi
   cd "$REPO_ROOT"
   git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || rm -rf "$WORKTREE_PATH"
@@ -176,8 +175,6 @@ if [ -n "$NON_CONVEX_VARS" ]; then
   printf '\n%s\n' "$NON_CONVEX_VARS" >> "$WORKTREE_PATH/.env.local"
 fi
 
-# Auth keys are configured on first `bun run dev:local` (needs a running backend)
-
 # `convex dev --once` exits after deploying, but `convex env set` needs a
 # running backend. Start one in the background, set env vars, then stop it.
 echo "Starting local Convex for environment setup..."
@@ -203,68 +200,23 @@ for i in $(seq 1 30); do
   sleep 1
 done
 
-CONVEX_ENV_FILE=$(mktemp)
-
-write_convex_env() {
-  local key="$1"
-  local value="$2"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  printf '%s="%s"\n' "$key" "$value" >> "$CONVEX_ENV_FILE"
-}
-
-# Override SITE_URL (a Convex Auth env var) to point at the app server port.
+# Generate Convex Auth keys, set env vars, seed dev user.
+# Shared with scripts/e2e-convex.sh via scripts/lib/convex-auth-setup.sh —
+# edit that file if you need to change the auth bootstrap flow.
+cd "$WORKTREE_PATH"
 # The app server proxies /api/auth/* to the Convex site port so OAuth callbacks
 # work through a single origin (matches what's configured in GitHub/Google OAuth apps).
-write_convex_env SITE_URL "http://localhost:$DEV_PORT"
-write_convex_env ALLOW_ANONYMOUS_AUTH 1
-write_convex_env ALLOW_PASSWORD_AUTH 1
+export SITE_URL="http://localhost:$DEV_PORT"
+setup_convex_auth
 
-# Generate and set INTERNAL_API_SECRET for companion ↔ Convex communication
-INTERNAL_API_SECRET=$(openssl rand -hex 32)
-write_convex_env INTERNAL_API_SECRET "$INTERNAL_API_SECRET"
-# Store the secret in .env.local (Bun prioritizes .env.local over .env).
-# convex-local.sh reads from .env.local first to stay in sync with the server.
+# Store the generated INTERNAL_API_SECRET in .env.local (Bun prioritizes
+# .env.local over .env). convex-local.sh reads from .env.local to stay in sync.
 ENV_LOCAL_FILE="$WORKTREE_PATH/.env.local"
 if [ -f "$ENV_LOCAL_FILE" ] && grep -q '^INTERNAL_API_SECRET=' "$ENV_LOCAL_FILE"; then
   sed -i '' "s|^INTERNAL_API_SECRET=.*|INTERNAL_API_SECRET=$INTERNAL_API_SECRET|" "$ENV_LOCAL_FILE"
 else
   echo "INTERNAL_API_SECRET=$INTERNAL_API_SECRET" >> "$ENV_LOCAL_FILE"
 fi
-
-# Generate JWT keys for Convex Auth (anonymous + OAuth login).
-# Uses jose directly instead of `bunx @convex-dev/auth` — that tool has
-# interactive prompts (SITE_URL, dirty tree) that break in automated scripts.
-echo "Generating Convex Auth JWT keys..."
-JWT_OUTPUT=$(cd "$WORKTREE_PATH" && "$BUN_BIN" --eval '
-import { generateKeyPair, exportPKCS8, exportJWK } from "jose";
-const keys = await generateKeyPair("RS256", { extractable: true });
-const priv = (await exportPKCS8(keys.privateKey)).trimEnd().replaceAll("\n", " ");
-const pub = await exportJWK(keys.publicKey);
-console.log(priv);
-console.log(JSON.stringify({ keys: [{ use: "sig", ...pub }] }));
-')
-JWT_PRIVATE_KEY=$(echo "$JWT_OUTPUT" | head -1)
-JWKS=$(echo "$JWT_OUTPUT" | tail -1)
-write_convex_env JWT_PRIVATE_KEY "$JWT_PRIVATE_KEY"
-write_convex_env JWKS "$JWKS"
-
-# Forward OAuth credentials from main repo's .dev-ports (if present)
-if [ -n "${AUTH_GITHUB_ID:-}" ] && [ -n "${AUTH_GITHUB_SECRET:-}" ]; then
-  write_convex_env AUTH_GITHUB_ID "$AUTH_GITHUB_ID"
-  write_convex_env AUTH_GITHUB_SECRET "$AUTH_GITHUB_SECRET"
-fi
-if [ -n "${AUTH_GOOGLE_ID:-}" ] && [ -n "${AUTH_GOOGLE_SECRET:-}" ]; then
-  write_convex_env AUTH_GOOGLE_ID "$AUTH_GOOGLE_ID"
-  write_convex_env AUTH_GOOGLE_SECRET "$AUTH_GOOGLE_SECRET"
-fi
-
-echo "Setting environment variables on local Convex..."
-cd "$WORKTREE_PATH" && "$BUN_BIN" x convex env set --from-file "$CONVEX_ENV_FILE" --force
-rm -f "$CONVEX_ENV_FILE"
-
-# Seed dev user for email+password auth (idempotent)
-cd "$WORKTREE_PATH" && "$BUN_BIN" run seed:dev-user || echo "Warning: Could not seed dev user"
 
 # Stop the background Convex backend (kill process group + port fallback,
 # because `bunx` spawns child processes that outlive the wrapper)


### PR DESCRIPTION
## Summary

- Extracted Convex Auth bootstrap (JWT keys, SITE_URL, ALLOW_*, seed dev user) into `scripts/lib/convex-auth-setup.sh`, shared between `worktree-create.sh` and `e2e-convex.sh` so they stop drifting.
- Fixed a silent JWKS corruption: `_cas_write_env` was double-quoting values and escaping `"` as `\"`, but `dotenv` (used by `convex env set --from-file`) does NOT unescape backslash sequences inside double-quoted values. The JWKS was stored as literal `{\"keys\":...}`, so server-side JWT verification failed and every signed-in user appeared unauthenticated. Switched to single-quoted dotenv lines which are parsed literally.
- Hardened `worktree-cleanup.sh` to SIGKILL processes by worktree path so the `bunx convex dev` wrapper doesn't loop retrying against a deleted directory.
- `e2e-convex.sh` now seeds the dev user against the ephemeral backend by overriding `CONVEX_URL` before calling `setup_convex_auth` (the isolated worktree's `.dev-ports` has dummy ports).

## Why this stays in sync

Both dev and E2E now go through the single `setup_convex_auth` function. If you need to change the bootstrap flow, edit the library — not the callers.

## Test plan

- [x] `bun run test:e2e:isolated` — 73/73 passing
- [ ] Manual: `bun run worktree:create <name>` → cd in → `bun run dev:local` → sign in as dev@holophyte.test
- [x] CI E2E workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development script organization and reliability by consolidating authentication setup logic into reusable shared helpers.
  * Enhanced process cleanup handling to ensure proper termination of background services during development and testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->