### PR TITLE
chore: tighten E2E waitForApp timeout and local worker cap

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -13,7 +13,11 @@ import type { Page } from '@playwright/test';
  */
 export async function waitForApp(page: Page): Promise<void> {
   await page.goto('/');
+  // 10s: auth handshake + Bun bundler cold-cache under parallel workers can be
+  // slow on the first hit, but a 30s timeout just hid regressions behind long
+  // retries. If the authenticated gate isn't visible in 10s, something is
+  // genuinely wrong.
   await page.waitForSelector('aside button:has-text("All Tasks")', {
-    timeout: 30000,
+    timeout: 10000,
   });
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,10 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // CI stays single-worker for deterministic logs. Locally, cap at 4 — the
+  // default (worker-per-core on M-series Macs) causes Bun bundler contention
+  // under cold-cache hits and drives `waitForApp` flake. See GH #255.
+  workers: process.env.CI ? 1 : 4,
   reporter: 'html',
   use: {
     baseURL: `http://localhost:${e2ePort}`,


### PR DESCRIPTION
## Summary

Closes out the two remaining items from GH #255. The bulk of the issue — selector bug, helper duplication across 8 spec files — was already resolved in earlier work (the helper now lives in `e2e/helpers.ts` with the correct `aside button:has-text("All Tasks")` selector). This PR picks off the two leftover tuning knobs:

- `e2e/helpers.ts`: drop `waitForApp`'s 30s timeout to 10s. At 30s, real regressions hide behind long retries; 10s is enough for Bun's cold-cache first hit.
- `playwright.config.ts`: cap local workers at 4. The default worker-per-core on M-series Macs causes Bun bundler contention under cold-cache hits, which drives the flake class the issue describes. CI stays single-worker.

Closes #255

## Test plan

- [x] `bun run test:e2e:isolated` — 67/67 passed (~25s), two consecutive runs.
- [x] `bun run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)