### PR TITLE
chore(deps): add codex-app-server-client

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "codex-app-server-client": "^0.1.5",
         "convex": "^1.35.1",
         "lucide-react": "^1.8.0",
         "motion": "^12.38.0",
@@ -822,6 +823,8 @@
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
+
+    "codex-app-server-client": ["codex-app-server-client@0.1.5", "", {}, "sha512-pAc8NLzPuHMRRCZGnBKue7oqCBBkel6cCL6jmUM+9t3n8sCrYevYX5mN6oKgKJPoEaPZ+9Pyai6Eokd+D5VpmA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "codex-app-server-client": "^0.1.5",
     "convex": "^1.35.1",
     "lucide-react": "^1.8.0",
     "motion": "^12.38.0",


### PR DESCRIPTION
## Summary

Phase 0 Task 1 — Bun compat spike for `codex-app-server-client`. Adds the package so Task 2 can build on it.

**Bun + `codex-app-server-client@0.1.5` works.** The throwaway spike (`scripts/codex-spike.ts`, not committed) verified: `createClient()` spawns `codex app-server` under Bun, `thread.start()` returns a thread, `turn.start` + `client.onEvent(...)` streams lifecycle notifications to `turn/completed`, `client.close()` exits cleanly. The spike also answered the single open question from the spec (`turn.interrupt` event-flush behaviour): interrupt acks in ~30 ms but the terminal `turn/completed` still arrives ~1 s later, so Task 3's `stopSession` needs a ~500 ms grace sleep between `turn.interrupt` and `client.close()`.

Three library-shape corrections surfaced by the spike — all propagated into `wiki/core/codex-integration-spec.md` § Task 1, § Task 3, and the "Also resolved 2026-04-17" section:

1. Thread id lives at `response.thread.id`, not `response.threadId`.
2. `TurnInterruptParams` requires both `threadId` and `turnId`.
3. `turn.run` is a composite helper that blocks until completion and hides the turn id; interruptible paths must use `client.turn.start(...)` + `client.onEvent(...)` directly.

No production source changes in this PR — just `package.json` + `bun.lock`.

## Test plan

- [x] `bun run scripts/codex-spike.ts` runs to `turn/completed` without throwing
- [x] Interrupt probe confirms post-interrupt `turn/completed` arrives ~1 s after ack
- [x] `bunx tsc --noEmit` clean
- [x] Pre-commit hooks (lint + typecheck) pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to include a new server client library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->