### PR TITLE
feat(codex): Task 2 — provider discriminator + constants substrate

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -196,6 +196,11 @@ export default defineSchema({
     lastActivityAt: v.optional(v.number()),
     name: v.optional(v.string()),
     sdkSessionId: v.optional(v.string()),
+    // Forward-going provider session identifier. Mirrors `sdkSessionId` on every
+    // write; reads should prefer `providerSessionId ?? sdkSessionId`.
+    providerSessionId: v.optional(v.string()),
+    // missing = 'claude' for pre-Phase-0 docs
+    provider: v.optional(v.union(v.literal('claude'), v.literal('codex'))),
     model: v.optional(v.string()),
     permissionMode: v.optional(v.string()),
     // Stored when status='queued' so the companion can pick it up
@@ -224,7 +229,24 @@ export default defineSchema({
     text: v.string(),
     consumed: v.boolean(),
     createdAt: v.number(),
+    // Per-turn reasoning effort captured at send time; the companion reads this
+    // when dispatching the follow-up turn.
+    reasoningEffort: v.optional(v.string()),
   }).index('by_session_pending', ['sessionId', 'consumed']),
+
+  // Cache of the live Codex `model/list` RPC response, replaced on every
+  // companion startup. Single-row table — no per-org variance. Populated by
+  // Task 2b; Task 2 only registers the shape.
+  codexModels: defineTable({
+    models: v.array(
+      v.object({
+        id: v.string(),
+        label: v.string(),
+        description: v.string(),
+      }),
+    ),
+    fetchedAt: v.number(),
+  }),
 
   pendingApprovals: defineTable({
     sessionId: v.id('sessions'),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -199,7 +199,7 @@ export default defineSchema({
     // Forward-going provider session identifier. Mirrors `sdkSessionId` on every
     // write; reads should prefer `providerSessionId ?? sdkSessionId`.
     providerSessionId: v.optional(v.string()),
-    // missing = 'claude' for pre-Phase-0 docs
+    // required; missing = 'claude' for pre-Phase-0 docs
     provider: v.optional(v.union(v.literal('claude'), v.literal('codex'))),
     model: v.optional(v.string()),
     permissionMode: v.optional(v.string()),

--- a/convex/sessionMessages.test.ts
+++ b/convex/sessionMessages.test.ts
@@ -28,7 +28,10 @@ async function setupSessionEnv(t: ReturnType<typeof convexTest>) {
     repoId,
     title: 'Test Task',
   });
-  const sessionId = await authed.mutation(api.sessions.create, { taskId });
+  const sessionId = await authed.mutation(api.sessions.create, {
+    taskId,
+    provider: 'claude',
+  });
   return { userId, authed, orgId, repoId, taskId, sessionId };
 }
 

--- a/convex/sessions.test.ts
+++ b/convex/sessions.test.ts
@@ -37,7 +37,10 @@ describe('sessions.create', () => {
     const { authed, taskId } = await setupTaskEnv(t);
 
     const before = Date.now();
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     const after = Date.now();
 
     const session = await authed.query(api.sessions.get, { id: sessionId });
@@ -66,7 +69,10 @@ describe('sessions.create', () => {
     });
 
     await expect(
-      viewerAuthed.mutation(api.sessions.create, { taskId }),
+      viewerAuthed.mutation(api.sessions.create, {
+        taskId,
+        provider: 'claude',
+      }),
     ).rejects.toThrow();
   });
 });
@@ -84,10 +90,16 @@ describe('sessions.getByTask', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const _firstId = await authed.mutation(api.sessions.create, { taskId });
+    const _firstId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     // Small delay to ensure different timestamps
     await new Promise((r) => setTimeout(r, 5));
-    const secondId = await authed.mutation(api.sessions.create, { taskId });
+    const secondId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
 
     const result = await authed.query(api.sessions.getByTask, { taskId });
     // Should return the most recently active (second created)
@@ -100,11 +112,20 @@ describe('sessions.listByTask', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const firstId = await authed.mutation(api.sessions.create, { taskId });
+    const firstId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await new Promise((r) => setTimeout(r, 5));
-    const secondId = await authed.mutation(api.sessions.create, { taskId });
+    const secondId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await new Promise((r) => setTimeout(r, 5));
-    const thirdId = await authed.mutation(api.sessions.create, { taskId });
+    const thirdId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
 
     const sessions = await authed.query(api.sessions.listByTask, { taskId });
     expect(sessions).toHaveLength(3);
@@ -132,8 +153,11 @@ describe('sessions.listByTask', () => {
       title: 'Other Task',
     });
 
-    await authed.mutation(api.sessions.create, { taskId });
-    await authed.mutation(api.sessions.create, { taskId: otherTaskId });
+    await authed.mutation(api.sessions.create, { taskId, provider: 'claude' });
+    await authed.mutation(api.sessions.create, {
+      taskId: otherTaskId,
+      provider: 'claude',
+    });
 
     const sessions = await authed.query(api.sessions.listByTask, { taskId });
     expect(sessions).toHaveLength(1);
@@ -146,8 +170,14 @@ describe('sessions.listActive', () => {
     const t = convexTest(schema);
     const { authed, orgId, taskId } = await setupTaskEnv(t);
 
-    const runningId = await authed.mutation(api.sessions.create, { taskId });
-    const idleId = await authed.mutation(api.sessions.create, { taskId });
+    const runningId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
+    const idleId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
 
     // create() now sets 'queued' — transition first session to 'running'
     // and second to 'idle' to test the listActive filter.
@@ -167,7 +197,10 @@ describe('sessions.updateStatus (client-side)', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
 
     await authed.mutation(api.sessions.updateStatus, {
       id: sessionId,
@@ -182,7 +215,10 @@ describe('sessions.updateStatus (client-side)', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
 
     await authed.mutation(api.sessions.updateStatus, {
       id: sessionId,
@@ -199,7 +235,10 @@ describe('sessions.updateLastActivity', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     const session = await authed.query(api.sessions.get, { id: sessionId });
     const originalActivity = session?.lastActivityAt;
 
@@ -221,7 +260,10 @@ describe('sessions.requestStop', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'running' });
     });
@@ -236,7 +278,10 @@ describe('sessions.requestStop', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     // create() already sets 'queued', no patch needed
 
     await authed.mutation(api.sessions.requestStop, { id: sessionId });
@@ -249,7 +294,10 @@ describe('sessions.requestStop', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'idle' });
     });
@@ -264,7 +312,10 @@ describe('sessions.requestStop', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'stopped' });
     });
@@ -279,7 +330,10 @@ describe('sessions.requestStop', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'failed' });
     });
@@ -296,6 +350,7 @@ describe('sessions.requestStop', () => {
 
     const sessionId = await ownerAuthed.mutation(api.sessions.create, {
       taskId,
+      provider: 'claude',
     });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'running' });
@@ -323,7 +378,10 @@ describe('sessions.queueResume', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'idle' });
     });
@@ -343,7 +401,10 @@ describe('sessions.queueResume', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'running' });
     });
@@ -364,6 +425,7 @@ describe('sessions.queueResume', () => {
 
     const sessionId = await ownerAuthed.mutation(api.sessions.create, {
       taskId,
+      provider: 'claude',
     });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'idle' });
@@ -394,7 +456,10 @@ describe('sessions.listQueued', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     // create() sets status to 'queued' — no patch needed
 
     const queued = await t.query(internal.sessions.listQueued, {});
@@ -407,7 +472,10 @@ describe('sessions.listQueued', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'running' });
     });
@@ -420,7 +488,10 @@ describe('sessions.listQueued', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
 
     // Delete the task to orphan the session
     await t.run(async (ctx) => {
@@ -438,7 +509,10 @@ describe('sessions.claimQueued', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
 
     const result = await t.mutation(internal.sessions.claimQueued, {
       id: sessionId,
@@ -453,7 +527,10 @@ describe('sessions.claimQueued', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'running' });
     });
@@ -469,7 +546,10 @@ describe('sessions.claimQueued', () => {
     const { authed, taskId } = await setupTaskEnv(t);
 
     // Create a session just to get a valid-format ID, then delete it
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.delete(sessionId);
     });
@@ -486,8 +566,14 @@ describe('sessions.listStopped', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const stoppedId = await authed.mutation(api.sessions.create, { taskId });
-    const runningId = await authed.mutation(api.sessions.create, { taskId });
+    const stoppedId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
+    const runningId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(stoppedId, { status: 'stopped' });
       await ctx.db.patch(runningId, { status: 'running' });
@@ -684,7 +770,10 @@ describe('sessions.companionListQueued', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
 
     const queued = await authed.query(api.sessions.companionListQueued, {});
     expect(queued).toHaveLength(1);
@@ -705,7 +794,7 @@ describe('sessions.companionListQueued', () => {
     const { authed, taskId } = await setupTaskEnv(t);
 
     // Create a session in the owner's org
-    await authed.mutation(api.sessions.create, { taskId });
+    await authed.mutation(api.sessions.create, { taskId, provider: 'claude' });
 
     // Create a second user with their own org
     const { authed: otherAuthed } = await setupUser(t, 'Other User');
@@ -722,7 +811,10 @@ describe('sessions.companionListQueued', () => {
       repoId: otherRepoId,
       title: 'Other Task',
     });
-    await otherAuthed.mutation(api.sessions.create, { taskId: otherTaskId });
+    await otherAuthed.mutation(api.sessions.create, {
+      taskId: otherTaskId,
+      provider: 'claude',
+    });
 
     // Other user should only see their own org's sessions
     const queued = await otherAuthed.query(
@@ -739,7 +831,10 @@ describe('sessions.companionListStopped', () => {
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'stopped' });
     });
@@ -762,7 +857,10 @@ describe('sessions.companionListStopped', () => {
     const { authed, taskId } = await setupTaskEnv(t);
 
     // Create a stopped session in owner's org
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'stopped' });
     });
@@ -878,7 +976,10 @@ describe('sessions.listActive — org isolation', () => {
     const { authed, orgId, taskId } = await setupTaskEnv(t);
 
     // Create a running session in org 1
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'running' });
     });
@@ -900,6 +1001,7 @@ describe('sessions.listActive — org isolation', () => {
     });
     const otherSessionId = await otherAuthed.mutation(api.sessions.create, {
       taskId: otherTaskId,
+      provider: 'claude',
     });
     await t.run(async (ctx) => {
       await ctx.db.patch(otherSessionId, { status: 'running' });
@@ -925,7 +1027,10 @@ describe('sessions.companionMarkStaleRunning — org isolation', () => {
     const { authed, taskId } = await setupTaskEnv(t);
 
     // Create running session in org 1
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'running' });
     });
@@ -947,6 +1052,7 @@ describe('sessions.companionMarkStaleRunning — org isolation', () => {
     });
     const otherSessionId = await otherAuthed.mutation(api.sessions.create, {
       taskId: otherTaskId,
+      provider: 'claude',
     });
     await t.run(async (ctx) => {
       await ctx.db.patch(otherSessionId, { status: 'running' });
@@ -973,7 +1079,10 @@ describe('sessions.companionMarkStoppedAsIdle — org isolation', () => {
     const { authed, taskId } = await setupTaskEnv(t);
 
     // Create stopped session in org 1
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'stopped' });
     });
@@ -995,6 +1104,7 @@ describe('sessions.companionMarkStoppedAsIdle — org isolation', () => {
     });
     const otherSessionId = await otherAuthed.mutation(api.sessions.create, {
       taskId: otherTaskId,
+      provider: 'claude',
     });
     await t.run(async (ctx) => {
       await ctx.db.patch(otherSessionId, { status: 'stopped' });
@@ -1021,7 +1131,7 @@ describe('sessions.companionListQueued — org isolation', () => {
     const { authed, taskId } = await setupTaskEnv(t);
 
     // Create a queued session in org 1
-    await authed.mutation(api.sessions.create, { taskId });
+    await authed.mutation(api.sessions.create, { taskId, provider: 'claude' });
 
     // Create a second user with their own org and a queued session
     const { authed: otherAuthed } = await setupUser(t, 'Other User');
@@ -1038,7 +1148,10 @@ describe('sessions.companionListQueued — org isolation', () => {
       repoId: otherRepoId,
       title: 'Other Task',
     });
-    await otherAuthed.mutation(api.sessions.create, { taskId: otherTaskId });
+    await otherAuthed.mutation(api.sessions.create, {
+      taskId: otherTaskId,
+      provider: 'claude',
+    });
 
     // Each user should only see their own org's queued sessions
     const myQueued = await authed.query(api.sessions.companionListQueued, {});
@@ -1058,7 +1171,10 @@ describe('sessions.companionListStopped — org isolation', () => {
     const { authed, taskId } = await setupTaskEnv(t);
 
     // Create a stopped session in org 1
-    const sessionId = await authed.mutation(api.sessions.create, { taskId });
+    const sessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
     await t.run(async (ctx) => {
       await ctx.db.patch(sessionId, { status: 'stopped' });
     });
@@ -1080,6 +1196,7 @@ describe('sessions.companionListStopped — org isolation', () => {
     });
     const otherSessionId = await otherAuthed.mutation(api.sessions.create, {
       taskId: otherTaskId,
+      provider: 'claude',
     });
     await t.run(async (ctx) => {
       await ctx.db.patch(otherSessionId, { status: 'stopped' });

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -135,6 +135,11 @@ export const create = mutation({
     prompt: v.optional(v.string()),
     model: v.optional(v.string()),
     permissionMode: v.optional(v.string()),
+    // Per-turn effort accepted at the boundary for forward compatibility; not
+    // persisted in Task 2 (see spec § Task 6 — no `sessions.reasoningEffort`
+    // column). Task 6 wires first-turn effort through its own channel.
+    reasoningEffort: v.optional(v.string()),
+    provider: v.union(v.literal('claude'), v.literal('codex')),
   },
   handler: async (ctx, args) => {
     const task = await ctx.db.get(args.taskId);
@@ -153,6 +158,7 @@ export const create = mutation({
       queuedPrompt: args.prompt,
       model: args.model,
       permissionMode: args.permissionMode,
+      provider: args.provider,
     });
   },
 });
@@ -337,6 +343,35 @@ export const updateSdkSessionId = internalMutation({
     if (!session) throw new Error('Session not found');
     const updates: Record<string, unknown> = {
       sdkSessionId: args.sdkSessionId,
+      providerSessionId: args.sdkSessionId,
+    };
+    if (args.model !== undefined) updates.model = args.model;
+    if (args.permissionMode !== undefined)
+      updates.permissionMode = args.permissionMode;
+    await ctx.db.patch(args.id, updates);
+  },
+});
+
+/**
+ * Forward-going entry point for Codex (and future providers) to persist the
+ * provider-owned session identifier. Writes both `providerSessionId` and
+ * `sdkSessionId` so reads via either name resolve during Phase 0.
+ *
+ * Internal — callers on the server trust this value.
+ */
+export const updateProviderSessionId = internalMutation({
+  args: {
+    id: v.id('sessions'),
+    providerSessionId: v.string(),
+    model: v.optional(v.string()),
+    permissionMode: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const session = await ctx.db.get(args.id);
+    if (!session) throw new Error('Session not found');
+    const updates: Record<string, unknown> = {
+      sdkSessionId: args.providerSessionId,
+      providerSessionId: args.providerSessionId,
     };
     if (args.model !== undefined) updates.model = args.model;
     if (args.permissionMode !== undefined)
@@ -834,6 +869,31 @@ export const companionUpdateSdkSessionId = mutation({
     if (!isLocalDevMode()) await requireSessionOwnership(ctx, args.id);
     await ctx.db.patch(args.id, {
       sdkSessionId: args.sdkSessionId,
+      providerSessionId: args.sdkSessionId,
+      ...(args.model !== undefined && { model: args.model }),
+      ...(args.permissionMode !== undefined && {
+        permissionMode: args.permissionMode,
+      }),
+    });
+  },
+});
+
+/**
+ * Forward-going companion equivalent of {@link updateProviderSessionId}.
+ * Writes both columns so readers on either name resolve during Phase 0.
+ */
+export const companionUpdateProviderSessionId = mutation({
+  args: {
+    id: v.id('sessions'),
+    providerSessionId: v.string(),
+    model: v.optional(v.string()),
+    permissionMode: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    if (!isLocalDevMode()) await requireSessionOwnership(ctx, args.id);
+    await ctx.db.patch(args.id, {
+      sdkSessionId: args.providerSessionId,
+      providerSessionId: args.providerSessionId,
       ...(args.model !== undefined && { model: args.model }),
       ...(args.permissionMode !== undefined && {
         permissionMode: args.permissionMode,

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -142,6 +142,13 @@ export const create = mutation({
     provider: v.union(v.literal('claude'), v.literal('codex')),
   },
   handler: async (ctx, args) => {
+    // Validator accepts 'codex' so the API shape is stable for Tasks 3–9, but
+    // the companion has no Codex dispatcher yet (lands in Task 4). Reject at
+    // the boundary until then so a queued Codex session can't be claimed by
+    // the Claude runner.
+    if (args.provider === 'codex') {
+      throw new Error('Codex provider not yet supported');
+    }
     const task = await ctx.db.get(args.taskId);
     if (!task) throw new Error('Task not found');
     const repo = await ctx.db.get(task.repoId);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,74 @@
 export const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
 
 /**
+ * UI-only default provider. Consumed by `useLaunchDefaults` as the fallback
+ * when localStorage is empty (first launch, cleared storage). Has NO effect on
+ * the backend: `sessions.create` requires `provider` explicitly.
+ */
+export const DEFAULT_PROVIDER: 'claude' | 'codex' = 'codex';
+
+/** Default Codex model — fallback when provider is 'codex' and no model is specified. */
+export const DEFAULT_CODEX_MODEL = 'gpt-5.4-mini';
+
+/** Fallback Codex model list if the live `model/list` RPC fails. Seven models matching the current `codex` CLI `/model` picker. */
+export const CODEX_MODELS_FALLBACK = [
+  {
+    id: 'gpt-5.4',
+    label: 'GPT-5.4',
+    description: 'Latest frontier agentic coding model',
+  },
+  {
+    id: 'gpt-5.2-codex',
+    label: 'GPT-5.2 Codex',
+    description: 'Frontier agentic coding model',
+  },
+  {
+    id: 'gpt-5.1-codex-max',
+    label: 'GPT-5.1 Codex Max',
+    description: 'Codex-optimized flagship for deep and fast reasoning',
+  },
+  {
+    id: 'gpt-5.4-mini',
+    label: 'GPT-5.4 Mini',
+    description: 'Smaller frontier agentic coding model',
+  },
+  {
+    id: 'gpt-5.3-codex',
+    label: 'GPT-5.3 Codex',
+    description: 'Frontier Codex-optimized agentic coding model',
+  },
+  {
+    id: 'gpt-5.2',
+    label: 'GPT-5.2',
+    description: 'Optimized for long-running agent work',
+  },
+  {
+    id: 'gpt-5.1-codex-mini',
+    label: 'GPT-5.1 Codex Mini',
+    description: 'Optimized for Codex. Cheaper, faster, less capable',
+  },
+] as const;
+
+export const CODEX_EFFORTS = ['minimal', 'low', 'medium', 'high'] as const;
+
+/**
+ * Claude effort picker values. `'auto'` = omit `effort` / `effortLevel`, let
+ * adaptive thinking drive (matches Claude Code CLI `/effort auto`). `'max'`
+ * omitted — start-only per SDK `Settings.effortLevel`. `'xhigh'` (Opus 4.7)
+ * not yet in `@anthropic-ai/claude-agent-sdk@0.2.112`; add when the SDK
+ * exposes it.
+ */
+export const CLAUDE_EFFORTS = ['auto', 'low', 'medium', 'high'] as const;
+
+export const DEFAULT_CODEX_EFFORT: (typeof CODEX_EFFORTS)[number] = 'medium';
+export const DEFAULT_CLAUDE_EFFORT: (typeof CLAUDE_EFFORTS)[number] = 'auto';
+
+/** localStorage keys for last-used-defaults persistence. */
+export const STORAGE_LAST_PROVIDER = 'holophyte.lastProvider';
+export const STORAGE_LAST_MODEL_PREFIX = 'holophyte.lastModel.'; // e.g. `holophyte.lastModel.codex`
+export const STORAGE_LAST_EFFORT_PREFIX = 'holophyte.lastEffort.'; // e.g. `holophyte.lastEffort.codex`
+
+/**
  * How long a session may remain in `queued` status before the Convex cron
  * reaps it as `failed`. 10 minutes gives ample time for the companion to come
  * online, but prevents orphaned sessions from accumulating indefinitely.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
  * when localStorage is empty (first launch, cleared storage). Has NO effect on
  * the backend: `sessions.create` requires `provider` explicitly.
  */
-export const DEFAULT_PROVIDER: 'claude' | 'codex' = 'codex';
+export const DEFAULT_PROVIDER: 'claude' | 'codex' = 'claude';
 
 /** Default Codex model — fallback when provider is 'codex' and no model is specified. */
 export const DEFAULT_CODEX_MODEL = 'gpt-5.4-mini';

--- a/src/frontend/components/ClaudeButton.tsx
+++ b/src/frontend/components/ClaudeButton.tsx
@@ -59,6 +59,7 @@ export function ClaudeButton({ task }: ClaudeButtonProps) {
           taskId: task._id,
           prompt: task.prompt,
           model,
+          provider: 'claude',
         });
         openSession(sessionId);
         if (!isOnThisTaskPage) {

--- a/src/frontend/components/SessionPanel.tsx
+++ b/src/frontend/components/SessionPanel.tsx
@@ -129,6 +129,7 @@ export default function SessionPanel({ taskId }: SessionPanelProps) {
       taskId,
       prompt: text,
       model,
+      provider: 'claude',
     });
     openSession(newSessionId);
   };

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -657,6 +657,7 @@ server.tool(
       taskId: taskId as Id<'tasks'>,
       prompt: effectivePrompt,
       model,
+      provider: 'claude',
     });
 
     return textResponse(


### PR DESCRIPTION
## Summary

Task 2 of the Codex integration ([spec](../blob/main/../../../holophyte-thoughts/wiki/core/codex-integration-spec.md)). Lays the data/constants substrate for Phase 0 so Tasks 3–9 can land without schema churn.

- **Schema**: adds `provider` + `providerSessionId` to `sessions`, `reasoningEffort` to `sessionMessages`, registers empty `codexModels` table
- **`sessions.create`**: requires `provider: 'claude' | 'codex'` at the validator boundary; rejects `'codex'` at runtime until Task 4 wires the companion dispatcher (per Codex adversarial-review feedback)
- **Writers mirror both session-id columns** so `providerSessionId ?? sdkSessionId` fallback resolves on pre-Phase-0 docs
- **Constants**: provider/model/effort defaults, fallback Codex model list, storage keys
- **Callers** pass `provider: 'claude'` until Task 6 (UI picker) and Task 9 (MCP tool arg) land

No new runtime behavior ships — existing Claude sessions flow through the same code paths.

## Test plan

- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx vitest run convex/sessions.test.ts convex/sessionMessages.test.ts` — 60/60 pass
- [ ] Manual: launch Claude session via UI, confirm `sessions` row carries both `sdkSessionId` and `providerSessionId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple AI providers (Claude and Codex)
  * Introduced reasoning effort configuration options per provider
  * Implemented persistent user preferences for last-used provider, model, and effort settings
  * Added model discovery and caching to display available options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->