### PR TITLE
feat(codex): Task 3 — Codex session manager and Claude effort-level plumbing

### DIFF
--- a/src/claude/manager.test.ts
+++ b/src/claude/manager.test.ts
@@ -939,7 +939,7 @@ describe('claude/manager (SDK-based)', () => {
       // Wait for init event to be processed (sets sdkSessionId)
       await new Promise((r) => setTimeout(r, 50));
 
-      const result = sendMessageToSession(
+      const result = await sendMessageToSession(
         'msg-delivery-test',
         'follow-up message',
       );
@@ -966,7 +966,9 @@ describe('claude/manager (SDK-based)', () => {
 
     it('returns false when session does not exist', async () => {
       const { sendMessageToSession } = await import('./manager');
-      expect(sendMessageToSession('nonexistent', 'hello')).toBe(false);
+      await expect(sendMessageToSession('nonexistent', 'hello')).resolves.toBe(
+        false,
+      );
     });
 
     it('returns false when sdkSessionId is not yet set', async () => {
@@ -996,7 +998,9 @@ describe('claude/manager (SDK-based)', () => {
 
       // sdkSessionId not set yet (no init event)
       await new Promise((r) => setTimeout(r, 20));
-      expect(sendMessageToSession('no-init-test', 'hello')).toBe(false);
+      await expect(sendMessageToSession('no-init-test', 'hello')).resolves.toBe(
+        false,
+      );
 
       // Cleanup
       resolveBlock?.();
@@ -1045,9 +1049,9 @@ describe('claude/manager (SDK-based)', () => {
       });
 
       await new Promise((r) => setTimeout(r, 50));
-      expect(
+      await expect(
         sendMessageToSession('xhigh-followup-test', 'go deep', 'xhigh'),
-      ).toBe(true);
+      ).resolves.toBe(true);
       await new Promise((r) => setTimeout(r, 50));
 
       expect(applyFlagSettings).toHaveBeenCalledWith({ effortLevel: 'xhigh' });
@@ -1102,9 +1106,9 @@ describe('claude/manager (SDK-based)', () => {
 
       // Production caller (subscriptions.ts:131) often calls this with no
       // effort. Should keep the session's chosen effort, NOT reset to undefined.
-      expect(
+      await expect(
         sendMessageToSession('omit-effort-followup-test', 'follow up'),
-      ).toBe(true);
+      ).resolves.toBe(true);
       await new Promise((r) => setTimeout(r, 50));
 
       expect(applyFlagSettings).not.toHaveBeenCalled();
@@ -1162,14 +1166,150 @@ describe('claude/manager (SDK-based)', () => {
       );
 
       await new Promise((r) => setTimeout(r, 50));
-      expect(sendMessageToSession('max-followup-test', 'again', 'max')).toBe(
-        true,
-      );
+      await expect(
+        sendMessageToSession('max-followup-test', 'again', 'max'),
+      ).resolves.toBe(true);
       await new Promise((r) => setTimeout(r, 50));
 
       expect(applyFlagSettings).toHaveBeenCalledWith({
         effortLevel: undefined,
       });
+
+      resolveBlock?.();
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    it('still pushes the message when applyFlagSettings rejects', async () => {
+      let resolveBlock: (() => void) | undefined;
+      const blockPromise = new Promise<void>((r) => {
+        resolveBlock = r;
+      });
+      const applyFlagSettings = vi
+        .fn()
+        .mockRejectedValue(new Error('flag settings unavailable'));
+      const streamInput = vi.fn().mockResolvedValue(undefined);
+      const blockingIter = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'system',
+            subtype: 'init',
+            session_id: 'sdk-apply-reject',
+            tools: [],
+            model: 'claude-opus-4-6',
+          };
+          await blockPromise;
+        },
+        streamInput,
+        supportedCommands: vi.fn().mockResolvedValue([]),
+        supportedModels: vi.fn().mockResolvedValue([
+          {
+            value: 'claude-opus-4-6',
+            displayName: 'Opus 4.6',
+            description: 'Most capable',
+            supportsEffort: true,
+            supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+          },
+        ]),
+        applyFlagSettings,
+      };
+      vi.mocked(mockSdkQuery).mockReturnValue(blockingIter as never);
+
+      const { startSession, sendMessageToSession } = await import('./manager');
+
+      await startSession({
+        sessionId: 'apply-reject-test',
+        repoPath: '/tmp/test',
+        prompt: 'test',
+        model: 'claude-opus-4-6',
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Effort change requested (auto → high) — applyFlagSettings will reject.
+      // The user message must still go through.
+      const result = await sendMessageToSession(
+        'apply-reject-test',
+        'go anyway',
+        'high',
+      );
+      expect(result).toBe(true);
+      expect(applyFlagSettings).toHaveBeenCalled();
+
+      await new Promise((r) => setTimeout(r, 50));
+      const insertCalls = mockMutation.mock.calls.filter(
+        (call) =>
+          typeof call[1] === 'object' &&
+          'events' in (call[1] as Record<string, unknown>),
+      );
+      const allEvents = insertCalls
+        .map((c) => JSON.stringify((c[1] as Record<string, unknown>).events))
+        .join(' ');
+      expect(allEvents).toContain('go anyway');
+
+      resolveBlock?.();
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    it('still pushes the message when applyFlagSettings is missing on the iterator', async () => {
+      let resolveBlock: (() => void) | undefined;
+      const blockPromise = new Promise<void>((r) => {
+        resolveBlock = r;
+      });
+      // Iterator does NOT expose applyFlagSettings (older SDK build).
+      const blockingIter = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'system',
+            subtype: 'init',
+            session_id: 'sdk-no-apply',
+            tools: [],
+            model: 'claude-opus-4-6',
+          };
+          await blockPromise;
+        },
+        streamInput: vi.fn().mockResolvedValue(undefined),
+        supportedCommands: vi.fn().mockResolvedValue([]),
+        supportedModels: vi.fn().mockResolvedValue([
+          {
+            value: 'claude-opus-4-6',
+            displayName: 'Opus 4.6',
+            description: 'Most capable',
+            supportsEffort: true,
+            supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+          },
+        ]),
+      };
+      vi.mocked(mockSdkQuery).mockReturnValue(blockingIter as never);
+
+      const { startSession, sendMessageToSession } = await import('./manager');
+
+      await startSession({
+        sessionId: 'no-apply-test',
+        repoPath: '/tmp/test',
+        prompt: 'test',
+        model: 'claude-opus-4-6',
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should not throw — guarded — and should still push.
+      const result = await sendMessageToSession(
+        'no-apply-test',
+        'message body',
+        'high',
+      );
+      expect(result).toBe(true);
+
+      await new Promise((r) => setTimeout(r, 50));
+      const insertCalls = mockMutation.mock.calls.filter(
+        (call) =>
+          typeof call[1] === 'object' &&
+          'events' in (call[1] as Record<string, unknown>),
+      );
+      const allEvents = insertCalls
+        .map((c) => JSON.stringify((c[1] as Record<string, unknown>).events))
+        .join(' ');
+      expect(allEvents).toContain('message body');
 
       resolveBlock?.();
       await new Promise((r) => setTimeout(r, 100));

--- a/src/claude/manager.test.ts
+++ b/src/claude/manager.test.ts
@@ -1056,6 +1056,63 @@ describe('claude/manager (SDK-based)', () => {
       await new Promise((r) => setTimeout(r, 100));
     });
 
+    it('does not reset effort when caller omits reasoningEffort on follow-up', async () => {
+      let resolveBlock: (() => void) | undefined;
+      const blockPromise = new Promise<void>((r) => {
+        resolveBlock = r;
+      });
+      const applyFlagSettings = vi.fn().mockResolvedValue(undefined);
+      const blockingIter = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'system',
+            subtype: 'init',
+            session_id: 'sdk-omit-effort',
+            tools: [],
+            model: 'claude-opus-4-6',
+          };
+          await blockPromise;
+        },
+        streamInput: vi.fn().mockResolvedValue(undefined),
+        supportedCommands: vi.fn().mockResolvedValue([]),
+        supportedModels: vi.fn().mockResolvedValue([
+          {
+            value: 'claude-opus-4-6',
+            displayName: 'Opus 4.6',
+            description: 'Most capable',
+            supportsEffort: true,
+            supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+          },
+        ]),
+        applyFlagSettings,
+      };
+      vi.mocked(mockSdkQuery).mockReturnValue(blockingIter as never);
+
+      const { startSession, sendMessageToSession } = await import('./manager');
+
+      await startSession({
+        sessionId: 'omit-effort-followup-test',
+        repoPath: '/tmp/test',
+        prompt: 'test',
+        model: 'claude-opus-4-6',
+        reasoningEffort: 'high',
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Production caller (subscriptions.ts:131) often calls this with no
+      // effort. Should keep the session's chosen effort, NOT reset to undefined.
+      expect(
+        sendMessageToSession('omit-effort-followup-test', 'follow up'),
+      ).toBe(true);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(applyFlagSettings).not.toHaveBeenCalled();
+
+      resolveBlock?.();
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
     it('passes max on initial query options but treats max follow-ups as auto', async () => {
       let resolveBlock: (() => void) | undefined;
       const blockPromise = new Promise<void>((r) => {

--- a/src/claude/manager.test.ts
+++ b/src/claude/manager.test.ts
@@ -49,6 +49,7 @@ function createMockIterator(events: Array<Record<string, unknown>>) {
     throw: vi.fn(),
     streamInput: vi.fn().mockResolvedValue(undefined),
     supportedCommands: vi.fn().mockResolvedValue([]),
+    supportedModels: vi.fn().mockResolvedValue([]),
   };
 }
 
@@ -155,6 +156,7 @@ describe('claude/manager (SDK-based)', () => {
         },
         streamInput: vi.fn().mockResolvedValue(undefined),
         supportedCommands: vi.fn().mockResolvedValue([]),
+        supportedModels: vi.fn().mockResolvedValue([]),
       };
       vi.mocked(mockSdkQuery).mockReturnValue(mockIter as never);
 
@@ -374,6 +376,7 @@ describe('claude/manager (SDK-based)', () => {
           },
           streamInput: vi.fn().mockResolvedValue(undefined),
           supportedCommands: vi.fn().mockResolvedValue([]),
+          supportedModels: vi.fn().mockResolvedValue([]),
         } as never;
       });
 
@@ -498,6 +501,7 @@ describe('claude/manager (SDK-based)', () => {
           },
           streamInput: vi.fn().mockResolvedValue(undefined),
           supportedCommands: vi.fn().mockResolvedValue([]),
+          supportedModels: vi.fn().mockResolvedValue([]),
         } as never;
       });
 
@@ -558,6 +562,7 @@ describe('claude/manager (SDK-based)', () => {
           },
           streamInput: vi.fn().mockResolvedValue(undefined),
           supportedCommands: vi.fn().mockResolvedValue([]),
+          supportedModels: vi.fn().mockResolvedValue([]),
         } as never;
       });
 
@@ -692,6 +697,7 @@ describe('claude/manager (SDK-based)', () => {
           },
           streamInput: vi.fn().mockResolvedValue(undefined),
           supportedCommands: vi.fn().mockResolvedValue([]),
+          supportedModels: vi.fn().mockResolvedValue([]),
         } as never;
       });
 
@@ -769,6 +775,7 @@ describe('claude/manager (SDK-based)', () => {
           },
           streamInput: vi.fn().mockResolvedValue(undefined),
           supportedCommands: vi.fn().mockResolvedValue([]),
+          supportedModels: vi.fn().mockResolvedValue([]),
         } as never;
       });
 
@@ -908,6 +915,16 @@ describe('claude/manager (SDK-based)', () => {
         },
         streamInput: mockIter.streamInput,
         supportedCommands: vi.fn().mockResolvedValue([]),
+        supportedModels: vi.fn().mockResolvedValue([
+          {
+            value: 'claude-sonnet-4-6',
+            displayName: 'Sonnet 4.6',
+            description: 'Balanced',
+            supportsEffort: true,
+            supportedEffortLevels: ['low', 'medium', 'high'],
+          },
+        ]),
+        applyFlagSettings: vi.fn().mockResolvedValue(undefined),
       };
       vi.mocked(mockSdkQuery).mockReturnValue(blockingIter as never);
 
@@ -965,6 +982,7 @@ describe('claude/manager (SDK-based)', () => {
         },
         streamInput: vi.fn().mockResolvedValue(undefined),
         supportedCommands: vi.fn().mockResolvedValue([]),
+        supportedModels: vi.fn().mockResolvedValue([]),
       };
       vi.mocked(mockSdkQuery).mockReturnValue(blockingIter as never);
 
@@ -981,6 +999,121 @@ describe('claude/manager (SDK-based)', () => {
       expect(sendMessageToSession('no-init-test', 'hello')).toBe(false);
 
       // Cleanup
+      resolveBlock?.();
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    it('applies xhigh for follow-up messages when the selected model supports it', async () => {
+      let resolveBlock: (() => void) | undefined;
+      const blockPromise = new Promise<void>((r) => {
+        resolveBlock = r;
+      });
+      const applyFlagSettings = vi.fn().mockResolvedValue(undefined);
+      const blockingIter = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'system',
+            subtype: 'init',
+            session_id: 'sdk-xhigh-test',
+            tools: [],
+            model: 'claude-opus-4-6',
+          };
+          await blockPromise;
+        },
+        streamInput: vi.fn().mockResolvedValue(undefined),
+        supportedCommands: vi.fn().mockResolvedValue([]),
+        supportedModels: vi.fn().mockResolvedValue([
+          {
+            value: 'claude-opus-4-6',
+            displayName: 'Opus 4.6',
+            description: 'Most capable',
+            supportsEffort: true,
+            supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+          },
+        ]),
+        applyFlagSettings,
+      };
+      vi.mocked(mockSdkQuery).mockReturnValue(blockingIter as never);
+
+      const { startSession, sendMessageToSession } = await import('./manager');
+
+      await startSession({
+        sessionId: 'xhigh-followup-test',
+        repoPath: '/tmp/test',
+        prompt: 'test',
+        model: 'claude-opus-4-6',
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(
+        sendMessageToSession('xhigh-followup-test', 'go deep', 'xhigh'),
+      ).toBe(true);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(applyFlagSettings).toHaveBeenCalledWith({ effortLevel: 'xhigh' });
+
+      resolveBlock?.();
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    it('passes max on initial query options but treats max follow-ups as auto', async () => {
+      let resolveBlock: (() => void) | undefined;
+      const blockPromise = new Promise<void>((r) => {
+        resolveBlock = r;
+      });
+      const applyFlagSettings = vi.fn().mockResolvedValue(undefined);
+      const blockingIter = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'system',
+            subtype: 'init',
+            session_id: 'sdk-max-test',
+            tools: [],
+            model: 'claude-opus-4-6',
+          };
+          await blockPromise;
+        },
+        streamInput: vi.fn().mockResolvedValue(undefined),
+        supportedCommands: vi.fn().mockResolvedValue([]),
+        supportedModels: vi.fn().mockResolvedValue([
+          {
+            value: 'claude-opus-4-6',
+            displayName: 'Opus 4.6',
+            description: 'Most capable',
+            supportsEffort: true,
+            supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+          },
+        ]),
+        applyFlagSettings,
+      };
+      vi.mocked(mockSdkQuery).mockReturnValue(blockingIter as never);
+
+      const { startSession, sendMessageToSession } = await import('./manager');
+
+      await startSession({
+        sessionId: 'max-followup-test',
+        repoPath: '/tmp/test',
+        prompt: 'test',
+        model: 'claude-opus-4-6',
+        reasoningEffort: 'max',
+      });
+
+      expect(mockSdkQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({ effort: 'max' }),
+        }),
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(sendMessageToSession('max-followup-test', 'again', 'max')).toBe(
+        true,
+      );
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(applyFlagSettings).toHaveBeenCalledWith({
+        effortLevel: undefined,
+      });
+
       resolveBlock?.();
       await new Promise((r) => setTimeout(r, 100));
     });
@@ -1073,6 +1206,7 @@ describe('claude/manager (SDK-based)', () => {
         },
         streamInput: vi.fn().mockResolvedValue(undefined),
         supportedCommands: vi.fn().mockResolvedValue([]),
+        supportedModels: vi.fn().mockResolvedValue([]),
       };
 
       return { iter, resolveBlock: () => resolveBlock?.(), used: false };

--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -736,11 +736,11 @@ export function stopSession(sessionId: string): void {
  * @returns `true` if the message was delivered, `false` if the session is not
  *   running or not yet initialized.
  */
-export function sendMessageToSession(
+export async function sendMessageToSession(
   sessionId: string,
   text: string,
   reasoningEffort?: string,
-): boolean {
+): Promise<boolean> {
   const session = sessions.get(sessionId);
   // sdkSessionId is set from the system/init event — if not yet available,
   // return false so the message stays unconsumed and retries on the next poll.
@@ -758,15 +758,17 @@ export function sendMessageToSession(
     );
     if (session.reasoningEffort !== effortLevel) {
       session.reasoningEffort = effortLevel;
-      void (async () => {
-        await session.sdkQuery
-          ?.applyFlagSettings({ effortLevel })
-          .catch((err) => {
-            console.error('Failed to apply Claude effort setting:', err);
-          });
-        pushUserMessage(session, text);
-      })();
-      return true;
+      // Existence-guard `applyFlagSettings` (older SDK builds may not expose
+      // it). Effort-application failure is logged but does not block the
+      // message — the user-visible follow-up matters more than the override.
+      const apply = (session.sdkQuery as Partial<Query>).applyFlagSettings;
+      if (apply) {
+        try {
+          await apply.call(session.sdkQuery, { effortLevel });
+        } catch (err) {
+          console.error('Failed to apply Claude effort setting:', err);
+        }
+      }
     }
   }
 

--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -746,21 +746,28 @@ export function sendMessageToSession(
   // return false so the message stays unconsumed and retries on the next poll.
   if (!session?.sdkQuery || !session.sdkSessionId) return false;
 
-  const effortLevel = normalizeClaudeFollowupEffort(
-    reasoningEffort,
-    session.supportedEffortLevels,
-  );
-  if (session.reasoningEffort !== effortLevel) {
-    session.reasoningEffort = effortLevel;
-    void (async () => {
-      await session.sdkQuery
-        ?.applyFlagSettings({ effortLevel })
-        .catch((err) => {
-          console.error('Failed to apply Claude effort setting:', err);
-        });
-      pushUserMessage(session, text);
-    })();
-    return true;
+  // Only honor an effort change when the caller actually supplied one.
+  // Production callers (e.g. queued follow-ups in subscriptions.ts) can
+  // legitimately omit `reasoningEffort`; treating that as a request to clear
+  // the override would clobber the session's chosen effort on every queued
+  // follow-up.
+  if (reasoningEffort !== undefined) {
+    const effortLevel = normalizeClaudeFollowupEffort(
+      reasoningEffort,
+      session.supportedEffortLevels,
+    );
+    if (session.reasoningEffort !== effortLevel) {
+      session.reasoningEffort = effortLevel;
+      void (async () => {
+        await session.sdkQuery
+          ?.applyFlagSettings({ effortLevel })
+          .catch((err) => {
+            console.error('Failed to apply Claude effort setting:', err);
+          });
+        pushUserMessage(session, text);
+      })();
+      return true;
+    }
   }
 
   return pushUserMessage(session, text);

--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -525,6 +525,10 @@ export async function startSession(opts: {
   };
 
   sdkOptions.model = opts.model ?? DEFAULT_MODEL;
+  // The supported-effort-level list is fetched after sdkQuery is created, so
+  // we can't pre-validate `xhigh`/`max` against the model here. Task 6's
+  // picker is responsible for keeping the client-side selection within the
+  // model's supported range; the manager forwards whatever the caller asks.
   if (session.reasoningEffort) sdkOptions.effort = session.reasoningEffort;
   sdkOptions.promptSuggestions = true;
   sdkOptions.settingSources = ['project'];

--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -1,4 +1,6 @@
 import type {
+  EffortLevel,
+  ModelInfo,
   Query,
   SDKMessage,
   SDKUserMessage,
@@ -32,6 +34,8 @@ type PermissionResult =
       toolUseID?: string;
     };
 
+type ClaudeFollowupEffortSetting = Exclude<EffortLevel, 'max'>;
+
 interface BufferedEvent {
   type: string;
   data: string; // JSON-serialized SDKMessage
@@ -53,6 +57,8 @@ interface Session {
   convexSessionId: string;
   permissionMode: PermissionMode;
   model?: string;
+  reasoningEffort?: EffortLevel;
+  supportedEffortLevels?: EffortLevel[];
   /** The live SDK query object — used to inject follow-up messages. */
   sdkQuery?: Query;
   /** Channel for pushing follow-up messages into the running SDK process. */
@@ -271,6 +277,51 @@ export function isApproachingSessionLimit(): boolean {
   return sessions.size >= WARN_ACTIVE_SESSIONS;
 }
 
+function normalizeClaudeEffort(
+  reasoningEffort: string | undefined,
+  supportedEffortLevels?: EffortLevel[],
+): EffortLevel | undefined {
+  if (
+    reasoningEffort === 'low' ||
+    reasoningEffort === 'medium' ||
+    reasoningEffort === 'high' ||
+    reasoningEffort === 'xhigh' ||
+    reasoningEffort === 'max'
+  ) {
+    if (
+      supportedEffortLevels &&
+      !supportedEffortLevels.includes(reasoningEffort)
+    ) {
+      return undefined;
+    }
+    return reasoningEffort;
+  }
+  return undefined;
+}
+
+function normalizeClaudeFollowupEffort(
+  reasoningEffort: string | undefined,
+  supportedEffortLevels?: EffortLevel[],
+): ClaudeFollowupEffortSetting | undefined {
+  const effort = normalizeClaudeEffort(reasoningEffort, supportedEffortLevels);
+  // The SDK start options support `max`, but `Settings.effortLevel` used for
+  // live follow-ups currently does not. Treat follow-up `max` as auto until the
+  // SDK exposes it there too.
+  if (effort === 'max') return undefined;
+  return effort;
+}
+
+function findModelInfo(
+  models: ModelInfo[],
+  selectedModel: string | undefined,
+): ModelInfo | undefined {
+  if (!selectedModel) return undefined;
+  return models.find(
+    (model) =>
+      model.value === selectedModel || model.displayName === selectedModel,
+  );
+}
+
 /**
  * Spawns a Claude Code SDK process for the given session and begins streaming
  * events to Convex.
@@ -296,6 +347,7 @@ export async function startSession(opts: {
   prompt: string;
   model?: string;
   permissionMode?: PermissionMode;
+  reasoningEffort?: string;
   resumeSdkSessionId?: string;
 }): Promise<{ sessionId: string; warning?: string }> {
   const { sessionId } = opts;
@@ -347,6 +399,7 @@ export async function startSession(opts: {
     convexSessionId: sessionId,
     permissionMode: mode,
     model: opts.model ?? DEFAULT_MODEL,
+    reasoningEffort: normalizeClaudeEffort(opts.reasoningEffort),
     messageChannel: new SdkMessageChannel(),
   };
 
@@ -475,6 +528,8 @@ export async function startSession(opts: {
   };
 
   sdkOptions.model = opts.model ?? DEFAULT_MODEL;
+  const effort = normalizeClaudeEffort(opts.reasoningEffort);
+  if (effort) sdkOptions.effort = effort;
   sdkOptions.promptSuggestions = true;
   sdkOptions.settingSources = ['project'];
 
@@ -501,6 +556,21 @@ async function consumeIterator(
   try {
     const iterator = sdkQuery({ prompt, options });
     session.sdkQuery = iterator;
+
+    const supportedModels = (iterator as Partial<Query>).supportedModels;
+    if (supportedModels) {
+      supportedModels
+        .call(iterator)
+        .then((models) => {
+          const currentModel = findModelInfo(models, session.model);
+          if (currentModel?.supportedEffortLevels) {
+            session.supportedEffortLevels = currentModel.supportedEffortLevels;
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to fetch Claude supported models:', err);
+        });
+    }
 
     // Connect the message channel so follow-up messages can be injected.
     // Fire-and-forget — the promise stays pending until the channel closes.
@@ -666,11 +736,38 @@ export function stopSession(sessionId: string): void {
  * @returns `true` if the message was delivered, `false` if the session is not
  *   running or not yet initialized.
  */
-export function sendMessageToSession(sessionId: string, text: string): boolean {
+export function sendMessageToSession(
+  sessionId: string,
+  text: string,
+  reasoningEffort?: string,
+): boolean {
   const session = sessions.get(sessionId);
   // sdkSessionId is set from the system/init event — if not yet available,
   // return false so the message stays unconsumed and retries on the next poll.
   if (!session?.sdkQuery || !session.sdkSessionId) return false;
+
+  const effortLevel = normalizeClaudeFollowupEffort(
+    reasoningEffort,
+    session.supportedEffortLevels,
+  );
+  if (session.reasoningEffort !== effortLevel) {
+    session.reasoningEffort = effortLevel;
+    void (async () => {
+      await session.sdkQuery
+        ?.applyFlagSettings({ effortLevel })
+        .catch((err) => {
+          console.error('Failed to apply Claude effort setting:', err);
+        });
+      pushUserMessage(session, text);
+    })();
+    return true;
+  }
+
+  return pushUserMessage(session, text);
+}
+
+function pushUserMessage(session: Session, text: string): boolean {
+  if (!session.sdkSessionId) return false;
 
   const userMsg: SDKUserMessage = {
     type: 'user',

--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -316,10 +316,7 @@ function findModelInfo(
   selectedModel: string | undefined,
 ): ModelInfo | undefined {
   if (!selectedModel) return undefined;
-  return models.find(
-    (model) =>
-      model.value === selectedModel || model.displayName === selectedModel,
-  );
+  return models.find((model) => model.value === selectedModel);
 }
 
 /**
@@ -528,8 +525,7 @@ export async function startSession(opts: {
   };
 
   sdkOptions.model = opts.model ?? DEFAULT_MODEL;
-  const effort = normalizeClaudeEffort(opts.reasoningEffort);
-  if (effort) sdkOptions.effort = effort;
+  if (session.reasoningEffort) sdkOptions.effort = session.reasoningEffort;
   sdkOptions.promptSuggestions = true;
   sdkOptions.settingSources = ['project'];
 

--- a/src/codex/manager.test.ts
+++ b/src/codex/manager.test.ts
@@ -205,8 +205,11 @@ describe('codex/manager', () => {
     // Session must still be in the map — only 'failed' status tears it down
     expect(getSession('codex-multiturn')).toBeDefined();
 
-    // Follow-up message must be accepted (returns true) and trigger a second turn.start
-    const delivered = sendMessageToSession('codex-multiturn', 'second turn');
+    // Follow-up message must be accepted (resolves true) and trigger a second turn.start
+    const delivered = await sendMessageToSession(
+      'codex-multiturn',
+      'second turn',
+    );
     expect(delivered).toBe(true);
     await new Promise((resolve) => setTimeout(resolve, 50));
 
@@ -512,10 +515,11 @@ describe('codex/manager', () => {
     // Wait for first turn to fully complete (turn/completed clears currentTurnId)
     await new Promise((r) => setTimeout(r, 50));
 
-    // Now fire two concurrent follow-ups synchronously. The second must be
-    // rejected because the first claimed the turn slot.
-    const accepted1 = sendMessageToSession('codex-reentrancy', 'follow-up A');
-    const accepted2 = sendMessageToSession('codex-reentrancy', 'follow-up B');
+    // Fire two concurrent follow-ups. The second must be rejected synchronously
+    // because the first claimed the turn slot before its async tail runs.
+    const p1 = sendMessageToSession('codex-reentrancy', 'follow-up A');
+    const p2 = sendMessageToSession('codex-reentrancy', 'follow-up B');
+    const [accepted1, accepted2] = await Promise.all([p1, p2]);
     expect(accepted1).toBe(true);
     expect(accepted2).toBe(false);
 
@@ -524,6 +528,97 @@ describe('codex/manager', () => {
 
     // Only one follow-up turn.start call beyond the initial one
     expect(client.turn.start).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns false when turn.start rejects so the pending message is not consumed', async () => {
+    // First turn succeeds; the follow-up turn.start rejects to simulate a
+    // transient app-server failure or an invalid thread state. The caller must
+    // see false so subscriptions.ts leaves the pending message unconsumed and
+    // the next polling tick can retry.
+    const handlers = new Map<
+      string,
+      Array<(notification: Notification) => void>
+    >();
+    const emit = (notification: Notification) => {
+      for (const handler of handlers.get(notification.method) ?? []) {
+        handler(notification);
+      }
+    };
+    let turnStartCalls = 0;
+    const client = {
+      thread: {
+        start: vi.fn().mockResolvedValue({
+          thread: { id: 'thread-fail' },
+          model: 'gpt-5.4-mini',
+          modelProvider: 'openai',
+          serviceTier: null,
+          cwd: '/tmp/repo',
+          approvalPolicy: 'never',
+          approvalsReviewer: 'client',
+          sandbox: { type: 'danger-full-access' },
+          reasoningEffort: 'medium',
+        }),
+        resume: vi.fn(),
+      },
+      turn: {
+        start: vi.fn(async () => {
+          turnStartCalls++;
+          if (turnStartCalls === 1) {
+            // First turn (from startSession) succeeds and completes
+            emit({
+              method: 'turn/started',
+              params: {
+                threadId: 'thread-fail',
+                turn: makeTurn('turn-1', 'inProgress'),
+              },
+            });
+            emit({
+              method: 'turn/completed',
+              params: {
+                threadId: 'thread-fail',
+                turn: makeTurn('turn-1', 'completed'),
+              },
+            });
+            return { turn: makeTurn('turn-1', 'completed') };
+          }
+          throw new Error('app-server unreachable');
+        }),
+        interrupt: vi.fn().mockResolvedValue({}),
+      },
+      onEvent: vi.fn(
+        (method: string, handler: (notification: Notification) => void) => {
+          const existing = handlers.get(method) ?? [];
+          existing.push(handler);
+          handlers.set(method, existing);
+          return () => {
+            handlers.set(
+              method,
+              (handlers.get(method) ?? []).filter((h) => h !== handler),
+            );
+          };
+        },
+      ),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    mockCreateClient.mockResolvedValue(client);
+
+    const { startSession, sendMessageToSession } = await import('./manager');
+
+    await startSession({
+      sessionId: 'codex-turn-fail',
+      repoPath: '/tmp/repo',
+      prompt: 'first',
+      permissionMode: 'bypass',
+      reasoningEffort: 'medium',
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const accepted = await sendMessageToSession(
+      'codex-turn-fail',
+      'follow-up that fails',
+    );
+    expect(accepted).toBe(false);
   });
 
   it('preserves the session reasoningEffort when caller omits it on a follow-up', async () => {
@@ -544,7 +639,10 @@ describe('codex/manager', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     // Caller omits reasoningEffort — must reuse 'high', not undefined.
-    const accepted = sendMessageToSession('codex-effort-keep', 'follow up');
+    const accepted = await sendMessageToSession(
+      'codex-effort-keep',
+      'follow up',
+    );
     expect(accepted).toBe(true);
     await new Promise((r) => setTimeout(r, 50));
 

--- a/src/codex/manager.test.ts
+++ b/src/codex/manager.test.ts
@@ -425,6 +425,107 @@ describe('codex/manager', () => {
     }
   });
 
+  it('rejects a second concurrent follow-up before turn/started lands', async () => {
+    // Custom stub: turn.start does NOT emit turn/started synchronously —
+    // it returns immediately so the test can fire two pending messages
+    // before any event handler claims the slot. The real-world race the
+    // adversarial review found: subscriptions.ts fans out pending messages
+    // with `void handlePendingMessage(msg)`, so two follow-ups for the same
+    // idle session can both pass the `currentTurnId` guard if nothing claims
+    // the slot synchronously.
+    const handlers = new Map<
+      string,
+      Array<(notification: Notification) => void>
+    >();
+    const emit = (notification: Notification) => {
+      for (const handler of handlers.get(notification.method) ?? []) {
+        handler(notification);
+      }
+    };
+    const client = {
+      thread: {
+        start: vi.fn().mockResolvedValue({
+          thread: { id: 'thread-reentrancy' },
+          model: 'gpt-5.4-mini',
+          modelProvider: 'openai',
+          serviceTier: null,
+          cwd: '/tmp/repo',
+          approvalPolicy: 'never',
+          approvalsReviewer: 'client',
+          sandbox: { type: 'danger-full-access' },
+          reasoningEffort: 'medium',
+        }),
+        resume: vi.fn(),
+      },
+      turn: {
+        start: vi.fn(async (params: { input: { text: string }[] }) => {
+          // Emit turn/started AFTER the start response resolves so the
+          // synchronous claim is the only thing protecting the slot.
+          const turnId = `turn-${params.input[0]?.text ?? 'x'}`;
+          queueMicrotask(() => {
+            emit({
+              method: 'turn/started',
+              params: {
+                threadId: 'thread-reentrancy',
+                turn: makeTurn(turnId, 'inProgress'),
+              },
+            });
+            emit({
+              method: 'turn/completed',
+              params: {
+                threadId: 'thread-reentrancy',
+                turn: makeTurn(turnId, 'completed'),
+              },
+            });
+          });
+          return { turn: makeTurn(turnId, 'inProgress') };
+        }),
+        interrupt: vi.fn().mockResolvedValue({}),
+      },
+      onEvent: vi.fn(
+        (method: string, handler: (notification: Notification) => void) => {
+          const existing = handlers.get(method) ?? [];
+          existing.push(handler);
+          handlers.set(method, existing);
+          return () => {
+            handlers.set(
+              method,
+              (handlers.get(method) ?? []).filter((h) => h !== handler),
+            );
+          };
+        },
+      ),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    mockCreateClient.mockResolvedValue(client);
+
+    const { startSession, sendMessageToSession } = await import('./manager');
+
+    await startSession({
+      sessionId: 'codex-reentrancy',
+      repoPath: '/tmp/repo',
+      prompt: 'first turn',
+      permissionMode: 'bypass',
+      reasoningEffort: 'medium',
+    });
+
+    // Wait for first turn to fully complete (turn/completed clears currentTurnId)
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Now fire two concurrent follow-ups synchronously. The second must be
+    // rejected because the first claimed the turn slot.
+    const accepted1 = sendMessageToSession('codex-reentrancy', 'follow-up A');
+    const accepted2 = sendMessageToSession('codex-reentrancy', 'follow-up B');
+    expect(accepted1).toBe(true);
+    expect(accepted2).toBe(false);
+
+    // Wait for the queueMicrotask emits so the turn settles
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Only one follow-up turn.start call beyond the initial one
+    expect(client.turn.start).toHaveBeenCalledTimes(2);
+  });
+
   it('rejects startSession when permissionMode is omitted', async () => {
     const client = makeClientStub();
     mockCreateClient.mockResolvedValue(client);

--- a/src/codex/manager.test.ts
+++ b/src/codex/manager.test.ts
@@ -172,4 +172,40 @@ describe('codex/manager', () => {
       true,
     );
   });
+
+  it('keeps the session alive after an idle turn/completed so follow-ups can run', async () => {
+    const client = makeClientStub();
+    mockCreateClient.mockResolvedValue(client);
+
+    const { startSession, sendMessageToSession, getSession } = await import(
+      './manager'
+    );
+
+    await startSession({
+      sessionId: 'codex-multiturn',
+      repoPath: '/tmp/repo',
+      prompt: 'first turn',
+      permissionMode: 'bypass',
+      reasoningEffort: 'medium',
+    });
+
+    // Let the first turn complete (turn.start emits turn/started + turn/completed)
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Session must still be in the map — only 'failed' status tears it down
+    expect(getSession('codex-multiturn')).toBeDefined();
+
+    // Follow-up message must be accepted (returns true) and trigger a second turn.start
+    const delivered = sendMessageToSession('codex-multiturn', 'second turn');
+    expect(delivered).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(client.turn.start).toHaveBeenCalledTimes(2);
+    expect(client.turn.start).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        threadId: 'thread-123',
+        input: [{ type: 'text', text: 'second turn', text_elements: [] }],
+      }),
+    );
+  });
 });

--- a/src/codex/manager.test.ts
+++ b/src/codex/manager.test.ts
@@ -113,10 +113,20 @@ afterEach(async () => {
   for (const id of getActiveSessions()) {
     stopSession(id);
   }
-  await new Promise((resolve) => setTimeout(resolve, 650));
+  // Poll until the in-memory map is drained (commit 2 makes finishSession
+  // delete synchronously; this returns fast). Then wait a STOP_GRACE_MS-
+  // shaped tail to let the still-pending cleanup mutations (status update,
+  // client.close) settle before the next test installs new mocks.
+  const deadline = Date.now() + 2000;
+  while (getActiveSessions().length > 0 && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  await new Promise((r) => setTimeout(r, 600));
   mockCreateClient.mockReset();
-  mockMutation.mockClear();
-  mockQuery.mockClear();
+  mockMutation.mockReset();
+  mockQuery.mockReset();
+  mockMutation.mockResolvedValue(undefined);
+  mockQuery.mockResolvedValue({ nextBatchIndex: 0 });
 });
 
 describe('codex/manager', () => {
@@ -358,6 +368,61 @@ describe('codex/manager', () => {
     // no gap (i.e. no jump from 0 to 2).
     expect(indices).not.toContain(2);
     expect(indices.filter((i) => i === 0).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('resumes via thread.resume and honors the next batch index from Convex', async () => {
+    const client = makeClientStub();
+    client.thread.resume = vi.fn().mockResolvedValue({
+      thread: { id: 'thread-resumed' },
+      model: 'gpt-5.4-mini',
+      modelProvider: 'openai',
+      serviceTier: null,
+      cwd: '/tmp/repo',
+      approvalPolicy: 'never',
+      approvalsReviewer: 'client',
+      sandbox: { type: 'danger-full-access' },
+      reasoningEffort: 'medium',
+    });
+    mockCreateClient.mockResolvedValue(client);
+    mockQuery.mockResolvedValueOnce({ nextBatchIndex: 7 });
+
+    const { startSession } = await import('./manager');
+
+    await startSession({
+      sessionId: 'codex-resume-test',
+      repoPath: '/tmp/repo',
+      prompt: 'continue',
+      permissionMode: 'bypass',
+      reasoningEffort: 'medium',
+      resumeProviderSessionId: 'thread-resumed',
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(client.thread.resume).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: 'thread-resumed' }),
+    );
+    expect(client.thread.start).not.toHaveBeenCalled();
+
+    // companionGetNextBatchIndex must have been queried
+    const queryCalls = mockQuery.mock.calls;
+    expect(queryCalls.length).toBeGreaterThan(0);
+
+    // First insertBatch should use the returned nextBatchIndex (7), not 0
+    const insertCalls = mockMutation.mock.calls.filter((call) => {
+      const arg = call[1];
+      return (
+        arg &&
+        typeof arg === 'object' &&
+        'events' in (arg as Record<string, unknown>) &&
+        'batchIndex' in (arg as Record<string, unknown>)
+      );
+    });
+    if (insertCalls.length > 0) {
+      const firstBatchIndex = (insertCalls[0]?.[1] as { batchIndex: number })
+        .batchIndex;
+      expect(firstBatchIndex).toBe(7);
+    }
   });
 
   it('rejects startSession when permissionMode is omitted', async () => {

--- a/src/codex/manager.test.ts
+++ b/src/codex/manager.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockCreateClient = vi.fn();
+
+vi.mock('codex-app-server-client', () => ({
+  createClient: mockCreateClient,
+}));
+
+const mockMutation = vi.fn().mockResolvedValue(undefined);
+const mockQuery = vi.fn().mockResolvedValue({ nextBatchIndex: 0 });
+
+vi.mock('@/server/convex-client', () => ({
+  getConvexClient: vi.fn(() => ({ mutation: mockMutation })),
+  getConvexHttpClient: vi.fn(async () => ({ query: mockQuery })),
+}));
+
+interface Notification {
+  method: string;
+  params: {
+    threadId?: string;
+    turn?: {
+      id: string;
+      status: 'completed' | 'interrupted' | 'failed' | 'inProgress';
+      items: unknown[];
+      error: null;
+      startedAt: number | null;
+      completedAt: number | null;
+      durationMs: number | null;
+    };
+  };
+}
+
+type TurnStatus = NonNullable<Notification['params']['turn']>['status'];
+
+function makeTurn(id: string, status: TurnStatus) {
+  return {
+    id,
+    status,
+    items: [],
+    error: null,
+    startedAt: Date.now() / 1000,
+    completedAt: Date.now() / 1000,
+    durationMs: 1,
+  };
+}
+
+function makeClientStub() {
+  const handlers = new Map<
+    string,
+    Array<(notification: Notification) => void>
+  >();
+  const emit = (notification: Notification) => {
+    for (const handler of handlers.get(notification.method) ?? []) {
+      handler(notification);
+    }
+  };
+
+  return {
+    thread: {
+      start: vi.fn().mockResolvedValue({
+        thread: { id: 'thread-123' },
+        model: 'gpt-5.4-mini',
+        modelProvider: 'openai',
+        serviceTier: null,
+        cwd: '/tmp/repo',
+        approvalPolicy: 'never',
+        approvalsReviewer: 'client',
+        sandbox: { type: 'danger-full-access' },
+        reasoningEffort: 'medium',
+      }),
+      resume: vi.fn(),
+    },
+    turn: {
+      start: vi.fn(async () => {
+        emit({
+          method: 'turn/started',
+          params: {
+            threadId: 'thread-123',
+            turn: makeTurn('turn-123', 'inProgress'),
+          },
+        });
+        emit({
+          method: 'turn/completed',
+          params: {
+            threadId: 'thread-123',
+            turn: makeTurn('turn-123', 'completed'),
+          },
+        });
+        return { turn: makeTurn('turn-123', 'completed') };
+      }),
+      interrupt: vi.fn().mockResolvedValue({}),
+    },
+    onEvent: vi.fn(
+      (method: string, handler: (notification: Notification) => void) => {
+        const existing = handlers.get(method) ?? [];
+        existing.push(handler);
+        handlers.set(method, existing);
+        return () => {
+          handlers.set(
+            method,
+            (handlers.get(method) ?? []).filter((h) => h !== handler),
+          );
+        };
+      },
+    ),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+afterEach(async () => {
+  const { getActiveSessions, stopSession } = await import('./manager');
+  for (const id of getActiveSessions()) {
+    stopSession(id);
+  }
+  await new Promise((resolve) => setTimeout(resolve, 650));
+  mockCreateClient.mockReset();
+  mockMutation.mockClear();
+  mockQuery.mockClear();
+});
+
+describe('codex/manager', () => {
+  it('starts a bypass turn, persists providerSessionId, and flushes completion events', async () => {
+    const client = makeClientStub();
+    mockCreateClient.mockResolvedValue(client);
+
+    const { startSession } = await import('./manager');
+
+    await startSession({
+      sessionId: 'codex-session-id',
+      repoPath: '/tmp/repo',
+      prompt: 'say hello',
+      permissionMode: 'bypass',
+      reasoningEffort: 'medium',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 650));
+
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/tmp/repo' }),
+    );
+    expect(client.thread.start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: '/tmp/repo',
+        approvalPolicy: 'never',
+      }),
+    );
+    expect(client.turn.start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: 'thread-123',
+        approvalPolicy: 'never',
+        effort: 'medium',
+      }),
+    );
+
+    const providerCall = mockMutation.mock.calls.find(
+      (call) =>
+        typeof call[1] === 'object' &&
+        (call[1] as Record<string, unknown>).providerSessionId === 'thread-123',
+    );
+    expect(providerCall).toBeDefined();
+
+    const eventCalls = mockMutation.mock.calls.filter(
+      (call) =>
+        typeof call[1] === 'object' &&
+        'events' in (call[1] as Record<string, unknown>),
+    );
+    const events = eventCalls.flatMap(
+      (call) => (call[1] as { events: Array<{ type: string }> }).events,
+    );
+    expect(events.some((event) => event.type === 'codex.turn/completed')).toBe(
+      true,
+    );
+  });
+});

--- a/src/codex/manager.test.ts
+++ b/src/codex/manager.test.ts
@@ -526,6 +526,33 @@ describe('codex/manager', () => {
     expect(client.turn.start).toHaveBeenCalledTimes(2);
   });
 
+  it('preserves the session reasoningEffort when caller omits it on a follow-up', async () => {
+    const client = makeClientStub();
+    mockCreateClient.mockResolvedValue(client);
+
+    const { startSession, sendMessageToSession } = await import('./manager');
+
+    await startSession({
+      sessionId: 'codex-effort-keep',
+      repoPath: '/tmp/repo',
+      prompt: 'first',
+      permissionMode: 'bypass',
+      reasoningEffort: 'high',
+    });
+
+    // Let first turn settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Caller omits reasoningEffort — must reuse 'high', not undefined.
+    const accepted = sendMessageToSession('codex-effort-keep', 'follow up');
+    expect(accepted).toBe(true);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(client.turn.start).toHaveBeenLastCalledWith(
+      expect.objectContaining({ effort: 'high' }),
+    );
+  });
+
   it('rejects startSession when permissionMode is omitted', async () => {
     const client = makeClientStub();
     mockCreateClient.mockResolvedValue(client);

--- a/src/codex/manager.test.ts
+++ b/src/codex/manager.test.ts
@@ -305,4 +305,58 @@ describe('codex/manager', () => {
     );
     expect(finalStatusCalls).toHaveLength(1);
   });
+
+  it('does not advance batchIndex when companionInsertBatch fails', async () => {
+    const client = makeClientStub();
+    mockCreateClient.mockResolvedValue(client);
+
+    // Reject the first event-batch insert, then succeed for subsequent calls.
+    let firstInsertSeen = false;
+    mockMutation.mockImplementation(
+      (_path: unknown, args: Record<string, unknown> | undefined) => {
+        if (
+          args &&
+          typeof args === 'object' &&
+          'events' in args &&
+          'batchIndex' in args
+        ) {
+          if (!firstInsertSeen) {
+            firstInsertSeen = true;
+            return Promise.reject(new Error('convex transient failure'));
+          }
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    const { startSession } = await import('./manager');
+
+    await startSession({
+      sessionId: 'codex-batchindex',
+      repoPath: '/tmp/repo',
+      prompt: 'test',
+      permissionMode: 'bypass',
+      reasoningEffort: 'medium',
+    });
+
+    // Wait for retries / subsequent flushes to settle.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const insertCalls = mockMutation.mock.calls.filter((call) => {
+      const arg = call[1];
+      return (
+        arg &&
+        typeof arg === 'object' &&
+        'events' in (arg as Record<string, unknown>) &&
+        'batchIndex' in (arg as Record<string, unknown>)
+      );
+    });
+    const indices = insertCalls
+      .map((c) => (c[1] as { batchIndex: number }).batchIndex)
+      .sort((a, b) => a - b);
+    // First insert rejected; the rejected index must be reused on retry —
+    // no gap (i.e. no jump from 0 to 2).
+    expect(indices).not.toContain(2);
+    expect(indices.filter((i) => i === 0).length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/src/codex/manager.test.ts
+++ b/src/codex/manager.test.ts
@@ -359,4 +359,23 @@ describe('codex/manager', () => {
     expect(indices).not.toContain(2);
     expect(indices.filter((i) => i === 0).length).toBeGreaterThanOrEqual(1);
   });
+
+  it('rejects startSession when permissionMode is omitted', async () => {
+    const client = makeClientStub();
+    mockCreateClient.mockResolvedValue(client);
+
+    const { startSession } = await import('./manager');
+
+    // Cast through `unknown` — TS already enforces the requirement, but the
+    // runtime guard catches callers that drift in via dynamic dispatch (e.g.
+    // a future Convex-driven dispatcher passing a partial config).
+    await expect(
+      startSession({
+        sessionId: 'codex-no-mode',
+        repoPath: '/tmp/repo',
+        prompt: 'test',
+        reasoningEffort: 'medium',
+      } as unknown as Parameters<typeof startSession>[0]),
+    ).rejects.toThrow(/Invalid permissionMode/);
+  });
 });

--- a/src/codex/manager.test.ts
+++ b/src/codex/manager.test.ts
@@ -208,4 +208,101 @@ describe('codex/manager', () => {
       }),
     );
   });
+
+  it('finishSession is idempotent when stopSession races a failed turn/completed', async () => {
+    // Race: handleNotification fires finishSession on a 'failed' turn while
+    // stopSession's finally also calls finishSession. Both pass the
+    // `if (!session) return` guard before any await unless the map is cleared
+    // synchronously at the top.
+    const handlers = new Map<
+      string,
+      Array<(notification: Notification) => void>
+    >();
+    const emit = (notification: Notification) => {
+      for (const handler of handlers.get(notification.method) ?? []) {
+        handler(notification);
+      }
+    };
+    const client = {
+      thread: {
+        start: vi.fn().mockResolvedValue({
+          thread: { id: 'thread-race' },
+          model: 'gpt-5.4-mini',
+          modelProvider: 'openai',
+          serviceTier: null,
+          cwd: '/tmp/repo',
+          approvalPolicy: 'never',
+          approvalsReviewer: 'client',
+          sandbox: { type: 'danger-full-access' },
+          reasoningEffort: 'medium',
+        }),
+        resume: vi.fn(),
+      },
+      turn: {
+        start: vi.fn(async () => {
+          emit({
+            method: 'turn/started',
+            params: {
+              threadId: 'thread-race',
+              turn: makeTurn('turn-race', 'inProgress'),
+            },
+          });
+          return { turn: makeTurn('turn-race', 'inProgress') };
+        }),
+        interrupt: vi.fn(async () => {
+          // Synthesize a 'failed' turn/completed (rather than 'interrupted')
+          // to drive both finishSession entry points concurrently.
+          emit({
+            method: 'turn/completed',
+            params: {
+              threadId: 'thread-race',
+              turn: makeTurn('turn-race', 'failed'),
+            },
+          });
+          return {};
+        }),
+      },
+      onEvent: vi.fn(
+        (method: string, handler: (notification: Notification) => void) => {
+          const existing = handlers.get(method) ?? [];
+          existing.push(handler);
+          handlers.set(method, existing);
+          return () => {
+            handlers.set(
+              method,
+              (handlers.get(method) ?? []).filter((h) => h !== handler),
+            );
+          };
+        },
+      ),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    mockCreateClient.mockResolvedValue(client);
+
+    const { startSession, stopSession } = await import('./manager');
+
+    await startSession({
+      sessionId: 'codex-race',
+      repoPath: '/tmp/repo',
+      prompt: 'long task',
+      permissionMode: 'bypass',
+      reasoningEffort: 'medium',
+    });
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    stopSession('codex-race');
+
+    await new Promise((r) => setTimeout(r, 700));
+
+    // Exactly one teardown despite both paths racing in.
+    expect(client.close).toHaveBeenCalledTimes(1);
+    const finalStatusCalls = mockMutation.mock.calls.filter(
+      (call) =>
+        typeof call[1] === 'object' &&
+        ((call[1] as Record<string, unknown>).status === 'idle' ||
+          (call[1] as Record<string, unknown>).status === 'failed'),
+    );
+    expect(finalStatusCalls).toHaveLength(1);
+  });
 });

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -248,6 +248,11 @@ async function finishSession(
   const session = sessions.get(sessionId);
   if (!session) return;
 
+  // Claim ownership synchronously: deleting from the map before any await
+  // ensures concurrent finishSession calls (e.g. user `stopSession` racing the
+  // post-`interrupt` `turn/completed`) bail at the guard above instead of
+  // double-closing the client and writing duplicate Convex statuses.
+  sessions.delete(sessionId);
   session.currentTurnId = undefined;
 
   await sleep(STOP_GRACE_MS);
@@ -271,7 +276,6 @@ async function finishSession(
   await session.client.close().catch((err: unknown) => {
     console.error('Failed to close Codex client:', err);
   });
-  sessions.delete(sessionId);
 }
 
 async function startTurn(

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -444,11 +444,11 @@ export function stopSession(sessionId: string): void {
   })();
 }
 
-export function sendMessageToSession(
+export async function sendMessageToSession(
   sessionId: string,
   text: string,
   reasoningEffort?: string,
-): boolean {
+): Promise<boolean> {
   const session = sessions.get(sessionId);
   if (!session || session.currentTurnId) return false;
 
@@ -469,15 +469,19 @@ export function sendMessageToSession(
   if (reasoningEffort !== undefined) {
     session.reasoningEffort = effort;
   }
-  void startTurn(session, text, effort).catch((err) => {
+
+  try {
+    await startTurn(session, text, effort);
+    return true;
+  } catch (err) {
     console.error(`[codex session ${sessionId}] failed to start turn:`, err);
-    // Release the sentinel if turn.start never landed — finishSession will
-    // also clear it, but bailing here avoids a poisoned slot if the failure
-    // path never reaches finishSession (e.g. session already removed).
+    // Release the sentinel so the next polling tick can retry the message.
+    // finishSession will also clear it, but bailing here avoids a poisoned
+    // slot if the failure path never reaches finishSession.
     if (session.currentTurnId === TURN_PENDING_SENTINEL) {
       session.currentTurnId = undefined;
     }
     void finishSession(sessionId, 'failed');
-  });
-  return true;
+    return false;
+  }
 }

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -467,8 +467,17 @@ export function sendMessageToSession(
   // open overlapping turns on the same Codex thread.
   session.currentTurnId = TURN_PENDING_SENTINEL;
 
-  const effort = normalizeReasoningEffort(reasoningEffort);
-  session.reasoningEffort = effort;
+  // Only honor an effort change when the caller explicitly supplied one.
+  // Production callers (queued follow-ups in subscriptions.ts) often omit
+  // this; treating that as a request to clear the override would silently
+  // drop the user's chosen effort on every queued follow-up.
+  const effort =
+    reasoningEffort !== undefined
+      ? normalizeReasoningEffort(reasoningEffort)
+      : session.reasoningEffort;
+  if (reasoningEffort !== undefined) {
+    session.reasoningEffort = effort;
+  }
   void startTurn(session, text, effort).catch((err) => {
     console.error(`[codex session ${sessionId}] failed to start turn:`, err);
     // Release the sentinel if turn.start never landed — finishSession will

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -34,6 +34,9 @@ interface Session {
   client: AppServerClient;
   threadId: string;
   currentTurnId?: string;
+  /** ID of the most recently completed turn — used to suppress the
+   * `turn.start` response-id fallback once that turn has already terminated. */
+  lastCompletedTurnId?: string;
   controller: AbortController;
   eventBuffer: BufferedEvent[];
   batchIndex: number;
@@ -213,9 +216,28 @@ function handleNotification(
   bufferEvent(session, notification);
 
   if (notification.method === 'turn/completed') {
-    const finalStatus =
-      notification.params.turn.status === 'failed' ? 'failed' : 'idle';
-    void finishSession(session.convexSessionId, finalStatus);
+    session.currentTurnId = undefined;
+    session.lastCompletedTurnId = notification.params.turn.id;
+    if (notification.params.turn.status === 'failed') {
+      void finishSession(session.convexSessionId, 'failed');
+      return;
+    }
+    // Idle: keep the session alive for follow-up turns. Flush any buffered
+    // events (the SDK can settle without further activity) and update Convex
+    // status so the UI shows the session as resumable.
+    void flushEvents(session).then(async () => {
+      try {
+        const client = getConvexClient();
+        if (client) {
+          await client.mutation(api.sessions.companionUpdateStatus, {
+            id: session.convexSessionId as Id<'sessions'>,
+            status: 'idle',
+          });
+        }
+      } catch (err) {
+        console.error('Failed to mark Codex session idle in Convex:', err);
+      }
+    });
   }
 }
 
@@ -266,8 +288,15 @@ async function startTurn(
 
   // `turn/started` is the authoritative stream event, but keeping the response
   // id as a fallback avoids a brief uninterruptible gap on clients that suppress
-  // the lifecycle notification.
-  session.currentTurnId ??= response.turn.id;
+  // the lifecycle notification. Skip the fallback if the turn already terminated
+  // (turn/completed cleared currentTurnId and recorded the id) — otherwise we'd
+  // resurrect a dead turn id and break follow-ups.
+  if (
+    session.currentTurnId === undefined &&
+    session.lastCompletedTurnId !== response.turn.id
+  ) {
+    session.currentTurnId = response.turn.id;
+  }
 }
 
 export async function startSession(opts: {

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -282,6 +282,11 @@ async function finishSession(
   });
 }
 
+// Sentinel placed in currentTurnId between accepting a follow-up and the real
+// turn id arriving via turn/started. Prevents a re-entrant sendMessageToSession
+// from passing the `currentTurnId` check while we're awaiting turn.start.
+const TURN_PENDING_SENTINEL = '__codex_turn_pending__';
+
 async function startTurn(
   session: Session,
   text: string,
@@ -296,11 +301,13 @@ async function startTurn(
 
   // `turn/started` is the authoritative stream event, but keeping the response
   // id as a fallback avoids a brief uninterruptible gap on clients that suppress
-  // the lifecycle notification. Skip the fallback if the turn already terminated
-  // (turn/completed cleared currentTurnId and recorded the id) — otherwise we'd
-  // resurrect a dead turn id and break follow-ups.
+  // the lifecycle notification. Promote the pending sentinel to the real id;
+  // skip the fallback if the turn already terminated (turn/completed cleared
+  // currentTurnId and recorded the id) — otherwise we'd resurrect a dead turn
+  // id and break follow-ups.
   if (
-    session.currentTurnId === undefined &&
+    (session.currentTurnId === undefined ||
+      session.currentTurnId === TURN_PENDING_SENTINEL) &&
     session.lastCompletedTurnId !== response.turn.id
   ) {
     session.currentTurnId = response.turn.id;
@@ -454,10 +461,22 @@ export function sendMessageToSession(
   const session = sessions.get(sessionId);
   if (!session || session.currentTurnId) return false;
 
+  // Claim the turn slot synchronously. Two pending messages dispatched
+  // concurrently (e.g. via parallel `void handlePendingMessage(msg)` calls in
+  // the subscription layer) would otherwise both pass the guard above and
+  // open overlapping turns on the same Codex thread.
+  session.currentTurnId = TURN_PENDING_SENTINEL;
+
   const effort = normalizeReasoningEffort(reasoningEffort);
   session.reasoningEffort = effort;
   void startTurn(session, text, effort).catch((err) => {
     console.error(`[codex session ${sessionId}] failed to start turn:`, err);
+    // Release the sentinel if turn.start never landed — finishSession will
+    // also clear it, but bailing here avoids a poisoned slot if the failure
+    // path never reaches finishSession (e.g. session already removed).
+    if (session.currentTurnId === TURN_PENDING_SENTINEL) {
+      session.currentTurnId = undefined;
+    }
     void finishSession(sessionId, 'failed');
   });
   return true;

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -1,0 +1,427 @@
+import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
+import {
+  type AppServerClient,
+  type AppServerClientEventMethod,
+  type AppServerClientNotification,
+  createClient,
+} from 'codex-app-server-client';
+import { DEFAULT_CODEX_MODEL } from '@/constants';
+import { getConvexClient, getConvexHttpClient } from '@/server/convex-client';
+
+export type PermissionMode = 'default' | 'safe-auto' | 'bypass';
+
+const VALID_PERMISSION_MODES = new Set<PermissionMode>([
+  'default',
+  'safe-auto',
+  'bypass',
+]);
+
+type ReasoningEffort = NonNullable<
+  Parameters<AppServerClient['turn']['start']>[0]['effort']
+>;
+type ApprovalPolicy = NonNullable<
+  Parameters<AppServerClient['turn']['start']>[0]['approvalPolicy']
+>;
+
+interface BufferedEvent {
+  type: string;
+  data: string;
+  timestamp: number;
+}
+
+interface Session {
+  client: AppServerClient;
+  threadId: string;
+  currentTurnId?: string;
+  controller: AbortController;
+  eventBuffer: BufferedEvent[];
+  batchIndex: number;
+  flushing: boolean;
+  stoppedByUser: boolean;
+  permissionMode: PermissionMode;
+  model: string;
+  reasoningEffort?: ReasoningEffort;
+  convexSessionId: string;
+  unsubscribers: Array<() => void>;
+}
+
+const sessions = new Map<string, Session>();
+
+const MAX_ACTIVE_SESSIONS = 10;
+const WARN_ACTIVE_SESSIONS = 5;
+const STOP_GRACE_MS = 500;
+
+const CODEX_EVENT_METHODS: AppServerClientEventMethod[] = [
+  'error',
+  'thread/started',
+  'thread/status/changed',
+  'thread/archived',
+  'thread/unarchived',
+  'thread/closed',
+  'skills/changed',
+  'thread/name/updated',
+  'thread/tokenUsage/updated',
+  'turn/started',
+  'hook/started',
+  'turn/completed',
+  'hook/completed',
+  'turn/diff/updated',
+  'turn/plan/updated',
+  'item/started',
+  'item/autoApprovalReview/started',
+  'item/autoApprovalReview/completed',
+  'item/completed',
+  'rawResponseItem/completed',
+  'item/agentMessage/delta',
+  'item/plan/delta',
+  'command/exec/outputDelta',
+  'item/commandExecution/outputDelta',
+  'item/commandExecution/terminalInteraction',
+  'item/fileChange/outputDelta',
+  'serverRequest/resolved',
+  'item/mcpToolCall/progress',
+  'mcpServer/oauthLogin/completed',
+  'mcpServer/startupStatus/updated',
+  'account/updated',
+  'account/rateLimits/updated',
+  'app/list/updated',
+  'fs/changed',
+  'item/reasoning/summaryTextDelta',
+  'item/reasoning/summaryPartAdded',
+  'item/reasoning/textDelta',
+  'thread/compacted',
+  'model/rerouted',
+  'deprecationNotice',
+  'configWarning',
+  'fuzzyFileSearch/sessionUpdated',
+  'fuzzyFileSearch/sessionCompleted',
+  'thread/realtime/started',
+  'thread/realtime/itemAdded',
+  'thread/realtime/transcriptUpdated',
+  'thread/realtime/outputAudio/delta',
+  'thread/realtime/sdp',
+  'thread/realtime/error',
+  'thread/realtime/closed',
+  'windows/worldWritableWarning',
+  'windowsSandbox/setupCompleted',
+  'account/login/completed',
+];
+
+function normalizeReasoningEffort(
+  reasoningEffort: string | undefined,
+): ReasoningEffort | undefined {
+  if (
+    reasoningEffort === 'minimal' ||
+    reasoningEffort === 'low' ||
+    reasoningEffort === 'medium' ||
+    reasoningEffort === 'high'
+  ) {
+    return reasoningEffort;
+  }
+  return undefined;
+}
+
+function approvalPolicyForMode(mode: PermissionMode): ApprovalPolicy {
+  // Task 3 deliberately has no approval handlers. Only bypass can make forward
+  // progress until Task 5 wires request handling.
+  if (mode === 'bypass') return 'never';
+  throw new Error(`Codex permissionMode is not supported yet: ${mode}`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function flushEvents(session: Session): Promise<void> {
+  if (session.eventBuffer.length === 0) return;
+
+  while (session.flushing) {
+    await sleep(50);
+  }
+  if (session.eventBuffer.length === 0) return;
+
+  session.flushing = true;
+  const events = [...session.eventBuffer];
+  session.eventBuffer = [];
+
+  try {
+    const client = getConvexClient();
+    if (!client) {
+      session.eventBuffer.unshift(...events);
+      return;
+    }
+    const batchIndex = session.batchIndex++;
+    await client.mutation(api.sessionEvents.companionInsertBatch, {
+      sessionId: session.convexSessionId as Id<'sessions'>,
+      events,
+      batchIndex,
+    });
+  } catch (err) {
+    console.error('Failed to flush Codex events to Convex:', err);
+    session.eventBuffer.unshift(...events);
+  } finally {
+    session.flushing = false;
+  }
+}
+
+function bufferEvent(
+  session: Session,
+  event: AppServerClientNotification,
+): void {
+  session.eventBuffer.push({
+    type: `codex.${event.method}`,
+    data: JSON.stringify(event),
+    timestamp: Date.now(),
+  });
+  void flushEvents(session);
+}
+
+export function getSession(sessionId: string): Session | undefined {
+  return sessions.get(sessionId);
+}
+
+export function getActiveSessions(): string[] {
+  return Array.from(sessions.keys());
+}
+
+export function getActiveSessionCount(): number {
+  return sessions.size;
+}
+
+export function isApproachingSessionLimit(): boolean {
+  return sessions.size >= WARN_ACTIVE_SESSIONS;
+}
+
+function subscribeToEvents(session: Session): void {
+  for (const method of CODEX_EVENT_METHODS) {
+    const unsubscribe = session.client.onEvent(method, (notification) => {
+      handleNotification(session, notification as AppServerClientNotification);
+    });
+    session.unsubscribers.push(unsubscribe);
+  }
+}
+
+function handleNotification(
+  session: Session,
+  notification: AppServerClientNotification,
+): void {
+  if (notification.method === 'turn/started') {
+    session.currentTurnId = notification.params.turn.id;
+  }
+
+  bufferEvent(session, notification);
+
+  if (notification.method === 'turn/completed') {
+    const finalStatus =
+      notification.params.turn.status === 'failed' ? 'failed' : 'idle';
+    void finishSession(session.convexSessionId, finalStatus);
+  }
+}
+
+async function finishSession(
+  sessionId: string,
+  status: 'idle' | 'failed',
+): Promise<void> {
+  const session = sessions.get(sessionId);
+  if (!session) return;
+
+  session.currentTurnId = undefined;
+
+  await sleep(STOP_GRACE_MS);
+  await flushEvents(session);
+
+  try {
+    const client = getConvexClient();
+    if (client) {
+      await client.mutation(api.sessions.companionUpdateStatus, {
+        id: session.convexSessionId as Id<'sessions'>,
+        status,
+      });
+    }
+  } catch (err) {
+    console.error('Failed to update Codex session status in Convex:', err);
+  }
+
+  for (const unsubscribe of session.unsubscribers) {
+    unsubscribe();
+  }
+  await session.client.close().catch((err: unknown) => {
+    console.error('Failed to close Codex client:', err);
+  });
+  sessions.delete(sessionId);
+}
+
+async function startTurn(
+  session: Session,
+  text: string,
+  reasoningEffort = session.reasoningEffort,
+): Promise<void> {
+  const response = await session.client.turn.start({
+    threadId: session.threadId,
+    input: [{ type: 'text', text, text_elements: [] }],
+    approvalPolicy: approvalPolicyForMode(session.permissionMode),
+    effort: reasoningEffort,
+  });
+
+  // `turn/started` is the authoritative stream event, but keeping the response
+  // id as a fallback avoids a brief uninterruptible gap on clients that suppress
+  // the lifecycle notification.
+  session.currentTurnId ??= response.turn.id;
+}
+
+export async function startSession(opts: {
+  sessionId: string;
+  repoPath: string;
+  prompt: string;
+  model?: string;
+  permissionMode?: PermissionMode;
+  reasoningEffort?: string;
+  resumeProviderSessionId?: string;
+}): Promise<{ sessionId: string; warning?: string }> {
+  const { sessionId } = opts;
+  const activeCount = sessions.size;
+  if (activeCount >= MAX_ACTIVE_SESSIONS) {
+    throw new Error(
+      `Maximum concurrent session limit reached (${MAX_ACTIVE_SESSIONS}). Stop an existing session before starting a new one.`,
+    );
+  }
+
+  const warning =
+    activeCount >= WARN_ACTIVE_SESSIONS
+      ? `Warning: ${activeCount} active sessions running. Consider stopping idle sessions to free resources.`
+      : undefined;
+
+  const mode = opts.permissionMode ?? 'bypass';
+  if (!VALID_PERMISSION_MODES.has(mode)) {
+    throw new Error(`Invalid permissionMode: ${mode}`);
+  }
+
+  let initialBatchIndex = 0;
+  if (opts.resumeProviderSessionId) {
+    try {
+      const httpClient = await getConvexHttpClient();
+      if (!httpClient) throw new Error('Convex client not initialized');
+      const result = await httpClient.query(
+        api.sessionEvents.companionGetNextBatchIndex,
+        { sessionId: sessionId as Id<'sessions'> },
+      );
+      initialBatchIndex = result.nextBatchIndex;
+    } catch (err) {
+      console.error('Failed to fetch next Codex batch index:', err);
+      throw new Error(
+        'Cannot resume Codex session: failed to determine batch index',
+      );
+    }
+  }
+
+  const controller = new AbortController();
+  const model = opts.model ?? DEFAULT_CODEX_MODEL;
+  const reasoningEffort = normalizeReasoningEffort(opts.reasoningEffort);
+  const approvalPolicy = approvalPolicyForMode(mode);
+
+  const codexEnv = { ...process.env };
+  delete codexEnv.CLAUDECODE;
+  delete codexEnv.CLAUDE_CODE_ENTRYPOINT;
+
+  const client = await createClient({
+    cwd: opts.repoPath,
+    env: codexEnv,
+  });
+
+  try {
+    const threadResponse = opts.resumeProviderSessionId
+      ? await client.thread.resume({
+          threadId: opts.resumeProviderSessionId,
+          cwd: opts.repoPath,
+          model,
+          approvalPolicy,
+          sandbox: mode === 'bypass' ? 'danger-full-access' : 'workspace-write',
+          persistExtendedHistory: false,
+        })
+      : await client.thread.start({
+          cwd: opts.repoPath,
+          model,
+          approvalPolicy,
+          sandbox: mode === 'bypass' ? 'danger-full-access' : 'workspace-write',
+        });
+
+    const threadId = threadResponse.thread.id;
+    const session: Session = {
+      client,
+      threadId,
+      controller,
+      eventBuffer: [],
+      batchIndex: initialBatchIndex,
+      flushing: false,
+      stoppedByUser: false,
+      permissionMode: mode,
+      model,
+      reasoningEffort,
+      convexSessionId: sessionId,
+      unsubscribers: [],
+    };
+    sessions.set(sessionId, session);
+    subscribeToEvents(session);
+
+    const convexClient = getConvexClient();
+    if (convexClient) {
+      await convexClient.mutation(
+        api.sessions.companionUpdateProviderSessionId,
+        {
+          id: sessionId as Id<'sessions'>,
+          providerSessionId: threadId,
+          model,
+          permissionMode: mode,
+        },
+      );
+    }
+
+    await startTurn(session, opts.prompt, reasoningEffort);
+  } catch (err) {
+    await client.close().catch(() => undefined);
+    sessions.delete(sessionId);
+    throw err;
+  }
+
+  return { sessionId, warning };
+}
+
+export function stopSession(sessionId: string): void {
+  const session = sessions.get(sessionId);
+  if (!session) return;
+  session.stoppedByUser = true;
+  session.controller.abort();
+
+  void (async () => {
+    try {
+      if (session.currentTurnId) {
+        await session.client.turn.interrupt({
+          threadId: session.threadId,
+          turnId: session.currentTurnId,
+        });
+      }
+    } catch (err) {
+      console.error('Failed to interrupt Codex turn:', err);
+    } finally {
+      await finishSession(sessionId, 'idle');
+    }
+  })();
+}
+
+export function sendMessageToSession(
+  sessionId: string,
+  text: string,
+  reasoningEffort?: string,
+): boolean {
+  const session = sessions.get(sessionId);
+  if (!session || session.currentTurnId) return false;
+
+  const effort = normalizeReasoningEffort(reasoningEffort);
+  session.reasoningEffort = effort;
+  void startTurn(session, text, effort).catch((err) => {
+    console.error(`[codex session ${sessionId}] failed to start turn:`, err);
+    void finishSession(sessionId, 'failed');
+  });
+  return true;
+}

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -312,7 +312,7 @@ export async function startSession(opts: {
   repoPath: string;
   prompt: string;
   model?: string;
-  permissionMode?: PermissionMode;
+  permissionMode: PermissionMode;
   reasoningEffort?: string;
   resumeProviderSessionId?: string;
 }): Promise<{ sessionId: string; warning?: string }> {
@@ -329,8 +329,8 @@ export async function startSession(opts: {
       ? `Warning: ${activeCount} active sessions running. Consider stopping idle sessions to free resources.`
       : undefined;
 
-  const mode = opts.permissionMode ?? 'bypass';
-  if (!VALID_PERMISSION_MODES.has(mode)) {
+  const mode = opts.permissionMode;
+  if (!mode || !VALID_PERMISSION_MODES.has(mode)) {
     throw new Error(`Invalid permissionMode: ${mode}`);
   }
 

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -430,7 +430,10 @@ export function stopSession(sessionId: string): void {
 
   void (async () => {
     try {
-      if (session.currentTurnId) {
+      if (
+        session.currentTurnId &&
+        session.currentTurnId !== TURN_PENDING_SENTINEL
+      ) {
         await session.client.turn.interrupt({
           threadId: session.threadId,
           turnId: session.currentTurnId,

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -154,12 +154,16 @@ async function flushEvents(session: Session): Promise<void> {
       session.eventBuffer.unshift(...events);
       return;
     }
-    const batchIndex = session.batchIndex++;
+    // Don't advance batchIndex until the mutation succeeds — otherwise a
+    // failure leaves a permanent gap when the next flush retries the
+    // restored events under a higher index.
+    const batchIndex = session.batchIndex;
     await client.mutation(api.sessionEvents.companionInsertBatch, {
       sessionId: session.convexSessionId as Id<'sessions'>,
       events,
       batchIndex,
     });
+    session.batchIndex = batchIndex + 1;
   } catch (err) {
     console.error('Failed to flush Codex events to Convex:', err);
     session.eventBuffer.unshift(...events);

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -227,21 +227,12 @@ function handleNotification(
       return;
     }
     // Idle: keep the session alive for follow-up turns. Flush any buffered
-    // events (the SDK can settle without further activity) and update Convex
-    // status so the UI shows the session as resumable.
-    void flushEvents(session).then(async () => {
-      try {
-        const client = getConvexClient();
-        if (client) {
-          await client.mutation(api.sessions.companionUpdateStatus, {
-            id: session.convexSessionId as Id<'sessions'>,
-            status: 'idle',
-          });
-        }
-      } catch (err) {
-        console.error('Failed to mark Codex session idle in Convex:', err);
-      }
-    });
+    // events but leave the Convex `status` as `'running'` — the session is
+    // still active locally and the upcoming subscription dispatcher routes
+    // follow-ups through `sessionMessages` → `sendMessageToSession`, not
+    // `queueResume` (which `handleQueuedSession` short-circuits when a local
+    // session exists). Writing `'idle'` here would create a stuck-queue race.
+    void flushEvents(session);
   }
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,12 +54,18 @@ export const CODEX_EFFORTS = ['minimal', 'low', 'medium', 'high'] as const;
 
 /**
  * Claude effort picker values. `'auto'` = omit `effort` / `effortLevel`, let
- * adaptive thinking drive (matches Claude Code CLI `/effort auto`). `'max'`
- * omitted — start-only per SDK `Settings.effortLevel`. `'xhigh'` (Opus 4.7)
- * not yet in `@anthropic-ai/claude-agent-sdk@0.2.112`; add when the SDK
- * exposes it.
+ * adaptive thinking drive (matches Claude Code CLI `/effort auto`). The
+ * companion narrows these dynamically per selected model when the Claude SDK
+ * exposes `supportedEffortLevels`.
  */
-export const CLAUDE_EFFORTS = ['auto', 'low', 'medium', 'high'] as const;
+export const CLAUDE_EFFORTS = [
+  'auto',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const;
 
 export const DEFAULT_CODEX_EFFORT: (typeof CODEX_EFFORTS)[number] = 'medium';
 export const DEFAULT_CLAUDE_EFFORT: (typeof CLAUDE_EFFORTS)[number] = 'auto';

--- a/src/server/subscriptions.ts
+++ b/src/server/subscriptions.ts
@@ -128,7 +128,7 @@ async function handlePendingMessage(msg: PendingMessage): Promise<void> {
 
   inFlightMessages.add(msg._id);
   try {
-    const delivered = sendMessageToSession(msg.sessionId, msg.text);
+    const delivered = await sendMessageToSession(msg.sessionId, msg.text);
     if (delivered) {
       await client.mutation(api.sessionMessages.companionMarkConsumed, {
         id: msg._id,


### PR DESCRIPTION
## Summary

- Adds `src/codex/manager.ts`: a new Codex session manager built on `codex-app-server-client`. Handles thread/turn lifecycle, event buffering → Convex flush, session resume, and stop/interrupt.
- Adds `src/codex/manager.test.ts` covering thread start, turn dispatch, `providerSessionId` persistence, and event flush.
- Extends `src/claude/manager.ts` with per-session `reasoningEffort` support — passes `effort` on initial `sdkQuery` options, fetches `supportedEffortLevels` via `supportedModels()` after init, and applies live effort changes via `applyFlagSettings` on follow-up messages. `max` effort is intentionally excluded from follow-up calls (SDK limitation — `Settings.effortLevel` doesn't expose it yet).
- Widens `CLAUDE_EFFORTS` in `constants.ts` to include `xhigh` and `max`, with a doc comment noting the companion narrows dynamically per model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new reasoning effort levels: xhigh and max.
  * Sessions can set a default reasoning effort at creation.
  * Individual messages can request or adjust reasoning effort during a session.
  * New Codex session management with event buffering, batching, and lifecycle controls.

* **Bug Fixes / Reliability**
  * Follow-up messages preserve or correctly update session effort; delivery is awaited before marking consumed and persists despite backend flag-update failures.

* **Tests**
  * Expanded tests covering effort handling and Codex session workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->