### PR TITLE
Light theme: cream-anchored counterpart to Kolada + dark/light rename

### DIFF
--- a/e2e/session-panel.spec.ts
+++ b/e2e/session-panel.spec.ts
@@ -145,7 +145,7 @@ test.describe('Session Panel', () => {
 });
 
 test.describe('Session Panel - Theme Rendering', () => {
-  const themes = ['kolada', 'dune'];
+  const themes = ['dark', 'light'];
 
   test.beforeEach(async ({ page }, testInfo) => {
     await waitForApp(page);

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <script>
       // Apply theme before CSS loads to prevent FOUC.
       // Theme list must match VALID_THEMES in src/frontend/stores/app.ts
-      try{var v=['kolada','dune'];var s=JSON.parse(localStorage.getItem('holophyte-app')||'{}');var t=s.state&&s.state.theme;document.documentElement.setAttribute('data-theme',v.indexOf(t)>-1?t:'kolada')}catch(e){document.documentElement.setAttribute('data-theme','kolada')}
+      try{var v=['dark','light'];var m={kolada:'dark',dune:'light'};var s=JSON.parse(localStorage.getItem('holophyte-app')||'{}');var t=s.state&&s.state.theme;t=m[t]||t;document.documentElement.setAttribute('data-theme',v.indexOf(t)>-1?t:'dark')}catch(e){document.documentElement.setAttribute('data-theme','dark')}
     </script>
     <link rel="stylesheet" href="../src/frontend/styles.css" />
     <script>

--- a/src/frontend/components/OrgSwitcher.tsx
+++ b/src/frontend/components/OrgSwitcher.tsx
@@ -32,7 +32,7 @@ export default function OrgSwitcher() {
       <PopoverTrigger asChild>
         <Button
           variant="ghost"
-          className="w-full justify-start gap-2 text-sm has-[>svg]:px-4 whitespace-nowrap overflow-hidden"
+          className="w-full justify-start gap-2 rounded-none text-sm has-[>svg]:px-4 whitespace-nowrap overflow-hidden"
           aria-label={
             selectedOrg
               ? `Current organization: ${selectedOrg.name}`

--- a/src/frontend/components/ThemeSwitcher.tsx
+++ b/src/frontend/components/ThemeSwitcher.tsx
@@ -28,10 +28,10 @@ const THEMES: ThemeOption[] = [
   {
     name: 'dune',
     label: 'Dune',
-    bg: '#f0e4cc',
-    surface: '#faf4e4',
-    primary: '#0f508c',
-    accent: '#d48830',
+    bg: '#f4eee3',
+    surface: '#fbf7ee',
+    primary: '#c4408a',
+    accent: '#2b8fb3',
   },
 ];
 

--- a/src/frontend/components/ThemeSwitcher.tsx
+++ b/src/frontend/components/ThemeSwitcher.tsx
@@ -18,16 +18,16 @@ interface ThemeOption {
  *  styles.css. Update these when theme palettes change. */
 const THEMES: ThemeOption[] = [
   {
-    name: 'kolada',
-    label: 'Kolada',
+    name: 'dark',
+    label: 'Dark',
     bg: '#0f0e11',
     surface: '#15141b',
     primary: '#ffa5e9',
     accent: '#5ddbff',
   },
   {
-    name: 'dune',
-    label: 'Dune',
+    name: 'light',
+    label: 'Light',
     bg: '#f4eee3',
     surface: '#fbf7ee',
     primary: '#c4408a',

--- a/src/frontend/components/UserMenu.tsx
+++ b/src/frontend/components/UserMenu.tsx
@@ -20,7 +20,7 @@ export default function UserMenu() {
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors whitespace-nowrap overflow-hidden hover:bg-muted/50"
+          className="flex w-full cursor-pointer items-center gap-2 px-4 py-1.5 text-sm transition-colors whitespace-nowrap overflow-hidden hover:bg-accent hover:text-accent-foreground"
           aria-label={user?.name ? `User menu for ${user.name}` : 'User menu'}
         >
           <Avatar

--- a/src/frontend/components/ai-elements/message.tsx
+++ b/src/frontend/components/ai-elements/message.tsx
@@ -55,7 +55,7 @@ export const MessageContent = ({
   <div
     className={cn(
       'is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-hidden text-sm',
-      'group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground',
+      'group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-secondary-foreground',
       'group-[.is-assistant]:text-foreground',
       className,
     )}

--- a/src/frontend/stores/app.test.ts
+++ b/src/frontend/stores/app.test.ts
@@ -182,9 +182,11 @@ describe('persist', () => {
     expect(
       useAppStore.getState().collapsedColumns.has(TaskStatus.Backlog),
     ).toBe(true);
+    expect(useAppStore.getState().theme).toBe('dark');
 
     const stored = JSON.parse(localStorage.getItem('holophyte-app') ?? '{}');
     expect(stored.version).toBe(7);
+    expect(stored.state.theme).toBe('dark');
     expect(stored.state.backlogCollapsed).toBeUndefined();
     expect(stored.state.collapsedColumns).toEqual({
       __type: 'Set',

--- a/src/frontend/stores/app.test.ts
+++ b/src/frontend/stores/app.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
     searchQuery: '',
     filterLabelIds: [],
     showArchive: false,
-    theme: 'kolada',
+    theme: 'dark',
     lastUsedRepoId: null,
     sidebarCollapsed: false,
     bulkSelectedTaskIds: [],
@@ -184,7 +184,7 @@ describe('persist', () => {
     ).toBe(true);
 
     const stored = JSON.parse(localStorage.getItem('holophyte-app') ?? '{}');
-    expect(stored.version).toBe(6);
+    expect(stored.version).toBe(7);
     expect(stored.state.backlogCollapsed).toBeUndefined();
     expect(stored.state.collapsedColumns).toEqual({
       __type: 'Set',
@@ -213,18 +213,45 @@ describe('persist', () => {
 
     await useAppStore.persist.rehydrate();
 
-    expect(useAppStore.getState().theme).toBe('kolada');
+    expect(useAppStore.getState().theme).toBe('dark');
     expect(useAppStore.getState().collapsedColumns).toEqual(
       new Set([TaskStatus.Backlog, TaskStatus.Done]),
     );
 
     const stored = JSON.parse(localStorage.getItem('holophyte-app') ?? '{}');
-    expect(stored.version).toBe(6);
-    expect(stored.state.theme).toBe('kolada');
+    expect(stored.version).toBe(7);
+    expect(stored.state.theme).toBe('dark');
     expect(stored.state.collapsedColumns).toEqual({
       __type: 'Set',
       values: [TaskStatus.Backlog, TaskStatus.Done],
     });
+  });
+
+  it.each([
+    ['kolada', 'dark'],
+    ['dune', 'light'],
+  ])('migrates legacy theme %s → %s', async (legacy, expected) => {
+    localStorage.setItem(
+      'holophyte-app',
+      JSON.stringify({
+        state: {
+          collapsedColumns: { __type: 'Set', values: [TaskStatus.Backlog] },
+          taskPageDetailCollapsed: false,
+          sidebarCollapsed: false,
+          showArchive: false,
+          lastUsedRepoId: null,
+          theme: legacy,
+        },
+        version: 6,
+      }),
+    );
+
+    await useAppStore.persist.rehydrate();
+
+    expect(useAppStore.getState().theme).toBe(expected);
+    const stored = JSON.parse(localStorage.getItem('holophyte-app') ?? '{}');
+    expect(stored.version).toBe(7);
+    expect(stored.state.theme).toBe(expected);
   });
 });
 

--- a/src/frontend/stores/app.ts
+++ b/src/frontend/stores/app.ts
@@ -3,15 +3,15 @@ import { TaskStatus } from '@convex/schema';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
-export type ThemeName = 'kolada' | 'dune';
+export type ThemeName = 'dark' | 'light';
 
-export const VALID_THEMES: ThemeName[] = ['kolada', 'dune'];
+export const VALID_THEMES: ThemeName[] = ['dark', 'light'];
 
 export const LIGHT_THEMES: ReadonlySet<ThemeName> = new Set<ThemeName>([
-  'dune',
+  'light',
 ]);
 
-export const DEFAULT_THEME: ThemeName = 'kolada';
+export const DEFAULT_THEME: ThemeName = 'dark';
 
 const DEFAULT_COLLAPSED_COLUMNS = new Set<string>([TaskStatus.Backlog]);
 
@@ -196,9 +196,12 @@ export const useAppStore = create<AppState>()(
     {
       name: 'holophyte-app',
       storage,
-      version: 6,
+      version: 7,
       migrate: (persisted) => {
         const state = persisted as Record<string, unknown>;
+        // v7: rename themes "kolada" → "dark", "dune" → "light"
+        if (state.theme === 'kolada') state.theme = 'dark';
+        else if (state.theme === 'dune') state.theme = 'light';
         const collapsedColumns = new Set<string>();
         if (state.collapsedColumns instanceof Set) {
           for (const value of state.collapsedColumns) {

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -60,8 +60,8 @@
   --color-attention: var(--attention);
   --color-violet: var(--violet);
   --color-highlight: var(--highlight);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: max(0px, calc(var(--radius) - 4px));
+  --radius-md: max(0px, calc(var(--radius) - 2px));
   --radius-lg: var(--radius);
 }
 

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -100,8 +100,8 @@
   --primary: oklch(0.8316 0.1352 336.17); /* #ffa5e9 */
   --primary-foreground: oklch(0.1663 0.0064 300.87);
 
-  /* Secondary: violet — calmer alt to primary pink (surface + accent dual use). */
-  --secondary: oklch(0.7187 0.1663 296.28); /* #af8bff */
+  /* Secondary: lilac — calmer alt to primary pink (surface + accent dual use). */
+  --secondary: oklch(0.62 0.14 296); /* ~#9378d9 */
   --secondary-foreground: oklch(0.1663 0.0064 300.87);
 
   /* Muted surface: line-highlight / hover fills */
@@ -124,7 +124,7 @@
   --info: oklch(0.8346 0.121 219.92); /* #5ddbff cyan — links, in-progress */
   --success: oklch(0.9027 0.153 167.27); /* #61ffca mint — completed */
   --attention: oklch(0.832 0.1356 71.04); /* #ffb85c orange — warnings */
-  --violet: oklch(0.7187 0.1663 296.28); /* #af8bff — calmer alt accent */
+  --violet: oklch(0.62 0.14 296); /* ~#9378d9 — calmer alt accent */
   --highlight: oklch(0.9837 0.0267 95.33); /* #fffae6 cream — rare sparkle */
 
   /* Danger */
@@ -140,59 +140,68 @@
   --radius: 0.5rem;
 }
 
-/* ━━━ Dune ━━━ Sun-baked sand + ocean blue ━━━
+/* ━━━ Dune ━━━ Warm cream + pink/mint/cyan/orange/violet accents ━━━
 
-   Placeholder values for the new custom vars (sidebar,
-   border-subtle, subtle-foreground, info, success,
-   attention, highlight) are set so components don't break
-   at runtime. Real Dune-palette equivalents are a separate
-   follow-up task (Dune contrast fix). */
+   Light-mode counterpart to Kolada. Same hue families and semantic
+   lanes, inverted lightness. Anchored on a cream background (#F4EEE3)
+   that's easy on the eyes. Pink primary stays rare/loud; the other
+   four accents each own their own semantic lane. Borders are a
+   signature warm sand — structural, not derived from background. */
 
 [data-theme="dune"] {
   color-scheme: light;
 
-  --background: oklch(0.92 0.03 80);
-  --foreground: oklch(0.22 0.025 70);
+  /* Base surfaces — warm cream hierarchy */
+  --background: oklch(0.9425 0.0149 83); /* #F4EEE3 */
+  --foreground: oklch(0.22 0.02 300);
 
-  /* Surfaces: lighter warm sand */
-  --card: oklch(0.97 0.02 82);
+  --sidebar: oklch(0.915 0.0185 80); /* slightly deeper cream */
+
+  --card: oklch(0.97 0.012 85); /* lifted ~3% above background */
   --card-foreground: var(--foreground);
-  --popover: oklch(0.97 0.02 82);
+  --popover: oklch(0.97 0.012 85);
   --popover-foreground: var(--foreground);
 
-  --sidebar: oklch(
-    0.89 0.035 80
-  ); /* TODO(dune): placeholder, refine in Dune contrast pass */
+  /* Primary: pink — rare & loud (active tabs, selected card, CTA, badges) */
+  --primary: oklch(0.58 0.19 340);
+  --primary-foreground: oklch(0.98 0.005 85);
 
-  /* Primary: deep ocean blue — complementary to warm sand */
-  --primary: oklch(0.42 0.14 250);
-  --primary-foreground: oklch(0.97 0.01 250);
-
-  /* Subtle surfaces — darker sand with ochre warmth */
-  --secondary: oklch(from var(--background) calc(l - 0.04) 0.035 78);
+  /* Secondary: pastel lilac — same hue family as Kolada, carries dark text on cream. */
+  --secondary: oklch(0.82 0.071 298); /* ~#c9bbec */
   --secondary-foreground: var(--foreground);
-  --muted: oklch(from var(--background) calc(l - 0.04) 0.035 78);
-  --muted-foreground: oklch(0.48 0.03 70);
-  --subtle-foreground: oklch(0.6 0.025 70); /* TODO(dune): placeholder */
-  --accent: oklch(from var(--background) calc(l - 0.035) 0.04 75);
+
+  /* Muted surface: line-highlight / hover fills */
+  --muted: oklch(0.895 0.017 80);
+  --muted-foreground: oklch(0.42 0.02 300);
+  /* Subtle foreground — for disabled / placeholder / decorative only.
+     Contrast against bg is intentionally below WCAG AA; do NOT use on
+     body text. Use --muted-foreground for readable secondary text. */
+  --subtle-foreground: oklch(0.68 0.015 80);
+
+  /* Accent surface (shadcn surface semantic — NOT the cyan lane).
+     Used by hover and selected states throughout the UI; must read
+     clearly raised above sidebar/background. The cyan / mint / orange
+     / violet semantic lanes live in --info / --success / --attention
+     / --violet below. */
+  --accent: oklch(0.88 0.02 80);
   --accent-foreground: var(--foreground);
 
-  /* Semantic accents — placeholders, refine in Dune contrast pass */
-  --info: oklch(0.55 0.15 230); /* TODO(dune): placeholder */
-  --success: oklch(0.6 0.15 155); /* TODO(dune): placeholder */
-  --attention: oklch(0.7 0.15 65); /* TODO(dune): placeholder */
-  --violet: oklch(0.55 0.18 295); /* TODO(dune): placeholder */
-  --highlight: oklch(0.95 0.05 95); /* TODO(dune): placeholder */
+  /* Semantic accents — each with a clear lane */
+  --info: oklch(0.55 0.16 220); /* cyan — links, in-progress */
+  --success: oklch(0.5 0.14 165); /* green — completed */
+  --attention: oklch(0.65 0.17 55); /* orange — warnings */
+  --violet: oklch(0.82 0.071 298); /* ~#c9bbec — calmer alt accent */
+  --highlight: oklch(0.92 0.09 95); /* cream-yellow — rare sparkle */
 
   /* Danger */
-  --destructive: oklch(0.52 0.2 25);
-  --destructive-foreground: oklch(0.985 0.01 60);
+  --destructive: oklch(0.55 0.2 25);
+  --destructive-foreground: oklch(0.98 0.005 85);
 
-  /* Chrome — warm sandy borders */
-  --border: oklch(from var(--background) calc(l - 0.1) 0.03 78);
-  --border-subtle: oklch(from var(--background) calc(l - 0.05) 0.025 78);
-  --input: oklch(from var(--background) calc(l - 0.1) 0.03 78);
-  --ring: oklch(from var(--primary) l c h / 0.35);
+  /* Chrome — signature warm sand borders */
+  --border: oklch(0.82 0.025 78);
+  --border-subtle: oklch(0.88 0.017 80);
+  --input: oklch(0.82 0.025 78);
+  --ring: oklch(0.58 0.19 340); /* primary pink */
 
   --radius: 0.5rem;
 }

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -138,7 +138,7 @@
   --input: oklch(0.3048 0.0523 297.49);
   --ring: oklch(0.8316 0.1352 336.17); /* primary pink */
 
-  --radius: 0.5rem;
+  --radius: 0;
 }
 
 /* ━━━ Light ━━━ Warm cream + pink/mint/cyan/orange/violet accents ━━━
@@ -204,7 +204,7 @@
   --input: oklch(0.82 0.025 78);
   --ring: oklch(0.58 0.19 340); /* primary pink */
 
-  --radius: 0.5rem;
+  --radius: 0;
 }
 
 /* ─── Global Resets ─── */

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -48,7 +48,7 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
-  /* Custom tokens from the Kolada spec. Reserved for follow-up passes
+  /* Custom tokens from the Dark palette spec. Reserved for follow-up passes
      (semantic badges, card gradients, sidebar chrome) — some are unused
      at first wire-up but are declared here so Tailwind generates
      `bg-info`, `text-success`, etc. classes for direct use. */
@@ -68,13 +68,14 @@
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    THEMES — oklch
 
-   Two themes: Kolada (dark, default) and Dune (light).
-   Core palette uses explicit oklch pinned per-value.
-   CSS Relative Colors (oklch(from var(--x) ...)) are
-   reserved for state variants (hover / selected lifts).
+   Two themes: Dark (default, Kolada palette) and Light
+   (cream palette, light-mode counterpart). Core palette
+   uses explicit oklch pinned per-value. CSS Relative Colors
+   (oklch(from var(--x) ...)) are reserved for state
+   variants (hover / selected lifts).
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
-/* ━━━ Kolada ━━━ Warm plum + pink/mint/cyan/orange/violet accents ━━━
+/* ━━━ Dark ━━━ Warm plum + pink/mint/cyan/orange/violet accents ━━━
 
    Palette source: Ko's customized VSCode Kolada theme.
    Pink primary is reserved for rare, loud UI state (active,
@@ -82,7 +83,7 @@
    lanes (success / info / attention / secondary). Borders are
    a signature plum — structural, not derived from background. */
 
-[data-theme="kolada"] {
+[data-theme="dark"] {
   color-scheme: dark;
 
   /* Base surfaces — warm dark plum hierarchy */
@@ -140,15 +141,15 @@
   --radius: 0.5rem;
 }
 
-/* ━━━ Dune ━━━ Warm cream + pink/mint/cyan/orange/violet accents ━━━
+/* ━━━ Light ━━━ Warm cream + pink/mint/cyan/orange/violet accents ━━━
 
-   Light-mode counterpart to Kolada. Same hue families and semantic
+   Light-mode counterpart to Dark. Same hue families and semantic
    lanes, inverted lightness. Anchored on a cream background (#F4EEE3)
    that's easy on the eyes. Pink primary stays rare/loud; the other
    four accents each own their own semantic lane. Borders are a
    signature warm sand — structural, not derived from background. */
 
-[data-theme="dune"] {
+[data-theme="light"] {
   color-scheme: light;
 
   /* Base surfaces — warm cream hierarchy */
@@ -166,7 +167,7 @@
   --primary: oklch(0.58 0.19 340);
   --primary-foreground: oklch(0.98 0.005 85);
 
-  /* Secondary: pastel lilac — same hue family as Kolada, carries dark text on cream. */
+  /* Secondary: pastel lilac — same hue family as Dark, carries dark text on cream. */
   --secondary: oklch(0.82 0.071 298); /* ~#c9bbec */
   --secondary-foreground: var(--foreground);
 


### PR DESCRIPTION
## Summary
- Rewrite Dune as a true light-mode counterpart to Kolada, anchored on warm cream (`#F4EEE3`). Same semantic lanes (primary pink, secondary lilac, info/success/attention/violet/highlight), inverted lightness. Every TODO lane from the Kolada pass now has a real value.
- Rename themes `kolada` → `dark`, `dune` → `light`. Bumps Zustand persist version 6→7 with a migration so existing users keep their preference. FOUC bootstrap in `public/index.html` handles legacy values too.
- Fix user message bubble contrast: was hardcoded `text-foreground` on `bg-secondary`, now `text-secondary-foreground` (root cause, affected both themes).
- Align sidebar `OrgSwitcher` + `UserMenu` hover rows with the ghost-variant nav rows — same hover bg, no rounded corners.
- Drop global border radius to `0` across both themes.

## Test plan
- [x] `bun run lint` + `bun run typecheck` on each commit
- [x] Existing `stores/app.test.ts` migration tests updated (adds `kolada→dark` / `dune→light` parameterized case)
- [x] Manual walk in both themes: kanban, task detail, session panel (streaming + code blocks), sidebar active states, toasts (success/error/info/warning)
- [x] Toggle dark ↔ light to verify the transition stays smooth
- [x] `e2e/session-panel.spec.ts` updated to use new theme names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Renamed theme system from kolada/dune to dark/light for improved clarity
* Updated button styling and interactions across interface components
* Refined message text appearance for better contrast
* Refreshed theme color palette and design tokens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->