### PR TITLE
chore: drop Communication Style block from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,6 @@ The role of this file is to describe common mistakes and confusion points that a
 
 Project management app for running parallel Claude Code sessions. A kanban board UI lets you create tasks with prompts, launch Claude Code sessions via the Agent SDK per task, and stream structured events to the browser via Convex real-time queries.
 
-## Communication Style
-
-- **Default to caveman-lite** — drop filler, hedging, and pleasantries; keep articles and full sentences. No need to invoke `/caveman`. Escalate to `full`/`ultra` only if the user asks.
-- **Think in 文言 (classical Chinese, simplified characters)** — internal reasoning and deliberation uses classical register to force semantic compression. User-facing output always stays in English.
-- **Auto-clarity still applies**: drop terse mode for security warnings, destructive-op confirmations, and anything where fragment order risks misread. See `.claude/skills/caveman/SKILL.md` for the full spec.
-
 ## Development Principles
 
 - **KISS** — Write simple, readable code over clever solutions. Prefer straightforward implementations that are easy to understand and maintain.


### PR DESCRIPTION
## Summary
- Communication style now lives in a global Claude Code output style (`~/.claude/output-styles/terse.md`), applied to every session
- Per-repo restatement is redundant and risks drift from the global source

## Test plan
- [x] CLAUDE.md still parses cleanly; no dangling references to the removed block
- [ ] Verify next Claude Code session in this repo still respects terse style (sourced from global output style)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal communication guidelines documentation.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->