### PR TITLE
fix: tool approval card stays expanded once approval is requested

### DIFF
--- a/src/frontend/components/session/ToolCallUI.test.tsx
+++ b/src/frontend/components/session/ToolCallUI.test.tsx
@@ -9,20 +9,28 @@ import { SessionActionsContext } from './SessionActionsContext';
 // Mocks
 // ---------------------------------------------------------------------------
 
-// Mock Radix Collapsible — controls open/closed state simply
+// Mock Radix Collapsible — reflect whichever of open/defaultOpen is provided.
+// ToolCallUI uses controlled `open`, but tests that still pass `defaultOpen`
+// (or nothing) should see the same data-open behavior.
 vi.mock('@/frontend/components/ui/collapsible', () => ({
   Collapsible: ({
     children,
+    open,
     defaultOpen,
   }: {
     children: ReactNode;
+    open?: boolean;
     defaultOpen?: boolean;
+    onOpenChange?: (next: boolean) => void;
     className?: string;
-  }) => (
-    <div data-testid="collapsible" data-open={defaultOpen ? 'true' : 'false'}>
-      {children}
-    </div>
-  ),
+  }) => {
+    const isOpen = open ?? defaultOpen ?? false;
+    return (
+      <div data-testid="collapsible" data-open={isOpen ? 'true' : 'false'}>
+        {children}
+      </div>
+    );
+  },
   CollapsibleTrigger: ({
     children,
     className,
@@ -238,6 +246,58 @@ describe('ToolCallUI', () => {
       render(<ToolCallUI part={part} />, { wrapper: withSessionActions() });
       const collapsible = screen.getByTestId('collapsible');
       expect(collapsible).toHaveAttribute('data-open', 'true');
+    });
+
+    it('stays open after the part transitions out of approval-requested', () => {
+      // Repro for GH #246: the card should remain expanded once an approval
+      // has been seen, even if the state flips to approval-responded or
+      // output-available afterwards.
+      const initial = makePart({
+        state: 'approval-requested',
+        approval: { id: 'appr-1' },
+      });
+      const { rerender } = render(<ToolCallUI part={initial} />, {
+        wrapper: withSessionActions(),
+      });
+      expect(screen.getByTestId('collapsible')).toHaveAttribute(
+        'data-open',
+        'true',
+      );
+
+      const resolved = makePart({
+        state: 'output-available',
+        output: 'done',
+        approval: { id: 'appr-1', approved: true },
+      });
+      rerender(<ToolCallUI part={resolved} />);
+      expect(screen.getByTestId('collapsible')).toHaveAttribute(
+        'data-open',
+        'true',
+      );
+    });
+
+    it('opens when an approval arrives after an earlier non-approval state', () => {
+      // Repro for GH #246: if the tool mounts before the approval-requested
+      // event lands (e.g. input-available first), the card should still open
+      // when the state transitions into approval-requested.
+      const initial = makePart({ state: 'input-available' });
+      const { rerender } = render(<ToolCallUI part={initial} />, {
+        wrapper: withSessionActions(),
+      });
+      expect(screen.getByTestId('collapsible')).toHaveAttribute(
+        'data-open',
+        'false',
+      );
+
+      const approving = makePart({
+        state: 'approval-requested',
+        approval: { id: 'appr-1' },
+      });
+      rerender(<ToolCallUI part={approving} />);
+      expect(screen.getByTestId('collapsible')).toHaveAttribute(
+        'data-open',
+        'true',
+      );
     });
 
     it('renders Approve button', () => {

--- a/src/frontend/components/session/ToolCallUI.tsx
+++ b/src/frontend/components/session/ToolCallUI.tsx
@@ -1,5 +1,5 @@
 import type { DynamicToolUIPart } from 'ai';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Confirmation,
   ConfirmationAccepted,
@@ -33,6 +33,16 @@ export default function ToolCallUI({ part }: ToolCallUIProps) {
 
   const isApprovalRequested = part.state === 'approval-requested';
   const isError = part.state === 'output-error';
+
+  // Controlled open state so the card stays expanded across state transitions
+  // once an approval has been requested. `defaultOpen` alone only applied on
+  // first mount, and the part could mount before state flipped to
+  // `approval-requested`, leaving users staring at a collapsed card. The user
+  // can still collapse it manually via the header.
+  const [open, setOpen] = useState(isApprovalRequested);
+  useEffect(() => {
+    if (isApprovalRequested) setOpen(true);
+  }, [isApprovalRequested]);
 
   const titleSummary = toolSummary(
     part.toolName,
@@ -77,7 +87,7 @@ export default function ToolCallUI({ part }: ToolCallUIProps) {
   };
 
   return (
-    <Tool defaultOpen={isApprovalRequested}>
+    <Tool open={open} onOpenChange={setOpen}>
       <ToolHeader
         type="dynamic-tool"
         state={part.state}


### PR DESCRIPTION
## Summary

Fixes a UX bug where tool cards rendered collapsed in the middle of an approval request, forcing the user to click to see the Approve/Deny buttons.

`defaultOpen` on the Radix Collapsible only applies at mount. If the tool part mounts in `input-available` state and transitions to `approval-requested` afterwards, or the part mounts in `approval-requested` and later resolves, the card state didn't track the approval lifecycle.

- Switch `ToolCallUI` to controlled `open` state, seeded by `isApprovalRequested`.
- Re-open whenever a new approval arrives via a guarded effect (the allowed "external state sync" case per CLAUDE.md's useEffect guidance).
- The user can still collapse manually through the header; `onOpenChange` is wired up.
- Two new regression tests cover both state-transition directions.

Closes #246

## Test plan

- [x] `bun run check` (620 → 622 tests, all pass).
- [x] Unit tests assert the card stays open across `approval-requested → output-available` and opens on `input-available → approval-requested`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)