### PR TITLE
fix: allow SDK sessions to write to /tmp after approval

### DIFF
--- a/docs/docs/sessions.md
+++ b/docs/docs/sessions.md
@@ -94,6 +94,16 @@ The frontend `useSession` hook derives a fourth status not present in the backen
 
 Tool-use approvals are handled via Convex mutations. When Claude requests permission to use a tool, a `pendingApprovals` record is created. The frontend renders an approve/deny UI, and the user's response is written back via `api.pendingApprovals.resolve()`. The companion process reads the resolved approval and resumes the SDK.
 
+### Filesystem Access
+
+Each session runs with the task's repo as the SDK's `cwd`. By default, the SDK's `Write`/`Edit` tools refuse paths outside `cwd`, even after the user approves. Holophyte widens that allowlist with `additionalDirectories` so sessions can use standard scratch locations:
+
+- `/tmp` — universal Unix scratch
+- `/private/tmp` (macOS) — where `/tmp` actually resolves to
+- `$TMPDIR` (when set) — the per-user tmp directory on macOS
+
+Anything outside the repo + those three paths is still blocked, regardless of approval.
+
 ## Stop
 
 Stopping a running session (`POST /api/sessions/:id/stop`) sets `stoppedByUser = true` on the in-memory session and aborts the SDK controller. The cleanup path in `consumeIterator` detects this flag and transitions the session to `idle` rather than `failed` — so the session remains resumable. Stop does not delete the session or its history.

--- a/src/claude/manager.test.ts
+++ b/src/claude/manager.test.ts
@@ -617,6 +617,34 @@ describe('claude/manager (SDK-based)', () => {
         );
       }
     });
+
+    it('includes $TMPDIR (stripped of trailing slashes) when set', async () => {
+      const originalTmpdir = process.env.TMPDIR;
+      process.env.TMPDIR = '/var/folders/abc/T//';
+      try {
+        let capturedOptions: Record<string, unknown> | undefined;
+        vi.mocked(mockSdkQuery).mockImplementation((params: unknown) => {
+          const { options } = params as { options: Record<string, unknown> };
+          capturedOptions = options;
+          return createMockIterator([]) as never;
+        });
+
+        const { startSession } = await import('./manager');
+        await startSession({
+          sessionId: `tmpdir-${Math.random().toString(36).slice(2)}`,
+          repoPath: '/some/repo',
+          prompt: 'test',
+        });
+        await new Promise((r) => setTimeout(r, 20));
+
+        expect(capturedOptions?.additionalDirectories).toEqual(
+          expect.arrayContaining(['/var/folders/abc/T']),
+        );
+      } finally {
+        if (originalTmpdir === undefined) delete process.env.TMPDIR;
+        else process.env.TMPDIR = originalTmpdir;
+      }
+    });
   });
 
   describe('canUseTool: allow-return shape (SDK Zod schema)', () => {

--- a/src/claude/manager.test.ts
+++ b/src/claude/manager.test.ts
@@ -589,6 +589,36 @@ describe('claude/manager (SDK-based)', () => {
     });
   });
 
+  describe('additionalDirectories (GH #247)', () => {
+    it('passes /tmp to the SDK so approved Writes outside the repo succeed', async () => {
+      let capturedOptions: Record<string, unknown> | undefined;
+      vi.mocked(mockSdkQuery).mockImplementation((params: unknown) => {
+        const { options } = params as { options: Record<string, unknown> };
+        capturedOptions = options;
+        return createMockIterator([]) as never;
+      });
+
+      const { startSession } = await import('./manager');
+      await startSession({
+        sessionId: `add-dir-${Math.random().toString(36).slice(2)}`,
+        repoPath: '/some/repo',
+        prompt: 'test',
+      });
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(capturedOptions?.additionalDirectories).toEqual(
+        expect.arrayContaining(['/tmp']),
+      );
+      // On macOS, /tmp is a symlink to /private/tmp — both should be allowed so
+      // path resolution doesn't matter for the permission check.
+      if (process.platform === 'darwin') {
+        expect(capturedOptions?.additionalDirectories).toEqual(
+          expect.arrayContaining(['/private/tmp']),
+        );
+      }
+    });
+  });
+
   describe('canUseTool: allow-return shape (SDK Zod schema)', () => {
     // The @anthropic-ai/claude-agent-sdk Zod schema requires `updatedInput` on
     // every `{ behavior: 'allow' }` response. Missing it throws ZodError and

--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -169,7 +169,7 @@ function buildAdditionalDirectories(): string[] {
   const dirs = new Set<string>(['/tmp']);
   if (process.platform === 'darwin') dirs.add('/private/tmp');
   const envTmp = process.env.TMPDIR;
-  if (envTmp) dirs.add(envTmp.replace(/\/$/, ''));
+  if (envTmp) dirs.add(envTmp.replace(/\/+$/, ''));
   return [...dirs];
 }
 

--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -155,6 +155,24 @@ class SdkMessageChannel implements AsyncIterable<SDKUserMessage> {
   }
 }
 
+/**
+ * Directories outside the repo that sessions are allowed to touch. The SDK's
+ * Write/Edit tools refuse paths outside cwd + this allowlist, even after the
+ * user approves — which is what GH #247 was reporting for `/tmp` writes.
+ *
+ * `/tmp` is universally expected as scratch space on Unix. On macOS, Node's
+ * `os.tmpdir()` typically resolves to `/var/folders/...` via `TMPDIR`, and
+ * `/tmp` is a symlink to `/private/tmp`. We whitelist all three so paths
+ * resolve consistently regardless of which form Claude picks.
+ */
+function buildAdditionalDirectories(): string[] {
+  const dirs = new Set<string>(['/tmp']);
+  if (process.platform === 'darwin') dirs.add('/private/tmp');
+  const envTmp = process.env.TMPDIR;
+  if (envTmp) dirs.add(envTmp.replace(/\/$/, ''));
+  return [...dirs];
+}
+
 function shouldAutoApprove(
   session: Session,
   toolName: string,
@@ -360,6 +378,7 @@ export async function startSession(opts: {
   const sdkOptions: Parameters<typeof sdkQuery>[0]['options'] = {
     cwd: opts.repoPath,
     env: sdkEnv,
+    additionalDirectories: buildAdditionalDirectories(),
     abortController: controller,
     canUseTool: async (toolName, input, toolOpts) => {
       if (shouldAutoApprove(session, toolName, input)) {


### PR DESCRIPTION
## Summary

The Claude Agent SDK's `Write`/`Edit` tools gate file paths against `cwd + additionalDirectories`, independent of the user's approval decision. Without an explicit allowlist, writing to `/tmp` — a universal scratch location — fails with a sandbox-shaped error even when the user approves the Write tool call, which is what GH #247 reports.

### Fix

Pass an `additionalDirectories` allowlist to `query()` in `manager.ts`:

- `/tmp` everywhere
- `/private/tmp` on macOS (where `/tmp` is symlinked)
- `$TMPDIR` when set (per-user tmp on macOS, typically `/var/folders/...`)

Anything outside those + the repo's `cwd` is still blocked, regardless of approval.

### Investigation notes

- SDK's `additionalDirectories` option is documented as "Additional directories Claude can access beyond the current working directory" (SDK types, `sdk.d.ts:1097`).
- Holophyte wasn't passing `sandbox` or `additionalDirectories` — so SDK defaults applied, which confine writes to `cwd`.
- On macOS, `/tmp` resolves to `/private/tmp`; both are whitelisted so path canonicalization doesn't matter.
- `TMPDIR` picks up the per-user tmp (e.g., `/var/folders/...`) used by Node's `os.tmpdir()` on macOS.

This is a config-level widening — no SDK internals were touched.

Closes #247

## Test plan

- [x] Unit test asserts `additionalDirectories` contains `/tmp` (and `/private/tmp` on darwin).
- [x] `bun run check` green (623 tests).
- [ ] Manual repro from the issue: start a session, "create /tmp/approval-test.txt", approve, verify the Write succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)