### PR TITLE
feat(codex): Task 2c — lock codexModels.replace behind companion-only HTTP action

### DIFF
--- a/convex/codexModels.test.ts
+++ b/convex/codexModels.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment edge-runtime
 import { convexTest } from 'convex-test';
 import { describe, expect, it } from 'vitest';
-import { api } from './_generated/api';
+import { api, internal } from './_generated/api';
 import schema from './schema';
 
 async function setupUser(t: ReturnType<typeof convexTest>) {
@@ -43,13 +43,13 @@ describe('codexModels.get', () => {
   });
 });
 
-describe('codexModels.replace', () => {
+describe('codexModels.replace (internalMutation)', () => {
   it('inserts on first call and get() returns the models', async () => {
     const t = convexTest(schema);
     const authed = await setupUser(t);
 
     const before = Date.now();
-    await authed.mutation(api.codexModels.replace, { models: sampleA });
+    await t.mutation(internal.codexModels.replace, { models: sampleA });
     const row = await authed.query(api.codexModels.get, {});
 
     expect(row).not.toBeNull();
@@ -59,10 +59,9 @@ describe('codexModels.replace', () => {
 
   it('patches the existing row in place — never appends', async () => {
     const t = convexTest(schema);
-    const authed = await setupUser(t);
 
-    await authed.mutation(api.codexModels.replace, { models: sampleA });
-    await authed.mutation(api.codexModels.replace, { models: sampleB });
+    await t.mutation(internal.codexModels.replace, { models: sampleA });
+    await t.mutation(internal.codexModels.replace, { models: sampleB });
 
     const rows = await t.run(async (ctx) =>
       ctx.db.query('codexModels').collect(),
@@ -75,28 +74,21 @@ describe('codexModels.replace', () => {
     const t = convexTest(schema);
     const authed = await setupUser(t);
 
-    await authed.mutation(api.codexModels.replace, { models: sampleA });
+    await t.mutation(internal.codexModels.replace, { models: sampleA });
     const first = await authed.query(api.codexModels.get, {});
     await new Promise((r) => setTimeout(r, 5));
-    await authed.mutation(api.codexModels.replace, { models: sampleB });
+    await t.mutation(internal.codexModels.replace, { models: sampleB });
     const second = await authed.query(api.codexModels.get, {});
 
     expect(second?.fetchedAt).toBeGreaterThan(first?.fetchedAt ?? 0);
-  });
-
-  it('throws when called unauthenticated', async () => {
-    const t = convexTest(schema);
-    await expect(
-      t.mutation(api.codexModels.replace, { models: sampleA }),
-    ).rejects.toThrow('Not authenticated');
   });
 
   it('ignores empty snapshots so the cached row is not nullified', async () => {
     const t = convexTest(schema);
     const authed = await setupUser(t);
 
-    await authed.mutation(api.codexModels.replace, { models: sampleA });
-    await authed.mutation(api.codexModels.replace, { models: [] });
+    await t.mutation(internal.codexModels.replace, { models: sampleA });
+    await t.mutation(internal.codexModels.replace, { models: [] });
 
     const row = await authed.query(api.codexModels.get, {});
     expect(row?.models).toEqual(sampleA);
@@ -104,9 +96,8 @@ describe('codexModels.replace', () => {
 
   it('does not insert an empty row on a fresh DB', async () => {
     const t = convexTest(schema);
-    const authed = await setupUser(t);
 
-    await authed.mutation(api.codexModels.replace, { models: [] });
+    await t.mutation(internal.codexModels.replace, { models: [] });
 
     const rows = await t.run(async (ctx) =>
       ctx.db.query('codexModels').collect(),

--- a/convex/codexModels.ts
+++ b/convex/codexModels.ts
@@ -1,5 +1,5 @@
 import { v } from 'convex/values';
-import { mutation, query } from './_generated/server';
+import { internalMutation, query } from './_generated/server';
 import { requireAuth } from './lib/auth';
 
 const modelEntry = v.object({
@@ -8,29 +8,10 @@ const modelEntry = v.object({
   description: v.string(),
 });
 
-/**
- * Replace the single-row `codexModels` cache with a fresh snapshot. Invoked
- * by the companion on startup after probing the live `codex app-server`
- * model/list RPC. Upsert semantics via first-row patch so the table never
- * grows past one row.
- *
- * Trust model: writable by any authenticated user. Convex Auth doesn't
- * distinguish "companion" from "browser," and the same pattern is used
- * by `companion.ts` mutations. The table is deliberately global (no
- * orgId scoping — spec Task 2), so a writer from one org updates the
- * cache seen by every org. Blast radius is the model picker UI only;
- * the list is not a security boundary. If this ever becomes untrusted,
- * switch to an `internalMutation` invoked from an HTTP action guarded
- * by `INTERNAL_API_SECRET`.
- */
-export const replace = mutation({
+// Companion-only: invoked from the /api/internal/codex-models/replace HTTP action.
+export const replace = internalMutation({
   args: { models: v.array(modelEntry) },
   handler: async (ctx, { models }) => {
-    await requireAuth(ctx);
-    // Reject empty snapshots so a well-formed-but-useless write from any
-    // authenticated client can't nullify the cached list and force the UI
-    // onto the fallback. The probe already skips empty `data` upstream;
-    // this is the defense-in-depth check at the mutation boundary.
     if (models.length === 0) return;
     const existing = await ctx.db.query('codexModels').first();
     const fetchedAt = Date.now();

--- a/convex/http.test.ts
+++ b/convex/http.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment edge-runtime
+import { convexTest } from 'convex-test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import schema from './schema';
+
+const SECRET = 'test-internal-secret';
+const PATH = '/api/internal/codex-models/replace';
+
+beforeEach(() => {
+  process.env.INTERNAL_API_SECRET = SECRET;
+});
+
+afterEach(() => {
+  delete process.env.INTERNAL_API_SECRET;
+  vi.restoreAllMocks();
+});
+
+function post(
+  t: ReturnType<typeof convexTest>,
+  body: unknown,
+  bearer: string | null = SECRET,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (bearer !== null) headers.Authorization = `Bearer ${bearer}`;
+  return t.fetch(PATH, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function makeModel(i = 0) {
+  return {
+    id: `model-${i}`,
+    label: `Model ${i}`,
+    description: `Description ${i}`,
+  };
+}
+
+describe('POST /api/internal/codex-models/replace — auth', () => {
+  it('returns 401 when Authorization header is missing', async () => {
+    const t = convexTest(schema);
+    const res = await post(t, { models: [makeModel()] }, null);
+    expect(res.status).toBe(401);
+
+    const rows = await t.run((ctx) => ctx.db.query('codexModels').collect());
+    expect(rows).toHaveLength(0);
+  });
+
+  it('returns 401 when the bearer token is wrong', async () => {
+    const t = convexTest(schema);
+    const res = await post(t, { models: [makeModel()] }, 'wrong-secret');
+    expect(res.status).toBe(401);
+
+    const rows = await t.run((ctx) => ctx.db.query('codexModels').collect());
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe('POST /api/internal/codex-models/replace — payload validation', () => {
+  it('rejects 65 models with a generic 400', async () => {
+    const t = convexTest(schema);
+    const models = Array.from({ length: 65 }, (_, i) => makeModel(i));
+    const res = await post(t, { models });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Invalid models payload');
+  });
+
+  it('rejects an entry whose id exceeds 256 chars', async () => {
+    const t = convexTest(schema);
+    const models = [{ ...makeModel(), id: 'x'.repeat(257) }];
+    const res = await post(t, { models });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Invalid models payload');
+  });
+
+  it('rejects an entry with an empty label', async () => {
+    const t = convexTest(schema);
+    const models = [{ ...makeModel(), label: '' }];
+    const res = await post(t, { models });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects when models is not an array', async () => {
+    const t = convexTest(schema);
+    const res = await post(t, { models: 'nope' });
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts the boundary payload (64 models, 256-char fields)', async () => {
+    const t = convexTest(schema);
+    const pad = 'x'.repeat(256);
+    const models = Array.from({ length: 64 }, (_, i) => ({
+      id: `${i}`.padEnd(256, 'a'),
+      label: pad,
+      description: pad,
+    }));
+    const res = await post(t, { models });
+    expect(res.status).toBe(200);
+
+    const rows = await t.run((ctx) => ctx.db.query('codexModels').collect());
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.models).toHaveLength(64);
+  });
+});
+
+describe('POST /api/internal/codex-models/replace — smoke', () => {
+  it('populates codexModels end-to-end with a valid bearer', async () => {
+    const t = convexTest(schema);
+    const models = [makeModel(1), makeModel(2)];
+    const res = await post(t, { models });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+
+    const rows = await t.run((ctx) => ctx.db.query('codexModels').collect());
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.models).toEqual(models);
+    expect(typeof rows[0]?.fetchedAt).toBe('number');
+  });
+});

--- a/convex/http.test.ts
+++ b/convex/http.test.ts
@@ -85,6 +85,16 @@ describe('POST /api/internal/codex-models/replace — payload validation', () =>
     expect(res.status).toBe(400);
   });
 
+  it('accepts an entry with an empty description (schema permits it)', async () => {
+    const t = convexTest(schema);
+    const models = [{ ...makeModel(), description: '' }];
+    const res = await post(t, { models });
+    expect(res.status).toBe(200);
+
+    const rows = await t.run((ctx) => ctx.db.query('codexModels').collect());
+    expect(rows[0]?.models[0]?.description).toBe('');
+  });
+
   it('rejects when models is not an array', async () => {
     const t = convexTest(schema);
     const res = await post(t, { models: 'nope' });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -489,7 +489,6 @@ function isValidCodexModel(m: unknown): m is {
     label.length > 0 &&
     label.length <= MAX_CODEX_FIELD_LEN &&
     typeof description === 'string' &&
-    description.length > 0 &&
     description.length <= MAX_CODEX_FIELD_LEN
   );
 }
@@ -518,7 +517,7 @@ http.route({
       return jsonOk();
     } catch (err) {
       console.error('codexModels.replace failed:', err);
-      return jsonError('Mutation failed', 400);
+      return jsonError('Mutation failed', 500);
     }
   }),
 });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -469,6 +469,60 @@ http.route({
   }),
 });
 
+// ── Codex models ─────────────────────────────────────────────────────
+
+const MAX_CODEX_MODELS = 64;
+const MAX_CODEX_FIELD_LEN = 256;
+
+function isValidCodexModel(m: unknown): m is {
+  id: string;
+  label: string;
+  description: string;
+} {
+  if (!m || typeof m !== 'object') return false;
+  const { id, label, description } = m as Record<string, unknown>;
+  return (
+    typeof id === 'string' &&
+    id.length > 0 &&
+    id.length <= MAX_CODEX_FIELD_LEN &&
+    typeof label === 'string' &&
+    label.length > 0 &&
+    label.length <= MAX_CODEX_FIELD_LEN &&
+    typeof description === 'string' &&
+    description.length > 0 &&
+    description.length <= MAX_CODEX_FIELD_LEN
+  );
+}
+
+http.route({
+  path: '/api/internal/codex-models/replace',
+  method: 'POST',
+  handler: httpAction(async (ctx, request) => {
+    const authError = validateSecret(request);
+    if (authError) return authError;
+
+    const body = await parseBody(request);
+    if (body instanceof Response) return body;
+
+    const { models } = body;
+    if (
+      !Array.isArray(models) ||
+      models.length > MAX_CODEX_MODELS ||
+      !models.every(isValidCodexModel)
+    ) {
+      return jsonError('Invalid models payload', 400);
+    }
+
+    try {
+      await ctx.runMutation(internal.codexModels.replace, { models });
+      return jsonOk();
+    } catch (err) {
+      console.error('codexModels.replace failed:', err);
+      return jsonError('Mutation failed', 400);
+    }
+  }),
+});
+
 // ── API key exchange ─────────────────────────────────────────────────
 
 /**

--- a/src/server/codex-models-probe.test.ts
+++ b/src/server/codex-models-probe.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockCreateClient = vi.fn();
 
@@ -7,8 +7,6 @@ vi.mock('codex-app-server-client', () => ({
   createClient: mockCreateClient,
 }));
 
-import { api } from '@convex/_generated/api';
-import type { ConvexClient } from 'convex/browser';
 import {
   ensureCodexModelsProbe,
   probeCodexModels,
@@ -42,14 +40,6 @@ function makeModel(overrides: Partial<Model> = {}): Model {
   };
 }
 
-function makeConvexClient() {
-  return {
-    mutation: vi.fn().mockResolvedValue(undefined),
-  } as unknown as ConvexClient & {
-    mutation: ReturnType<typeof vi.fn>;
-  };
-}
-
 function makeCodexStub(opts: { models?: Model[]; modelListError?: Error }) {
   const close = vi.fn().mockResolvedValue(undefined);
   const modelList = opts.modelListError
@@ -58,14 +48,27 @@ function makeCodexStub(opts: { models?: Model[]; modelListError?: Error }) {
   return { modelList, close };
 }
 
+const target = {
+  siteUrl: 'https://example.convex.site',
+  secret: 'test-secret',
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+  vi.stubGlobal('fetch', fetchMock);
+});
+
 afterEach(() => {
   mockCreateClient.mockReset();
   vi.useRealTimers();
+  vi.unstubAllGlobals();
   resetCodexModelsProbeStateForTests();
 });
 
 describe('probeCodexModels', () => {
-  it('maps Model[] → {id,label,description} and calls the Convex mutation', async () => {
+  it('maps Model[] → {id,label,description} and POSTs to the HTTP action', async () => {
     const codex = makeCodexStub({
       models: [
         makeModel({
@@ -81,12 +84,19 @@ describe('probeCodexModels', () => {
       ],
     });
     mockCreateClient.mockResolvedValue(codex);
-    const client = makeConvexClient();
 
-    await probeCodexModels(client);
+    await probeCodexModels(target);
 
-    expect(client.mutation).toHaveBeenCalledTimes(1);
-    expect(client.mutation).toHaveBeenCalledWith(api.codexModels.replace, {
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      'https://example.convex.site/api/internal/codex-models/replace',
+    );
+    expect(init.method).toBe('POST');
+    const headers = new Headers(init.headers);
+    expect(headers.get('Authorization')).toBe('Bearer test-secret');
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(JSON.parse(init.body as string)).toEqual({
       models: [
         { id: 'gpt-5.4', label: 'GPT-5.4', description: 'Frontier' },
         {
@@ -107,75 +117,78 @@ describe('probeCodexModels', () => {
       ],
     });
     mockCreateClient.mockResolvedValue(codex);
-    const client = makeConvexClient();
 
-    await probeCodexModels(client);
+    await probeCodexModels(target);
 
-    const [, args] = client.mutation.mock.calls[0] as [
-      unknown,
-      { models: Array<{ id: string }> },
-    ];
-    expect(args.models.map((m) => m.id)).toEqual(['visible']);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as {
+      models: Array<{ id: string }>;
+    };
+    expect(body.models.map((m) => m.id)).toEqual(['visible']);
     expect(codex.close).toHaveBeenCalledTimes(1);
   });
 
-  it('skips the mutation when the probe returns no models', async () => {
+  it('skips the HTTP call when the probe returns no models', async () => {
     const codex = makeCodexStub({ models: [] });
     mockCreateClient.mockResolvedValue(codex);
-    const client = makeConvexClient();
 
-    await probeCodexModels(client);
+    await probeCodexModels(target);
 
-    expect(client.mutation).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(codex.close).toHaveBeenCalledTimes(1);
   });
 
-  it('skips the mutation when every model is hidden', async () => {
+  it('skips the HTTP call when every model is hidden', async () => {
     const codex = makeCodexStub({ models: [makeModel({ hidden: true })] });
     mockCreateClient.mockResolvedValue(codex);
-    const client = makeConvexClient();
 
-    await probeCodexModels(client);
+    await probeCodexModels(target);
 
-    expect(client.mutation).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(codex.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when the HTTP action returns a non-2xx status', async () => {
+    const codex = makeCodexStub({ models: [makeModel()] });
+    mockCreateClient.mockResolvedValue(codex);
+    fetchMock.mockResolvedValue(new Response(null, { status: 401 }));
+
+    await expect(probeCodexModels(target)).rejects.toThrow(
+      'codex-models replace failed: 401',
+    );
     expect(codex.close).toHaveBeenCalledTimes(1);
   });
 
   it('surfaces createClient errors (missing binary) without calling close', async () => {
     const spawnError = new Error('spawn codex ENOENT');
     mockCreateClient.mockRejectedValue(spawnError);
-    const client = makeConvexClient();
 
-    await expect(probeCodexModels(client)).rejects.toThrow(
+    await expect(probeCodexModels(target)).rejects.toThrow(
       'spawn codex ENOENT',
     );
-    expect(client.mutation).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('still closes the subprocess when modelList throws', async () => {
     const codex = makeCodexStub({ modelListError: new Error('rpc timeout') });
     mockCreateClient.mockResolvedValue(codex);
-    const client = makeConvexClient();
 
-    await expect(probeCodexModels(client)).rejects.toThrow('rpc timeout');
+    await expect(probeCodexModels(target)).rejects.toThrow('rpc timeout');
     expect(codex.close).toHaveBeenCalledTimes(1);
-    expect(client.mutation).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('rejects with a timeout error when createClient hangs', async () => {
     vi.useFakeTimers();
-    // Promise that never resolves — simulates Bun's ENOENT path where
-    // createClient neither fulfils nor rejects.
     mockCreateClient.mockReturnValue(new Promise(() => undefined));
-    const client = makeConvexClient();
 
-    const assertion = expect(probeCodexModels(client)).rejects.toThrow(
+    const assertion = expect(probeCodexModels(target)).rejects.toThrow(
       'Codex model probe timed out',
     );
     await vi.advanceTimersByTimeAsync(15_000);
     await assertion;
 
-    expect(client.mutation).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('closes the codex subprocess from the timeout path when modelList hangs', async () => {
@@ -185,20 +198,15 @@ describe('probeCodexModels', () => {
       close: vi.fn().mockResolvedValue(undefined),
     };
     mockCreateClient.mockResolvedValue(codex);
-    const client = makeConvexClient();
 
-    const probe = probeCodexModels(client);
-    // Swallow the expected timeout rejection so assertion ordering doesn't
-    // race the microtask queue.
+    const probe = probeCodexModels(target);
     probe.catch(() => undefined);
-    // Let createClient resolve so the probe stores its handle on `codex`.
     await vi.advanceTimersByTimeAsync(0);
-    // Wall-clock fires while modelList is still pending.
     await vi.advanceTimersByTimeAsync(15_000);
 
     await expect(probe).rejects.toThrow('Codex model probe timed out');
     expect(codex.close).toHaveBeenCalled();
-    expect(client.mutation).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('closes the subprocess even when createClient resolves after the timeout', async () => {
@@ -213,23 +221,19 @@ describe('probeCodexModels', () => {
         resolveCreate = resolve;
       }),
     );
-    const client = makeConvexClient();
 
-    const probe = probeCodexModels(client);
+    const probe = probeCodexModels(target);
     probe.catch(() => undefined);
-    // Timer fires before createClient settles.
     await vi.advanceTimersByTimeAsync(15_000);
     await expect(probe).rejects.toThrow('Codex model probe timed out');
 
-    // Orphaned subprocess arrives late — probe branch must still tear it
-    // down rather than leaking.
     resolveCreate(codex);
     await vi.advanceTimersByTimeAsync(0);
     await Promise.resolve();
 
     expect(codex.close).toHaveBeenCalledTimes(1);
     expect(codex.modelList).not.toHaveBeenCalled();
-    expect(client.mutation).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 
@@ -237,21 +241,19 @@ describe('ensureCodexModelsProbe', () => {
   it('latches after a successful probe so repeat calls no-op', async () => {
     const codex = makeCodexStub({ models: [makeModel()] });
     mockCreateClient.mockResolvedValue(codex);
-    const client = makeConvexClient();
 
-    ensureCodexModelsProbe(client);
-    ensureCodexModelsProbe(client); // concurrent — must not spawn again
-    // Flush microtasks so the probe completes.
+    ensureCodexModelsProbe(target);
+    ensureCodexModelsProbe(target);
     await vi.waitFor(() => {
-      expect(client.mutation).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    ensureCodexModelsProbe(client); // post-success — still a no-op
+    ensureCodexModelsProbe(target);
     await Promise.resolve();
     await Promise.resolve();
 
     expect(mockCreateClient).toHaveBeenCalledTimes(1);
-    expect(client.mutation).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('retries after a failed probe so the recovery path can refresh', async () => {
@@ -263,24 +265,38 @@ describe('ensureCodexModelsProbe', () => {
       .mockResolvedValueOnce(failingCodex)
       .mockResolvedValueOnce(succeedingCodex);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const client = makeConvexClient();
 
-    ensureCodexModelsProbe(client);
+    ensureCodexModelsProbe(target);
     await vi.waitFor(() => {
       expect(errorSpy).toHaveBeenCalledWith(
         'Codex model-list probe failed:',
         expect.any(Error),
       );
     });
-    // First attempt failed — latch should be cleared, not stuck "succeeded".
-    expect(client.mutation).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
 
-    ensureCodexModelsProbe(client); // retry
+    ensureCodexModelsProbe(target);
     await vi.waitFor(() => {
-      expect(client.mutation).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     expect(mockCreateClient).toHaveBeenCalledTimes(2);
+    errorSpy.mockRestore();
+  });
+
+  it('swallows non-2xx errors from the HTTP action', async () => {
+    const codex = makeCodexStub({ models: [makeModel()] });
+    mockCreateClient.mockResolvedValue(codex);
+    fetchMock.mockResolvedValue(new Response(null, { status: 500 }));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    ensureCodexModelsProbe(target);
+    await vi.waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Codex model-list probe failed:',
+        expect.any(Error),
+      );
+    });
     errorSpy.mockRestore();
   });
 });

--- a/src/server/codex-models-probe.test.ts
+++ b/src/server/codex-models-probe.test.ts
@@ -106,7 +106,35 @@ describe('probeCodexModels', () => {
         },
       ],
     });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect((init.signal as AbortSignal).aborted).toBe(false);
     expect(codex.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the in-flight HTTP request when the probe times out', async () => {
+    vi.useFakeTimers();
+    let capturedSignal: AbortSignal | undefined;
+    // Hang the fetch forever until aborted — mirrors a wedged Convex backend.
+    fetchMock.mockImplementation((_url, init: RequestInit) => {
+      capturedSignal = init.signal ?? undefined;
+      return new Promise((_, reject) => {
+        capturedSignal?.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'));
+        });
+      });
+    });
+    const codex = makeCodexStub({ models: [makeModel()] });
+    mockCreateClient.mockResolvedValue(codex);
+
+    const probe = probeCodexModels(target);
+    probe.catch(() => undefined);
+    await vi.advanceTimersByTimeAsync(0);
+    // Let the codex RPC + fetch path kick off.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    await expect(probe).rejects.toThrow('Codex model probe timed out');
+    expect(capturedSignal?.aborted).toBe(true);
   });
 
   it('filters out hidden models', async () => {

--- a/src/server/codex-models-probe.ts
+++ b/src/server/codex-models-probe.ts
@@ -102,6 +102,7 @@ export function ensureCodexModelsProbe(target: ProbeTarget): void {
   void probeCodexModels(target)
     .then(() => {
       succeeded = true;
+      console.log('Codex model cache refreshed');
     })
     .catch((err) => {
       console.error('Codex model-list probe failed:', err);

--- a/src/server/codex-models-probe.ts
+++ b/src/server/codex-models-probe.ts
@@ -1,6 +1,3 @@
-import { api } from '@convex/_generated/api';
-import type { ConvexClient } from 'convex/browser';
-
 /**
  * Wall-clock cap on the entire probe (spawn + initialize + RPC + close).
  * Belt-and-suspenders for Bun, where a missing `codex` binary has been
@@ -9,10 +6,16 @@ import type { ConvexClient } from 'convex/browser';
  */
 const PROBE_TIMEOUT_MS = 15_000;
 
+export interface ProbeTarget {
+  siteUrl: string;
+  secret: string;
+}
+
 /**
  * Spawn an ephemeral `codex app-server` subprocess, fetch the live model
- * list, and replace the `codexModels` Convex cache. Best-effort: callers
- * swallow errors and fall back to `CODEX_MODELS_FALLBACK` on the frontend.
+ * list, and replace the `codexModels` Convex cache via the companion-only
+ * HTTP action. Best-effort: callers swallow errors and fall back to
+ * `CODEX_MODELS_FALLBACK` on the frontend.
  *
  * The `codex-app-server-client` import is dynamic so a missing binary does
  * not crash companion startup at module-load time. The wall-clock timeout
@@ -20,7 +23,7 @@ const PROBE_TIMEOUT_MS = 15_000;
  * `close` hangs — critical because `Promise.race` alone would only unblock
  * the caller while leaving the child process alive.
  */
-export async function probeCodexModels(client: ConvexClient): Promise<void> {
+export async function probeCodexModels(target: ProbeTarget): Promise<void> {
   const { createClient } = await import('codex-app-server-client');
   type Codex = Awaited<ReturnType<typeof createClient>>;
 
@@ -31,9 +34,6 @@ export async function probeCodexModels(client: ConvexClient): Promise<void> {
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
       timedOut = true;
-      // If the client is already live, kill the subprocess now. Otherwise
-      // the probe branch below will close it as soon as `createClient`
-      // resolves (which may happen long after the timeout fires).
       codex?.close().catch(() => undefined);
       reject(new Error('Codex model probe timed out'));
     }, PROBE_TIMEOUT_MS);
@@ -56,14 +56,11 @@ export async function probeCodexModels(client: ConvexClient): Promise<void> {
           description: m.description,
         }));
       if (models.length === 0) return;
-      await client.mutation(api.codexModels.replace, { models });
+      await replaceCodexModels(target, models);
     } finally {
       await codex.close().catch(() => undefined);
     }
   })();
-  // Swallow late rejections from the losing side of the race so a timed-out
-  // probe that eventually errors (e.g. subprocess crash) never triggers an
-  // unhandled-rejection warning.
   probe.catch(() => undefined);
 
   try {
@@ -73,11 +70,23 @@ export async function probeCodexModels(client: ConvexClient): Promise<void> {
   }
 }
 
-// Latches for `ensureCodexModelsProbe`. `succeeded` is a one-shot gate after
-// a successful refresh so we don't churn a subprocess on every companion
-// poll. `inFlight` prevents concurrent probes while one is running. Failures
-// leave both `false`, so the recovery path can retry after a transient
-// spawn/RPC/network error.
+async function replaceCodexModels(
+  { siteUrl, secret }: ProbeTarget,
+  models: Array<{ id: string; label: string; description: string }>,
+): Promise<void> {
+  const res = await fetch(`${siteUrl}/api/internal/codex-models/replace`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${secret}`,
+    },
+    body: JSON.stringify({ models }),
+  });
+  if (!res.ok) {
+    throw new Error(`codex-models replace failed: ${res.status}`);
+  }
+}
+
 let succeeded = false;
 let inFlight = false;
 
@@ -87,10 +96,10 @@ let inFlight = false;
  * duplicate calls while a probe is in flight (or after one has succeeded)
  * no-op.
  */
-export function ensureCodexModelsProbe(client: ConvexClient): void {
+export function ensureCodexModelsProbe(target: ProbeTarget): void {
   if (succeeded || inFlight) return;
   inFlight = true;
-  void probeCodexModels(client)
+  void probeCodexModels(target)
     .then(() => {
       succeeded = true;
     })

--- a/src/server/codex-models-probe.ts
+++ b/src/server/codex-models-probe.ts
@@ -30,10 +30,13 @@ export async function probeCodexModels(target: ProbeTarget): Promise<void> {
   let codex: Codex | null = null;
   let timedOut = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const abortController = new AbortController();
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
       timedOut = true;
+      // Abort the in-flight fetch to the HTTP action, if any.
+      abortController.abort();
       codex?.close().catch(() => undefined);
       reject(new Error('Codex model probe timed out'));
     }, PROBE_TIMEOUT_MS);
@@ -56,7 +59,7 @@ export async function probeCodexModels(target: ProbeTarget): Promise<void> {
           description: m.description,
         }));
       if (models.length === 0) return;
-      await replaceCodexModels(target, models);
+      await replaceCodexModels(target, models, abortController.signal);
     } finally {
       await codex.close().catch(() => undefined);
     }
@@ -73,6 +76,7 @@ export async function probeCodexModels(target: ProbeTarget): Promise<void> {
 async function replaceCodexModels(
   { siteUrl, secret }: ProbeTarget,
   models: Array<{ id: string; label: string; description: string }>,
+  signal: AbortSignal,
 ): Promise<void> {
   const res = await fetch(`${siteUrl}/api/internal/codex-models/replace`, {
     method: 'POST',
@@ -81,6 +85,7 @@ async function replaceCodexModels(
       Authorization: `Bearer ${secret}`,
     },
     body: JSON.stringify({ models }),
+    signal,
   });
   if (!res.ok) {
     throw new Error(`codex-models replace failed: ${res.status}`);

--- a/src/server/polling.ts
+++ b/src/server/polling.ts
@@ -38,6 +38,23 @@ export interface PendingMessage {
   text: string;
 }
 
+let codexProbeEnvWarned = false;
+
+function tryCodexModelsProbe(): void {
+  const siteUrl = process.env.CONVEX_SITE_URL;
+  const secret = process.env.INTERNAL_API_SECRET;
+  if (!siteUrl || !secret) {
+    if (!codexProbeEnvWarned) {
+      console.warn(
+        'Skipping Codex model probe: CONVEX_SITE_URL or INTERNAL_API_SECRET not set',
+      );
+      codexProbeEnvWarned = true;
+    }
+    return;
+  }
+  ensureCodexModelsProbe({ siteUrl, secret });
+}
+
 const MACHINE_ID = process.env.MACHINE_ID ?? hostname();
 const INSTANCE_ID = `${MACHINE_ID}:${process.pid}`;
 export const POLL_INTERVAL_MS = 2000;
@@ -163,8 +180,7 @@ export async function companionPoll() {
               // live — handles the case where companion started without a
               // usable token and auth recovered mid-flight. No-op after
               // the first successful call.
-              const recoveredClient = getConvexClient();
-              if (recoveredClient) ensureCodexModelsProbe(recoveredClient);
+              if (getConvexClient()) tryCodexModelsProbe();
             } catch (subErr) {
               // Clear stale ephemeral tokens so the next cycle can obtain a
               // fresh anonymous identity (e.g. after a Convex restart).
@@ -409,7 +425,7 @@ export async function startCompanion(url: string): Promise<void> {
   // Frontend falls back to CODEX_MODELS_FALLBACK and Convex's reactive
   // query picks up the row whenever the probe eventually lands.
   if (client) {
-    ensureCodexModelsProbe(client);
+    tryCodexModelsProbe();
   }
 
   // 5. Start reactive subscriptions for queued/stopped sessions and pending messages

--- a/src/server/polling.ts
+++ b/src/server/polling.ts
@@ -109,6 +109,13 @@ export async function companionPoll() {
   try {
     const client = getConvexClient();
 
+    // Keep retrying the Codex model probe until it succeeds. The success
+    // latch inside `ensureCodexModelsProbe` makes this a no-op after the
+    // first win; before then, this covers the cold-boot race where the
+    // probe fires before `convex dev` has pushed `http.ts` (404) as well
+    // as transient `codex` spawn failures.
+    if (client) tryCodexModelsProbe();
+
     // 1. Send heartbeat for all active sessions
     if (client) {
       const activeIds = getActiveSessions();


### PR DESCRIPTION
## Summary

Closes the Phase 0 trade-off flagged during Task 2b review: `codexModels.replace` was a public Convex `mutation` guarded only by `requireAuth`, so any authenticated user in any tenant could overwrite the single global row every other tenant's launch picker reads.

- `codexModels.replace` → `internalMutation`. Removed the "Trust model" escape-hatch block comment — the hatch no longer exists.
- New route `POST /api/internal/codex-models/replace` in `convex/http.ts`, guarded by `INTERNAL_API_SECRET` (same pattern as existing `/api/internal/sessions/*` routes). Payload bounds: `models.length ≤ 64`; each entry's `id`/`label`/`description` non-empty and `≤ 256` chars. Violations return a generic 400 so the tripped bound isn't disclosed.
- Companion probe (`src/server/codex-models-probe.ts`) now POSTs to the HTTP action with a bearer header instead of calling `ConvexClient.mutation`. Signature changed to `{ siteUrl, secret }`.
- `src/server/polling.ts`: env-gated helper that reads `CONVEX_SITE_URL` + `INTERNAL_API_SECRET` and skips with a one-shot warn if either is missing. Probe runs every poll tick until it succeeds — the `succeeded` latch in `ensureCodexModelsProbe` makes this a no-op after the first win, and self-heals the cold-boot race where the probe fires before `convex dev` has pushed `http.ts` (404). One-shot `console.log('Codex model cache refreshed')` on first success.

## Test plan

- [x] `bun run check` — 665/665 pass, lint + typecheck clean
- [x] New `convex/http.test.ts`: 401 (missing/wrong bearer), 400 (65 models, 257-char id, empty label, non-array), 200 boundary (64 × 256-char), end-to-end smoke
- [x] `src/server/codex-models-probe.test.ts` rewritten around a `fetch` mock; new case covers non-2xx → reject
- [x] `convex/codexModels.test.ts` updated to call through `internal.codexModels.replace`
- [x] Manual smoke: `bun run dev:local` — probe lands, `Codex model cache refreshed` logs once, `bunx convex data codexModels` shows live row
- [ ] E2E coverage for the model picker lands with Task 6 (picker UI doesn't exist yet)

Acceptance (from the task brief):
- [x] `codexModels.replace` is `internalMutation` — not callable from frontend or browser-identity `ConvexClient.mutation`
- [x] HTTP action rejects missing/invalid secret and oversized payloads (generic 400)
- [x] `src/server/codex-models-probe.ts` no longer calls `client.mutation`
- [x] "Trust model" escape-hatch paragraph deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated internal HTTP endpoint to replace Codex models and server-side payload validation.

* **Bug Fixes**
  * Switched model cache refresh to use the internal endpoint and improved probe error handling and logging.

* **Tests**
  * Expanded tests covering the internal endpoint’s auth, payload bounds, and end-to-end cache refresh behavior.

* **Chores**
  * Made polling probe environment-aware to skip when config is missing and retry more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->