### PR TITLE
fix: include updatedInput on canUseTool allow responses

### DIFF
--- a/src/claude/manager.test.ts
+++ b/src/claude/manager.test.ts
@@ -17,6 +17,8 @@ vi.mock('@/server/convex-client', () => ({
 }));
 
 import { query as mockSdkQuery } from '@anthropic-ai/claude-agent-sdk';
+import { api } from '@convex/_generated/api';
+import { getFunctionName } from 'convex/server';
 
 afterEach(async () => {
   const { getActiveSessions, stopSession } = await import('./manager');
@@ -635,21 +637,25 @@ describe('claude/manager (SDK-based)', () => {
         } as never;
       });
 
-      // The poll loop reads resolved approvals from Convex. Return one that matches.
-      mockQuery.mockImplementation(
-        (_path: unknown, args: Record<string, unknown>) => {
-          if (args && 'sessionId' in args) {
-            return Promise.resolve([
-              {
-                _id: 'approved-id',
-                requestId: 'approval-shape-1',
-                approved: true,
-              },
-            ]);
-          }
-          return Promise.resolve(null);
-        },
+      // The poll loop reads resolved approvals from Convex. Match only the
+      // approvals query — other queries (e.g. companionGetNextBatchIndex) fall
+      // through to the default. Convex FunctionReferences are proxies, so
+      // compare by stable name, not reference.
+      const approvalsQuery = getFunctionName(
+        api.pendingApprovals.companionListResolvedUnconsumed,
       );
+      mockQuery.mockImplementation((path: unknown) => {
+        if (path && getFunctionName(path as never) === approvalsQuery) {
+          return Promise.resolve([
+            {
+              _id: 'approved-id',
+              requestId: 'approval-shape-1',
+              approved: true,
+            },
+          ]);
+        }
+        return Promise.resolve(null);
+      });
 
       const { startSession } = await import('./manager');
       await startSession({

--- a/src/claude/manager.test.ts
+++ b/src/claude/manager.test.ts
@@ -272,7 +272,12 @@ describe('claude/manager (SDK-based)', () => {
     tool: string,
     input: Record<string, unknown>,
     opts: { toolUseID: string; signal: AbortSignal },
-  ) => Promise<{ behavior: string; toolUseID?: string; message?: string }>;
+  ) => Promise<{
+    behavior: string;
+    toolUseID?: string;
+    message?: string;
+    updatedInput?: Record<string, unknown>;
+  }>;
 
   /** Start a session and capture the canUseTool callback from the SDK options. */
   async function captureCanUseTool(
@@ -579,6 +584,86 @@ describe('claude/manager (SDK-based)', () => {
           (c) => (c[1] as Record<string, unknown>).requestId === 'e1',
         ),
       ).toBe(true);
+    });
+  });
+
+  describe('canUseTool: allow-return shape (SDK Zod schema)', () => {
+    // The @anthropic-ai/claude-agent-sdk Zod schema requires `updatedInput` on
+    // every `{ behavior: 'allow' }` response. Missing it throws ZodError and
+    // breaks tools like AskUserQuestion. See GH issue #206.
+
+    it('auto-approve (safe-auto) returns updatedInput matching input', async () => {
+      const { canUseTool } = await captureCanUseTool('safe-auto');
+      const input = { pattern: 'foo', path: '/tmp' };
+      const result = await canUseTool('Grep', input, {
+        toolUseID: 'safe-shape-1',
+        signal: sig(),
+      });
+      expect(result.behavior).toBe('allow');
+      expect(result.updatedInput).toEqual(input);
+    });
+
+    it('auto-approve (bypass) returns updatedInput matching input', async () => {
+      const { canUseTool } = await captureCanUseTool('bypass');
+      const input = { file_path: '/tmp/x', content: 'hi' };
+      const result = await canUseTool('Write', input, {
+        toolUseID: 'bypass-shape-1',
+        signal: sig(),
+      });
+      expect(result.behavior).toBe('allow');
+      expect(result.updatedInput).toEqual(input);
+    });
+
+    it('user-approved tool (default) returns updatedInput matching input', async () => {
+      const input = { question: 'Keep going?' };
+      let pendingResult: Awaited<ReturnType<CanUseTool>> | undefined;
+
+      vi.mocked(mockSdkQuery).mockImplementation((params: unknown) => {
+        const { options } = params as {
+          options: { canUseTool: CanUseTool };
+        };
+        return {
+          // biome-ignore lint/correctness/useYield: blocking mock — parks via await without yielding events
+          async *[Symbol.asyncIterator]() {
+            pendingResult = await options.canUseTool('AskUserQuestion', input, {
+              toolUseID: 'approval-shape-1',
+              signal: new AbortController().signal,
+            });
+          },
+          streamInput: vi.fn().mockResolvedValue(undefined),
+          supportedCommands: vi.fn().mockResolvedValue([]),
+        } as never;
+      });
+
+      // The poll loop reads resolved approvals from Convex. Return one that matches.
+      mockQuery.mockImplementation(
+        (_path: unknown, args: Record<string, unknown>) => {
+          if (args && 'sessionId' in args) {
+            return Promise.resolve([
+              {
+                _id: 'approved-id',
+                requestId: 'approval-shape-1',
+                approved: true,
+              },
+            ]);
+          }
+          return Promise.resolve(null);
+        },
+      );
+
+      const { startSession } = await import('./manager');
+      await startSession({
+        sessionId: 'approval-shape-test',
+        repoPath: '/tmp',
+        prompt: 'test',
+        permissionMode: 'default',
+      });
+
+      // Wait for the poll interval (500ms) to tick at least once
+      await new Promise((r) => setTimeout(r, 800));
+
+      expect(pendingResult?.behavior).toBe('allow');
+      expect(pendingResult?.updatedInput).toEqual(input);
     });
   });
 

--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -363,7 +363,11 @@ export async function startSession(opts: {
     abortController: controller,
     canUseTool: async (toolName, input, toolOpts) => {
       if (shouldAutoApprove(session, toolName, input)) {
-        return { behavior: 'allow' as const, toolUseID: toolOpts.toolUseID };
+        return {
+          behavior: 'allow' as const,
+          updatedInput: input as Record<string, unknown>,
+          toolUseID: toolOpts.toolUseID,
+        };
       }
 
       const requestId = toolOpts.toolUseID;
@@ -416,7 +420,11 @@ export async function startSession(opts: {
                 console.error('Failed to mark approval consumed:', err);
               }
               if (match.approved) {
-                resolve({ behavior: 'allow', toolUseID: toolOpts.toolUseID });
+                resolve({
+                  behavior: 'allow',
+                  updatedInput: input as Record<string, unknown>,
+                  toolUseID: toolOpts.toolUseID,
+                });
               } else {
                 resolve({
                   behavior: 'deny',


### PR DESCRIPTION
## Summary

The `@anthropic-ai/claude-agent-sdk` Zod schema requires `updatedInput` on every `{ behavior: 'allow' }` permission result. Both allow-paths in `canUseTool` (the `shouldAutoApprove` fast path and the user-approved resolve) were omitting it, causing ZodError crashes for tools like `AskUserQuestion`.

- Pass the original `input` through unchanged as `updatedInput` on both allow paths.
- Add unit coverage asserting the Zod-compliant shape for auto-approve (safe-auto + bypass modes) and the post-approval resolve path.

Closes #206

## Test plan

- [x] `bun run check` passes (lint + typecheck + 620 unit tests).
- [ ] Launch an SDK session, ask Claude a question via `AskUserQuestion`, approve — verify no ZodError in companion stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool approval responses now include the original input data, ensuring complete information is available during tool execution.

* **Tests**
  * Added test coverage for tool approval response handling in multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->