### PR TITLE
feat(codex): Task 2b — companion probes live Codex model list

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as apiKeys from "../apiKeys.js";
 import type * as auth from "../auth.js";
+import type * as codexModels from "../codexModels.js";
 import type * as companion from "../companion.js";
 import type * as crons from "../crons.js";
 import type * as http from "../http.js";
@@ -40,6 +41,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   apiKeys: typeof apiKeys;
   auth: typeof auth;
+  codexModels: typeof codexModels;
   companion: typeof companion;
   crons: typeof crons;
   http: typeof http;

--- a/convex/codexModels.test.ts
+++ b/convex/codexModels.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment edge-runtime
+import { convexTest } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+import { api } from './_generated/api';
+import schema from './schema';
+
+async function setupUser(t: ReturnType<typeof convexTest>) {
+  const userId = await t.run(async (ctx) => {
+    return await ctx.db.insert('users', { name: 'Companion User' });
+  });
+  return t.withIdentity({ subject: `${userId}|s1` });
+}
+
+const sampleA = [
+  { id: 'gpt-5.4', label: 'GPT-5.4', description: 'Frontier' },
+  {
+    id: 'gpt-5.4-mini',
+    label: 'GPT-5.4 Mini',
+    description: 'Smaller frontier',
+  },
+];
+const sampleB = [
+  {
+    id: 'gpt-5.3-codex',
+    label: 'GPT-5.3 Codex',
+    description: 'Codex-optimized',
+  },
+];
+
+describe('codexModels.get', () => {
+  it('returns null when no probe has run', async () => {
+    const t = convexTest(schema);
+    const authed = await setupUser(t);
+    const result = await authed.query(api.codexModels.get, {});
+    expect(result).toBeNull();
+  });
+
+  it('throws when called unauthenticated', async () => {
+    const t = convexTest(schema);
+    await expect(t.query(api.codexModels.get, {})).rejects.toThrow(
+      'Not authenticated',
+    );
+  });
+});
+
+describe('codexModels.replace', () => {
+  it('inserts on first call and get() returns the models', async () => {
+    const t = convexTest(schema);
+    const authed = await setupUser(t);
+
+    const before = Date.now();
+    await authed.mutation(api.codexModels.replace, { models: sampleA });
+    const row = await authed.query(api.codexModels.get, {});
+
+    expect(row).not.toBeNull();
+    expect(row?.models).toEqual(sampleA);
+    expect(row?.fetchedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('patches the existing row in place — never appends', async () => {
+    const t = convexTest(schema);
+    const authed = await setupUser(t);
+
+    await authed.mutation(api.codexModels.replace, { models: sampleA });
+    await authed.mutation(api.codexModels.replace, { models: sampleB });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query('codexModels').collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.models).toEqual(sampleB);
+  });
+
+  it('updates fetchedAt on every call', async () => {
+    const t = convexTest(schema);
+    const authed = await setupUser(t);
+
+    await authed.mutation(api.codexModels.replace, { models: sampleA });
+    const first = await authed.query(api.codexModels.get, {});
+    await new Promise((r) => setTimeout(r, 5));
+    await authed.mutation(api.codexModels.replace, { models: sampleB });
+    const second = await authed.query(api.codexModels.get, {});
+
+    expect(second?.fetchedAt).toBeGreaterThan(first?.fetchedAt ?? 0);
+  });
+
+  it('throws when called unauthenticated', async () => {
+    const t = convexTest(schema);
+    await expect(
+      t.mutation(api.codexModels.replace, { models: sampleA }),
+    ).rejects.toThrow('Not authenticated');
+  });
+});

--- a/convex/codexModels.test.ts
+++ b/convex/codexModels.test.ts
@@ -90,4 +90,27 @@ describe('codexModels.replace', () => {
       t.mutation(api.codexModels.replace, { models: sampleA }),
     ).rejects.toThrow('Not authenticated');
   });
+
+  it('ignores empty snapshots so the cached row is not nullified', async () => {
+    const t = convexTest(schema);
+    const authed = await setupUser(t);
+
+    await authed.mutation(api.codexModels.replace, { models: sampleA });
+    await authed.mutation(api.codexModels.replace, { models: [] });
+
+    const row = await authed.query(api.codexModels.get, {});
+    expect(row?.models).toEqual(sampleA);
+  });
+
+  it('does not insert an empty row on a fresh DB', async () => {
+    const t = convexTest(schema);
+    const authed = await setupUser(t);
+
+    await authed.mutation(api.codexModels.replace, { models: [] });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query('codexModels').collect(),
+    );
+    expect(rows).toHaveLength(0);
+  });
 });

--- a/convex/codexModels.ts
+++ b/convex/codexModels.ts
@@ -1,0 +1,38 @@
+import { v } from 'convex/values';
+import { mutation, query } from './_generated/server';
+import { requireAuth } from './lib/auth';
+
+const modelEntry = v.object({
+  id: v.string(),
+  label: v.string(),
+  description: v.string(),
+});
+
+/**
+ * Replace the single-row `codexModels` cache with a fresh snapshot. Invoked
+ * by the companion on startup after probing the live `codex app-server`
+ * model/list RPC. Upsert semantics via first-row patch so the table never
+ * grows past one row.
+ */
+export const replace = mutation({
+  args: { models: v.array(modelEntry) },
+  handler: async (ctx, { models }) => {
+    await requireAuth(ctx);
+    const existing = await ctx.db.query('codexModels').first();
+    const fetchedAt = Date.now();
+    if (existing) {
+      await ctx.db.patch(existing._id, { models, fetchedAt });
+    } else {
+      await ctx.db.insert('codexModels', { models, fetchedAt });
+    }
+  },
+});
+
+/** Current Codex model cache, or `null` before the companion has probed. */
+export const get = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireAuth(ctx);
+    return await ctx.db.query('codexModels').first();
+  },
+});

--- a/convex/codexModels.ts
+++ b/convex/codexModels.ts
@@ -13,6 +13,15 @@ const modelEntry = v.object({
  * by the companion on startup after probing the live `codex app-server`
  * model/list RPC. Upsert semantics via first-row patch so the table never
  * grows past one row.
+ *
+ * Trust model: writable by any authenticated user. Convex Auth doesn't
+ * distinguish "companion" from "browser," and the same pattern is used
+ * by `companion.ts` mutations. The table is deliberately global (no
+ * orgId scoping — spec Task 2), so a writer from one org updates the
+ * cache seen by every org. Blast radius is the model picker UI only;
+ * the list is not a security boundary. If this ever becomes untrusted,
+ * switch to an `internalMutation` invoked from an HTTP action guarded
+ * by `INTERNAL_API_SECRET`.
  */
 export const replace = mutation({
   args: { models: v.array(modelEntry) },

--- a/convex/codexModels.ts
+++ b/convex/codexModels.ts
@@ -27,6 +27,11 @@ export const replace = mutation({
   args: { models: v.array(modelEntry) },
   handler: async (ctx, { models }) => {
     await requireAuth(ctx);
+    // Reject empty snapshots so a well-formed-but-useless write from any
+    // authenticated client can't nullify the cached list and force the UI
+    // onto the fallback. The probe already skips empty `data` upstream;
+    // this is the defense-in-depth check at the mutation boundary.
+    if (models.length === 0) return;
     const existing = await ctx.db.query('codexModels').first();
     const fetchedAt = Date.now();
     if (existing) {

--- a/src/server/codex-models-probe.test.ts
+++ b/src/server/codex-models-probe.test.ts
@@ -9,7 +9,11 @@ vi.mock('codex-app-server-client', () => ({
 
 import { api } from '@convex/_generated/api';
 import type { ConvexClient } from 'convex/browser';
-import { probeCodexModels } from './codex-models-probe';
+import {
+  ensureCodexModelsProbe,
+  probeCodexModels,
+  resetCodexModelsProbeStateForTests,
+} from './codex-models-probe';
 
 type ModelListResponse = Awaited<
   ReturnType<
@@ -57,6 +61,7 @@ function makeCodexStub(opts: { models?: Model[]; modelListError?: Error }) {
 afterEach(() => {
   mockCreateClient.mockReset();
   vi.useRealTimers();
+  resetCodexModelsProbeStateForTests();
 });
 
 describe('probeCodexModels', () => {
@@ -171,5 +176,111 @@ describe('probeCodexModels', () => {
     await assertion;
 
     expect(client.mutation).not.toHaveBeenCalled();
+  });
+
+  it('closes the codex subprocess from the timeout path when modelList hangs', async () => {
+    vi.useFakeTimers();
+    const codex = {
+      modelList: vi.fn().mockReturnValue(new Promise(() => undefined)),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    mockCreateClient.mockResolvedValue(codex);
+    const client = makeConvexClient();
+
+    const probe = probeCodexModels(client);
+    // Swallow the expected timeout rejection so assertion ordering doesn't
+    // race the microtask queue.
+    probe.catch(() => undefined);
+    // Let createClient resolve so the probe stores its handle on `codex`.
+    await vi.advanceTimersByTimeAsync(0);
+    // Wall-clock fires while modelList is still pending.
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    await expect(probe).rejects.toThrow('Codex model probe timed out');
+    expect(codex.close).toHaveBeenCalled();
+    expect(client.mutation).not.toHaveBeenCalled();
+  });
+
+  it('closes the subprocess even when createClient resolves after the timeout', async () => {
+    vi.useFakeTimers();
+    const codex = {
+      modelList: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    let resolveCreate!: (value: typeof codex) => void;
+    mockCreateClient.mockReturnValue(
+      new Promise<typeof codex>((resolve) => {
+        resolveCreate = resolve;
+      }),
+    );
+    const client = makeConvexClient();
+
+    const probe = probeCodexModels(client);
+    probe.catch(() => undefined);
+    // Timer fires before createClient settles.
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(probe).rejects.toThrow('Codex model probe timed out');
+
+    // Orphaned subprocess arrives late — probe branch must still tear it
+    // down rather than leaking.
+    resolveCreate(codex);
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+
+    expect(codex.close).toHaveBeenCalledTimes(1);
+    expect(codex.modelList).not.toHaveBeenCalled();
+    expect(client.mutation).not.toHaveBeenCalled();
+  });
+});
+
+describe('ensureCodexModelsProbe', () => {
+  it('latches after a successful probe so repeat calls no-op', async () => {
+    const codex = makeCodexStub({ models: [makeModel()] });
+    mockCreateClient.mockResolvedValue(codex);
+    const client = makeConvexClient();
+
+    ensureCodexModelsProbe(client);
+    ensureCodexModelsProbe(client); // concurrent — must not spawn again
+    // Flush microtasks so the probe completes.
+    await vi.waitFor(() => {
+      expect(client.mutation).toHaveBeenCalledTimes(1);
+    });
+
+    ensureCodexModelsProbe(client); // post-success — still a no-op
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+    expect(client.mutation).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries after a failed probe so the recovery path can refresh', async () => {
+    const failingCodex = makeCodexStub({
+      modelListError: new Error('rpc timeout'),
+    });
+    const succeedingCodex = makeCodexStub({ models: [makeModel()] });
+    mockCreateClient
+      .mockResolvedValueOnce(failingCodex)
+      .mockResolvedValueOnce(succeedingCodex);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const client = makeConvexClient();
+
+    ensureCodexModelsProbe(client);
+    await vi.waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Codex model-list probe failed:',
+        expect.any(Error),
+      );
+    });
+    // First attempt failed — latch should be cleared, not stuck "succeeded".
+    expect(client.mutation).not.toHaveBeenCalled();
+
+    ensureCodexModelsProbe(client); // retry
+    await vi.waitFor(() => {
+      expect(client.mutation).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockCreateClient).toHaveBeenCalledTimes(2);
+    errorSpy.mockRestore();
   });
 });

--- a/src/server/codex-models-probe.test.ts
+++ b/src/server/codex-models-probe.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockCreateClient = vi.fn();
+
+vi.mock('codex-app-server-client', () => ({
+  createClient: mockCreateClient,
+}));
+
+import { api } from '@convex/_generated/api';
+import type { ConvexClient } from 'convex/browser';
+import { probeCodexModels } from './codex-models-probe';
+
+type ModelListResponse = Awaited<
+  ReturnType<
+    typeof import('codex-app-server-client').AppServerClient.prototype.modelList
+  >
+>;
+type Model = ModelListResponse['data'][number];
+
+function makeModel(overrides: Partial<Model> = {}): Model {
+  return {
+    id: 'gpt-5.4',
+    model: 'gpt-5.4',
+    upgrade: null,
+    upgradeInfo: null,
+    availabilityNux: null,
+    displayName: 'GPT-5.4',
+    description: 'Frontier',
+    hidden: false,
+    supportedReasoningEfforts: [],
+    defaultReasoningEffort: 'medium',
+    inputModalities: [],
+    supportsPersonality: false,
+    additionalSpeedTiers: [],
+    isDefault: false,
+    ...overrides,
+  };
+}
+
+function makeConvexClient() {
+  return {
+    mutation: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ConvexClient & {
+    mutation: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeCodexStub(opts: { models?: Model[]; modelListError?: Error }) {
+  const close = vi.fn().mockResolvedValue(undefined);
+  const modelList = opts.modelListError
+    ? vi.fn().mockRejectedValue(opts.modelListError)
+    : vi.fn().mockResolvedValue({ data: opts.models ?? [], nextCursor: null });
+  return { modelList, close };
+}
+
+afterEach(() => {
+  mockCreateClient.mockReset();
+});
+
+describe('probeCodexModels', () => {
+  it('maps Model[] → {id,label,description} and calls the Convex mutation', async () => {
+    const codex = makeCodexStub({
+      models: [
+        makeModel({
+          id: 'gpt-5.4',
+          displayName: 'GPT-5.4',
+          description: 'Frontier',
+        }),
+        makeModel({
+          id: 'gpt-5.4-mini',
+          displayName: 'GPT-5.4 Mini',
+          description: 'Smaller frontier',
+        }),
+      ],
+    });
+    mockCreateClient.mockResolvedValue(codex);
+    const client = makeConvexClient();
+
+    await probeCodexModels(client);
+
+    expect(client.mutation).toHaveBeenCalledTimes(1);
+    expect(client.mutation).toHaveBeenCalledWith(api.codexModels.replace, {
+      models: [
+        { id: 'gpt-5.4', label: 'GPT-5.4', description: 'Frontier' },
+        {
+          id: 'gpt-5.4-mini',
+          label: 'GPT-5.4 Mini',
+          description: 'Smaller frontier',
+        },
+      ],
+    });
+    expect(codex.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters out hidden models', async () => {
+    const codex = makeCodexStub({
+      models: [
+        makeModel({ id: 'visible', hidden: false }),
+        makeModel({ id: 'secret', hidden: true }),
+      ],
+    });
+    mockCreateClient.mockResolvedValue(codex);
+    const client = makeConvexClient();
+
+    await probeCodexModels(client);
+
+    const [, args] = client.mutation.mock.calls[0] as [
+      unknown,
+      { models: Array<{ id: string }> },
+    ];
+    expect(args.models.map((m) => m.id)).toEqual(['visible']);
+    expect(codex.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the mutation when the probe returns no models', async () => {
+    const codex = makeCodexStub({ models: [] });
+    mockCreateClient.mockResolvedValue(codex);
+    const client = makeConvexClient();
+
+    await probeCodexModels(client);
+
+    expect(client.mutation).not.toHaveBeenCalled();
+    expect(codex.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the mutation when every model is hidden', async () => {
+    const codex = makeCodexStub({ models: [makeModel({ hidden: true })] });
+    mockCreateClient.mockResolvedValue(codex);
+    const client = makeConvexClient();
+
+    await probeCodexModels(client);
+
+    expect(client.mutation).not.toHaveBeenCalled();
+    expect(codex.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces createClient errors (missing binary) without calling close', async () => {
+    const spawnError = new Error('spawn codex ENOENT');
+    mockCreateClient.mockRejectedValue(spawnError);
+    const client = makeConvexClient();
+
+    await expect(probeCodexModels(client)).rejects.toThrow(
+      'spawn codex ENOENT',
+    );
+    expect(client.mutation).not.toHaveBeenCalled();
+  });
+
+  it('still closes the subprocess when modelList throws', async () => {
+    const codex = makeCodexStub({ modelListError: new Error('rpc timeout') });
+    mockCreateClient.mockResolvedValue(codex);
+    const client = makeConvexClient();
+
+    await expect(probeCodexModels(client)).rejects.toThrow('rpc timeout');
+    expect(codex.close).toHaveBeenCalledTimes(1);
+    expect(client.mutation).not.toHaveBeenCalled();
+  });
+
+  it('rejects with a timeout error when createClient hangs', async () => {
+    vi.useFakeTimers();
+    // Promise that never resolves — simulates Bun's ENOENT path where
+    // createClient neither fulfils nor rejects.
+    mockCreateClient.mockReturnValue(new Promise(() => undefined));
+    const client = makeConvexClient();
+
+    const assertion = expect(probeCodexModels(client)).rejects.toThrow(
+      'Codex model probe timed out',
+    );
+    await vi.advanceTimersByTimeAsync(15_000);
+    await assertion;
+
+    expect(client.mutation).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/src/server/codex-models-probe.test.ts
+++ b/src/server/codex-models-probe.test.ts
@@ -56,6 +56,7 @@ function makeCodexStub(opts: { models?: Model[]; modelListError?: Error }) {
 
 afterEach(() => {
   mockCreateClient.mockReset();
+  vi.useRealTimers();
 });
 
 describe('probeCodexModels', () => {
@@ -170,6 +171,5 @@ describe('probeCodexModels', () => {
     await assertion;
 
     expect(client.mutation).not.toHaveBeenCalled();
-    vi.useRealTimers();
   });
 });

--- a/src/server/codex-models-probe.ts
+++ b/src/server/codex-models-probe.ts
@@ -15,46 +15,95 @@ const PROBE_TIMEOUT_MS = 15_000;
  * swallow errors and fall back to `CODEX_MODELS_FALLBACK` on the frontend.
  *
  * The `codex-app-server-client` import is dynamic so a missing binary does
- * not crash companion startup at module-load time.
+ * not crash companion startup at module-load time. The wall-clock timeout
+ * tears down the Codex subprocess even when `createClient`, `modelList`, or
+ * `close` hangs — critical because `Promise.race` alone would only unblock
+ * the caller while leaving the child process alive.
  */
 export async function probeCodexModels(client: ConvexClient): Promise<void> {
-  await withTimeout(
-    runProbe(client),
-    PROBE_TIMEOUT_MS,
-    'Codex model probe timed out',
-  );
-}
-
-async function runProbe(client: ConvexClient): Promise<void> {
   const { createClient } = await import('codex-app-server-client');
-  const codex = await createClient({ defaultRequestTimeoutMs: 10_000 });
+  type Codex = Awaited<ReturnType<typeof createClient>>;
+
+  let codex: Codex | null = null;
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      // If the client is already live, kill the subprocess now. Otherwise
+      // the probe branch below will close it as soon as `createClient`
+      // resolves (which may happen long after the timeout fires).
+      codex?.close().catch(() => undefined);
+      reject(new Error('Codex model probe timed out'));
+    }, PROBE_TIMEOUT_MS);
+    timer.unref?.();
+  });
+
+  const probe = (async () => {
+    codex = await createClient({ defaultRequestTimeoutMs: 10_000 });
+    if (timedOut) {
+      await codex.close().catch(() => undefined);
+      return;
+    }
+    try {
+      const { data } = await codex.modelList();
+      const models = data
+        .filter((m) => !m.hidden)
+        .map((m) => ({
+          id: m.id,
+          label: m.displayName,
+          description: m.description,
+        }));
+      if (models.length === 0) return;
+      await client.mutation(api.codexModels.replace, { models });
+    } finally {
+      await codex.close().catch(() => undefined);
+    }
+  })();
+  // Swallow late rejections from the losing side of the race so a timed-out
+  // probe that eventually errors (e.g. subprocess crash) never triggers an
+  // unhandled-rejection warning.
+  probe.catch(() => undefined);
+
   try {
-    const { data } = await codex.modelList();
-    const models = data
-      .filter((m) => !m.hidden)
-      .map((m) => ({
-        id: m.id,
-        label: m.displayName,
-        description: m.description,
-      }));
-    if (models.length === 0) return;
-    await client.mutation(api.codexModels.replace, { models });
+    await Promise.race([probe, timeoutPromise]);
   } finally {
-    await codex.close().catch(() => undefined);
+    if (timer) clearTimeout(timer);
   }
 }
 
-function withTimeout<T>(
-  promise: Promise<T>,
-  ms: number,
-  message: string,
-): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(message)), ms);
-    timer.unref?.();
-  });
-  return Promise.race([promise, timeout]).finally(() => {
-    if (timer) clearTimeout(timer);
-  });
+// Latches for `ensureCodexModelsProbe`. `succeeded` is a one-shot gate after
+// a successful refresh so we don't churn a subprocess on every companion
+// poll. `inFlight` prevents concurrent probes while one is running. Failures
+// leave both `false`, so the recovery path can retry after a transient
+// spawn/RPC/network error.
+let succeeded = false;
+let inFlight = false;
+
+/**
+ * Kick off a background Codex model probe at most once per successful run.
+ * Safe to call from companion startup and from the polling recovery path —
+ * duplicate calls while a probe is in flight (or after one has succeeded)
+ * no-op.
+ */
+export function ensureCodexModelsProbe(client: ConvexClient): void {
+  if (succeeded || inFlight) return;
+  inFlight = true;
+  void probeCodexModels(client)
+    .then(() => {
+      succeeded = true;
+    })
+    .catch((err) => {
+      console.error('Codex model-list probe failed:', err);
+    })
+    .finally(() => {
+      inFlight = false;
+    });
+}
+
+/** Test-only: clear both latches so unit tests can exercise retry paths. */
+export function resetCodexModelsProbeStateForTests(): void {
+  succeeded = false;
+  inFlight = false;
 }

--- a/src/server/codex-models-probe.ts
+++ b/src/server/codex-models-probe.ts
@@ -1,0 +1,60 @@
+import { api } from '@convex/_generated/api';
+import type { ConvexClient } from 'convex/browser';
+
+/**
+ * Wall-clock cap on the entire probe (spawn + initialize + RPC + close).
+ * Belt-and-suspenders for Bun, where a missing `codex` binary has been
+ * observed to leave the underlying spawn promise unresolved instead of
+ * emitting an ENOENT error.
+ */
+const PROBE_TIMEOUT_MS = 15_000;
+
+/**
+ * Spawn an ephemeral `codex app-server` subprocess, fetch the live model
+ * list, and replace the `codexModels` Convex cache. Best-effort: callers
+ * swallow errors and fall back to `CODEX_MODELS_FALLBACK` on the frontend.
+ *
+ * The `codex-app-server-client` import is dynamic so a missing binary does
+ * not crash companion startup at module-load time.
+ */
+export async function probeCodexModels(client: ConvexClient): Promise<void> {
+  await withTimeout(
+    runProbe(client),
+    PROBE_TIMEOUT_MS,
+    'Codex model probe timed out',
+  );
+}
+
+async function runProbe(client: ConvexClient): Promise<void> {
+  const { createClient } = await import('codex-app-server-client');
+  const codex = await createClient({ defaultRequestTimeoutMs: 10_000 });
+  try {
+    const { data } = await codex.modelList();
+    const models = data
+      .filter((m) => !m.hidden)
+      .map((m) => ({
+        id: m.id,
+        label: m.displayName,
+        description: m.description,
+      }));
+    if (models.length === 0) return;
+    await client.mutation(api.codexModels.replace, { models });
+  } finally {
+    await codex.close().catch(() => undefined);
+  }
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+    timer.unref?.();
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}

--- a/src/server/polling.ts
+++ b/src/server/polling.ts
@@ -6,6 +6,7 @@ import type { Id } from '@convex/_generated/dataModel';
 import { getActiveSessions } from '@/claude/manager';
 import type { TokenFileData } from './auth-token';
 import { readTokenFile, signInAnonymous } from './auth-token';
+import { probeCodexModels } from './codex-models-probe';
 import {
   closeCompanionClients,
   getConvexClient,
@@ -395,6 +396,17 @@ export async function startCompanion(url: string): Promise<void> {
     } catch {
       // Non-critical — Convex may not be configured yet
     }
+  }
+
+  // 4.5. Refresh the Codex model cache in the background — fire-and-forget
+  // so the probe never delays subscriptions/heartbeats even when `codex` is
+  // missing or the app-server handshake hangs until PROBE_TIMEOUT_MS.
+  // Frontend falls back to CODEX_MODELS_FALLBACK and Convex's reactive
+  // query picks up the row whenever the probe eventually lands.
+  if (client) {
+    void probeCodexModels(client).catch((err) => {
+      console.error('Codex model-list probe failed:', err);
+    });
   }
 
   // 5. Start reactive subscriptions for queued/stopped sessions and pending messages

--- a/src/server/polling.ts
+++ b/src/server/polling.ts
@@ -3,6 +3,7 @@
 import { hostname } from 'node:os';
 import { api } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
+import type { ConvexClient } from 'convex/browser';
 import { getActiveSessions } from '@/claude/manager';
 import type { TokenFileData } from './auth-token';
 import { readTokenFile, signInAnonymous } from './auth-token';
@@ -53,6 +54,19 @@ let heartbeatFailureLogged = false;
 // and a replacement obtained on the next cycle, kept for the rest of the window.
 let ephemeralClearedAt: number | null = null;
 const EPHEMERAL_CLEAR_COOLDOWN_MS = 30_000;
+// Gate the Codex model-list probe to once per process: the probe is fire-
+// and-forget with its own 15s timeout, so re-running it per poll cycle
+// would churn a subprocess on every tick. Reset only on explicit cases
+// (currently none — restart companion to refresh the cache).
+let codexProbeStarted = false;
+
+function ensureCodexProbe(client: ConvexClient): void {
+  if (codexProbeStarted) return;
+  codexProbeStarted = true;
+  void probeCodexModels(client).catch((err) => {
+    console.error('Codex model-list probe failed:', err);
+  });
+}
 
 function getDeployment(): string | undefined {
   return process.env.CONVEX_DEPLOYMENT;
@@ -160,6 +174,12 @@ export async function companionPoll() {
               );
               await startCompanionSubscriptions();
               ephemeralClearedAt = null;
+              // Fire the Codex model probe now that the Convex client is
+              // live — handles the case where companion started without a
+              // usable token and auth recovered mid-flight. No-op after
+              // the first successful call.
+              const recoveredClient = getConvexClient();
+              if (recoveredClient) ensureCodexProbe(recoveredClient);
             } catch (subErr) {
               // Clear stale ephemeral tokens so the next cycle can obtain a
               // fresh anonymous identity (e.g. after a Convex restart).
@@ -404,9 +424,7 @@ export async function startCompanion(url: string): Promise<void> {
   // Frontend falls back to CODEX_MODELS_FALLBACK and Convex's reactive
   // query picks up the row whenever the probe eventually lands.
   if (client) {
-    void probeCodexModels(client).catch((err) => {
-      console.error('Codex model-list probe failed:', err);
-    });
+    ensureCodexProbe(client);
   }
 
   // 5. Start reactive subscriptions for queued/stopped sessions and pending messages

--- a/src/server/polling.ts
+++ b/src/server/polling.ts
@@ -3,11 +3,10 @@
 import { hostname } from 'node:os';
 import { api } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
-import type { ConvexClient } from 'convex/browser';
 import { getActiveSessions } from '@/claude/manager';
 import type { TokenFileData } from './auth-token';
 import { readTokenFile, signInAnonymous } from './auth-token';
-import { probeCodexModels } from './codex-models-probe';
+import { ensureCodexModelsProbe } from './codex-models-probe';
 import {
   closeCompanionClients,
   getConvexClient,
@@ -54,20 +53,6 @@ let heartbeatFailureLogged = false;
 // and a replacement obtained on the next cycle, kept for the rest of the window.
 let ephemeralClearedAt: number | null = null;
 const EPHEMERAL_CLEAR_COOLDOWN_MS = 30_000;
-// Gate the Codex model-list probe to once per process: the probe is fire-
-// and-forget with its own 15s timeout, so re-running it per poll cycle
-// would churn a subprocess on every tick. Reset only on explicit cases
-// (currently none — restart companion to refresh the cache).
-let codexProbeStarted = false;
-
-function ensureCodexProbe(client: ConvexClient): void {
-  if (codexProbeStarted) return;
-  codexProbeStarted = true;
-  void probeCodexModels(client).catch((err) => {
-    console.error('Codex model-list probe failed:', err);
-  });
-}
-
 function getDeployment(): string | undefined {
   return process.env.CONVEX_DEPLOYMENT;
 }
@@ -179,7 +164,7 @@ export async function companionPoll() {
               // usable token and auth recovered mid-flight. No-op after
               // the first successful call.
               const recoveredClient = getConvexClient();
-              if (recoveredClient) ensureCodexProbe(recoveredClient);
+              if (recoveredClient) ensureCodexModelsProbe(recoveredClient);
             } catch (subErr) {
               // Clear stale ephemeral tokens so the next cycle can obtain a
               // fresh anonymous identity (e.g. after a Convex restart).
@@ -424,7 +409,7 @@ export async function startCompanion(url: string): Promise<void> {
   // Frontend falls back to CODEX_MODELS_FALLBACK and Convex's reactive
   // query picks up the row whenever the probe eventually lands.
   if (client) {
-    ensureCodexProbe(client);
+    ensureCodexModelsProbe(client);
   }
 
   // 5. Start reactive subscriptions for queued/stopped sessions and pending messages


### PR DESCRIPTION
## Summary

- Populates the `codexModels` Convex cache on every companion startup by spawning an ephemeral `codex app-server` subprocess and mapping the live `model/list` RPC into the schema row added in Task 2.
- Frontend picker (wired in Task 6) reads `api.codexModels.get` reactively; falls back to `CODEX_MODELS_FALLBACK` when the probe hasn't landed yet or the `codex` binary is missing.
- Probe is fire-and-forget — never blocks subscriptions or heartbeats, even on the 15s wall-clock-timeout failure path.

Spec: `wiki/core/codex-integration-spec.md` § Task 2b.

## Implementation notes

- Dynamic import of `codex-app-server-client` so a missing binary doesn't crash module load.
- Dual timeout: 10s per-RPC (`defaultRequestTimeoutMs`) plus a 15s wall-clock cap because Bun has been observed to swallow ENOENT from `node:child_process` instead of rejecting.
- Single-row cache semantics: `replace` patches in place, never appends. Empty probe results leave the prior row alone so the picker keeps whatever was previously cached.

## Test plan

- [x] `bun run check` — 630/630 unit tests, lint clean, typecheck clean.
- [x] 13 new unit tests (6 Convex + 7 probe, incl. Bun timeout path).
- [x] Manual: with `codex` on PATH → row populated with 7 live models.
- [x] Manual: with `codex` off PATH → companion logs `Codex model probe timed out` at ~15s and keeps running; subscriptions + heartbeats unaffected.
- [x] GH Actions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic discovery and caching of Codex AI model metadata, fetched during app startup and recovery
  * Hidden models are automatically filtered from the cached list
  * Includes 15-second timeout protection for safe operation

* **Tests**
  * Added comprehensive test coverage for model caching endpoints and discovery functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->