### PR TITLE
feat(codex): Task 7 — render Codex events in session thread

### DIFF
--- a/src/frontend/components/SessionPanel.tsx
+++ b/src/frontend/components/SessionPanel.tsx
@@ -311,6 +311,7 @@ function ActiveSession({
         messages={chat.messages}
         status={chat.status}
         isInterrupted={chat.isInterrupted}
+        isThinking={chat.isThinking}
       />
     </SessionActionsProvider>
   );

--- a/src/frontend/components/session/SessionThread.test.tsx
+++ b/src/frontend/components/session/SessionThread.test.tsx
@@ -319,5 +319,22 @@ describe('SessionThread', () => {
       });
       expect(screen.queryByText(/thinking/i)).not.toBeInTheDocument();
     });
+
+    it('hides thinking indicator when isThinking={false} overrides session status', () => {
+      render(
+        <SessionThread messages={[]} status="streaming" isThinking={false} />,
+        { wrapper: withSessionActions('running') },
+      );
+      expect(
+        screen.queryByTestId('thinking-indicator'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows thinking indicator when isThinking={true} even if session is idle', () => {
+      render(<SessionThread messages={[]} status="ready" isThinking={true} />, {
+        wrapper: withSessionActions('idle'),
+      });
+      expect(screen.queryByTestId('thinking-indicator')).toBeInTheDocument();
+    });
   });
 });

--- a/src/frontend/components/session/SessionThread.tsx
+++ b/src/frontend/components/session/SessionThread.tsx
@@ -62,15 +62,24 @@ interface SessionThreadProps {
    * "— interrupted —" divider after the last message.
    */
   isInterrupted?: boolean;
+  /**
+   * Override for the thinking-indicator visibility. When provided, gates the
+   * indicator instead of `sessionStatus === 'running'`. Codex sessions stay
+   * `running` between turns, so session status alone leaves the spinner stuck;
+   * the parent hook (`useHolophyteChat.isThinking`) factors in turn boundaries.
+   */
+  isThinking?: boolean;
 }
 
 export default function SessionThread({
   messages,
   status,
   isInterrupted = false,
+  isThinking,
 }: SessionThreadProps) {
   const { sessionStatus } = useSessionActions();
-  const isRunning = sessionStatus === 'running';
+  const isRunning =
+    isThinking !== undefined ? isThinking : sessionStatus === 'running';
   const isStreaming = status === 'streaming';
   // A user message is "queued" when it's still optimistic (no corresponding
   // SDK event yet) while the session is actively processing a prior turn.

--- a/src/frontend/components/session/SessionThread.tsx
+++ b/src/frontend/components/session/SessionThread.tsx
@@ -44,7 +44,7 @@ function ThinkingIndicator({ isRunning }: ThinkingIndicatorProps) {
   return (
     <output
       data-testid="thinking-indicator"
-      aria-label="Claude is thinking"
+      aria-label="Assistant is thinking"
       className="flex items-center gap-1.5 py-1 text-xs text-muted-foreground/70"
     >
       <Sparkles className="h-3.5 w-3.5 pulse-spin animate-[pulse-spin_2s_linear_infinite]" />
@@ -80,7 +80,12 @@ export default function SessionThread({
   const { sessionStatus } = useSessionActions();
   const isRunning =
     isThinking !== undefined ? isThinking : sessionStatus === 'running';
-  const isStreaming = status === 'streaming';
+  // Animate streaming text/reasoning only while a turn is actually in flight.
+  // For Codex sessions, `status` stays `'streaming'` between turns (session
+  // status remains `running`), so deriving from `status` alone leaves prior
+  // turns visually "in progress" after `turn/completed`. `isRunning` already
+  // factors in turn boundaries when `isThinking` is provided.
+  const isStreaming = isRunning && status === 'streaming';
   // A user message is "queued" when it's still optimistic (no corresponding
   // SDK event yet) while the session is actively processing a prior turn.
   // The first active prompt is not optimistic — by the time the session is

--- a/src/frontend/hooks/useHolophyteChat.test.ts
+++ b/src/frontend/hooks/useHolophyteChat.test.ts
@@ -313,3 +313,79 @@ describe('useHolophyteChat — isInterrupted', () => {
     expect(result.current.isInterrupted).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// isThinking — Codex turn awareness
+// ---------------------------------------------------------------------------
+
+function makeCodexEvent(method: string, params: unknown = {}): SDKMessage {
+  return {
+    type: `codex.${method}`,
+    data: JSON.stringify({ method, params }),
+  } as unknown as SDKMessage;
+}
+
+describe('useHolophyteChat — isThinking', () => {
+  it('is true for a running Claude session (no codex events)', () => {
+    const { result } = renderHook(() =>
+      useHolophyteChat(
+        makeProps({
+          events: [makeAssistantEvent('Hello')],
+          sessionStatus: 'running',
+        }),
+      ),
+    );
+    expect(result.current.isThinking).toBe(true);
+  });
+
+  it('is false when session is idle', () => {
+    const { result } = renderHook(() =>
+      useHolophyteChat(makeProps({ sessionStatus: 'idle' })),
+    );
+    expect(result.current.isThinking).toBe(false);
+  });
+
+  it('is true when last codex turn marker is turn/started', () => {
+    const { result } = renderHook(() =>
+      useHolophyteChat(
+        makeProps({
+          events: [makeCodexEvent('turn/started')],
+          sessionStatus: 'running',
+        }),
+      ),
+    );
+    expect(result.current.isThinking).toBe(true);
+  });
+
+  it('is false when last codex turn marker is turn/completed', () => {
+    const { result } = renderHook(() =>
+      useHolophyteChat(
+        makeProps({
+          events: [
+            makeCodexEvent('turn/started'),
+            makeCodexEvent('item/agentMessage/delta'),
+            makeCodexEvent('turn/completed'),
+          ],
+          sessionStatus: 'running',
+        }),
+      ),
+    );
+    expect(result.current.isThinking).toBe(false);
+  });
+
+  it('is true again after a new turn/started follows a completed turn', () => {
+    const { result } = renderHook(() =>
+      useHolophyteChat(
+        makeProps({
+          events: [
+            makeCodexEvent('turn/started'),
+            makeCodexEvent('turn/completed'),
+            makeCodexEvent('turn/started'),
+          ],
+          sessionStatus: 'running',
+        }),
+      ),
+    );
+    expect(result.current.isThinking).toBe(true);
+  });
+});

--- a/src/frontend/hooks/useHolophyteChat.test.ts
+++ b/src/frontend/hooks/useHolophyteChat.test.ts
@@ -345,6 +345,13 @@ describe('useHolophyteChat — isThinking', () => {
     expect(result.current.isThinking).toBe(false);
   });
 
+  it('is false when session is waiting_input (approval pending, not actively thinking)', () => {
+    const { result } = renderHook(() =>
+      useHolophyteChat(makeProps({ sessionStatus: 'waiting_input' })),
+    );
+    expect(result.current.isThinking).toBe(false);
+  });
+
   it('is true when last codex turn marker is turn/started', () => {
     const { result } = renderHook(() =>
       useHolophyteChat(

--- a/src/frontend/hooks/useHolophyteChat.ts
+++ b/src/frontend/hooks/useHolophyteChat.ts
@@ -47,6 +47,14 @@ export interface UseHolophyteChatReturn {
    * "— interrupted —" indicator after the last assistant message.
    */
   isInterrupted: boolean;
+  /**
+   * True when the session is actively producing output and the thinking
+   * indicator should render. Combines session status with provider-specific
+   * turn-state derivation: Codex sessions stay `running` between turns, so we
+   * additionally require an active turn (`codex.turn/started` with no matching
+   * `codex.turn/completed`) before showing the indicator.
+   */
+  isThinking: boolean;
 }
 
 /**
@@ -121,6 +129,28 @@ export function useHolophyteChat(
       if (ev.type === 'user') return true;
     }
     return false;
+  }, [events, sessionStatus]);
+
+  // Thinking-indicator gating. Codex sessions stay `running` between turns
+  // (the manager keeps the local app-server child alive for follow-ups), so
+  // session status alone leaves the spinner stuck. Look for a Codex turn
+  // boundary in the event stream: indicator shows iff session is running AND
+  // (no Codex events have been seen — pure Claude session) OR (a
+  // `codex.turn/started` is the most recent turn marker without a matching
+  // `codex.turn/completed`).
+  const isThinking = useMemo(() => {
+    if (sessionStatus !== 'running') return false;
+    for (let i = events.length - 1; i >= 0; i--) {
+      const ev = events[i];
+      const t = (ev as { type?: unknown } | undefined)?.type;
+      if (typeof t !== 'string' || !t.startsWith('codex.')) continue;
+      if (t === 'codex.turn/completed') return false;
+      if (t === 'codex.turn/started') return true;
+      // Other Codex events (item/*, thread/*, tokenUsage, etc.) carry no
+      // turn-boundary signal — keep scanning.
+    }
+    // Pure Claude session, or Codex session before any turn marker arrived.
+    return true;
   }, [events, sessionStatus]);
 
   // Extract the latest prompt suggestion from the event stream
@@ -212,5 +242,6 @@ export function useHolophyteChat(
     availableCommands,
     messageQueued,
     isInterrupted,
+    isThinking,
   };
 }

--- a/src/frontend/hooks/useSession.test.ts
+++ b/src/frontend/hooks/useSession.test.ts
@@ -100,12 +100,13 @@ function makeConvexApproval(overrides: Record<string, unknown> = {}) {
 
 // Build a Convex event batch
 function makeBatch(
-  events: Array<{ data: string; timestamp?: number }>,
+  events: Array<{ data: string; type?: string; timestamp?: number }>,
   batchIndex = 0,
 ) {
   return {
     batchIndex,
     events: events.map((e) => ({
+      type: e.type,
       data: e.data,
       timestamp: e.timestamp ?? Date.now(),
     })),
@@ -735,6 +736,69 @@ describe('useSession', () => {
       rerender();
 
       expect(result.current.messageQueued).toBe(false);
+    });
+
+    it('resets messageQueued on codex.turn/completed (Codex sessions stay running across turns)', async () => {
+      mockSendSessionMessage.mockResolvedValue(undefined);
+
+      let batches: ReturnType<typeof makeBatch>[] = [];
+      mockedUseQuery.mockImplementation((query: unknown) => {
+        if (query === 'sessions:get')
+          return makeSessionRecord({ status: 'running' });
+        if (query === 'sessionEvents:getBySession') return batches;
+        return [];
+      });
+
+      const { result, rerender } = renderSession('session-1');
+
+      await act(async () => {
+        await result.current.sendMessage('session-1', 'hi');
+      });
+      expect(result.current.messageQueued).toBe(true);
+
+      // A new codex.turn/completed event arrives — queued message has been
+      // (or is about to be) delivered as a follow-up turn.
+      batches = [
+        makeBatch([
+          {
+            type: 'codex.turn/completed',
+            data: JSON.stringify({ method: 'turn/completed', params: {} }),
+          },
+        ]),
+      ];
+      rerender();
+
+      expect(result.current.messageQueued).toBe(false);
+    });
+
+    it('keeps messageQueued true while a Codex turn is still in flight', async () => {
+      mockSendSessionMessage.mockResolvedValue(undefined);
+
+      // The turn that was running when sendMessage was called: count=1 already.
+      const initialBatches = [
+        makeBatch([
+          {
+            type: 'codex.turn/completed',
+            data: JSON.stringify({ method: 'turn/completed', params: {} }),
+          },
+        ]),
+      ];
+
+      mockedUseQuery.mockImplementation((query: unknown) => {
+        if (query === 'sessions:get')
+          return makeSessionRecord({ status: 'running' });
+        if (query === 'sessionEvents:getBySession') return initialBatches;
+        return [];
+      });
+
+      const { result } = renderSession('session-1');
+
+      // Send while a previous turn already completed (count snapshot = 1)
+      await act(async () => {
+        await result.current.sendMessage('session-1', 'hi');
+      });
+      // No new turn/completed since send → still queued
+      expect(result.current.messageQueued).toBe(true);
     });
 
     it('does NOT reset messageQueued when session transitions to waiting_input', async () => {

--- a/src/frontend/hooks/useSession.ts
+++ b/src/frontend/hooks/useSession.ts
@@ -239,6 +239,11 @@ export function useSession(sessionId: string | null): UseSessionReturn {
     }
     return n;
   }, [events]);
+  // Mirror the count into a ref so async callbacks (sendMessage) read the
+  // latest value after their `await`, not the closure-captured snapshot from
+  // when the callback was memoized.
+  const codexTurnCompletedCountRef = useRef(0);
+  codexTurnCompletedCountRef.current = codexTurnCompletedCount;
   const queuedAtCodexTurnCount = useRef<number | null>(null);
   if (
     messageQueued &&
@@ -295,11 +300,11 @@ export function useSession(sessionId: string | null): UseSessionReturn {
       });
       // If the session was running, the message is queued — show an indicator
       if (sessionStatus === 'running') {
-        queuedAtCodexTurnCount.current = codexTurnCompletedCount;
+        queuedAtCodexTurnCount.current = codexTurnCompletedCountRef.current;
         setMessageQueued(true);
       }
     },
-    [sessionStatus, sendSessionMessage, codexTurnCompletedCount],
+    [sessionStatus, sendSessionMessage],
   );
 
   return {

--- a/src/frontend/hooks/useSession.ts
+++ b/src/frontend/hooks/useSession.ts
@@ -166,11 +166,26 @@ export function useSession(sessionId: string | null): UseSessionReturn {
     sessionId ? { sessionId: sessionId as Id<'sessions'> } : 'skip',
   );
 
-  // Flatten persisted batches into a single event list
+  // Flatten persisted batches into a single event list.
+  //
+  // Claude events: `e.data` is a serialized SDKMessage whose own `type` field
+  //   (`'assistant'`, `'user'`, `'result'`, …) is what the renderer keys off.
+  //   Parse and unwrap.
+  // Codex events: `e.type` is `'codex.<method>'` and `e.data` is the raw
+  //   `{ jsonrpc, method, params }` notification — which has NO `type` field.
+  //   If we unwrapped these, the renderer / `isThinking` lose the `'codex.*'`
+  //   tag and silently drop every event. Pass through as `{ type, data }` so
+  //   the renderer's `event.type.startsWith('codex.')` branch fires and its
+  //   inner `JSON.parse(data)` step still works.
   const events = useMemo<SDKMessage[]>(() => {
     if (!persistedBatches) return [];
     return persistedBatches.flatMap((batch) =>
-      batch.events.map((e) => JSON.parse(e.data) as SDKMessage),
+      batch.events.map((e) => {
+        if (typeof e.type === 'string' && e.type.startsWith('codex.')) {
+          return { type: e.type, data: e.data } as unknown as SDKMessage;
+        }
+        return JSON.parse(e.data) as SDKMessage;
+      }),
     );
   }, [persistedBatches]);
 
@@ -211,6 +226,28 @@ export function useSession(sessionId: string | null): UseSessionReturn {
     setMessageQueued(false);
   }
   prevStatusRef.current = sessionStatus;
+
+  // Codex sessions stay `running` between turns (no idle status), so the
+  // status-transition reset above never fires. Use `codex.turn/completed`
+  // count as the per-turn boundary instead: when a new turn completes after
+  // we set `messageQueued`, the queued message has been (or is about to be)
+  // delivered as a follow-up turn — clear the indicator.
+  const codexTurnCompletedCount = useMemo(() => {
+    let n = 0;
+    for (const ev of events) {
+      if ((ev as { type?: unknown })?.type === 'codex.turn/completed') n++;
+    }
+    return n;
+  }, [events]);
+  const queuedAtCodexTurnCount = useRef<number | null>(null);
+  if (
+    messageQueued &&
+    queuedAtCodexTurnCount.current !== null &&
+    codexTurnCompletedCount > queuedAtCodexTurnCount.current
+  ) {
+    setMessageQueued(false);
+    queuedAtCodexTurnCount.current = null;
+  }
 
   // Refresh "now" every 5s to keep companionOnline fresh
   const [now, setNow] = useState(() => Date.now());
@@ -258,10 +295,11 @@ export function useSession(sessionId: string | null): UseSessionReturn {
       });
       // If the session was running, the message is queued — show an indicator
       if (sessionStatus === 'running') {
+        queuedAtCodexTurnCount.current = codexTurnCompletedCount;
         setMessageQueued(true);
       }
     },
-    [sessionStatus, sendSessionMessage],
+    [sessionStatus, sendSessionMessage, codexTurnCompletedCount],
   );
 
   return {

--- a/src/frontend/lib/sdkToUIMessages.test.ts
+++ b/src/frontend/lib/sdkToUIMessages.test.ts
@@ -510,6 +510,26 @@ describe('sdkToUIMessages — Codex agent message', () => {
 });
 
 describe('sdkToUIMessages — Codex user messages', () => {
+  it('renders a placeholder for image-only userMessage so the turn stays visible', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/completed', {
+        item: {
+          type: 'userMessage',
+          id: 'um-img',
+          content: [
+            { type: 'image', url: 'https://example.com/x.png' },
+            { type: 'localImage', path: '/tmp/x.png' },
+          ],
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.role).toBe('user');
+    const part = result[0]?.parts[0] as { text: string };
+    expect(part.text).toMatch(/image|localImage/);
+  });
+
   it('renders a userMessage item as a role=user UIMessage', () => {
     const events: SDKMessage[] = [
       makeCodexEvent('item/completed', {

--- a/src/frontend/lib/sdkToUIMessages.test.ts
+++ b/src/frontend/lib/sdkToUIMessages.test.ts
@@ -640,6 +640,56 @@ describe('sdkToUIMessages — Codex tool items', () => {
     expect(part.state).toBe('output-available');
   });
 
+  it('shows an in-progress Bash card on item/started before completion', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/started', {
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-pending',
+          command: 'sleep 30',
+          cwd: '/tmp',
+          status: 'inProgress',
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, true, noPending);
+    expect(result).toHaveLength(1);
+    const part = result[0]?.parts[0] as { state: string; toolName: string };
+    expect(part.toolName).toBe('Bash');
+    expect(part.state).toBe('input-available');
+  });
+
+  it('updates the same message when item/started is followed by item/completed', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/started', {
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-x',
+          command: 'echo hi',
+          cwd: '/tmp',
+          status: 'inProgress',
+        },
+      }),
+      makeCodexEvent('item/completed', {
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-x',
+          command: 'echo hi',
+          cwd: '/tmp',
+          status: 'completed',
+          aggregatedOutput: 'hi\n',
+          exitCode: 0,
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('codex-cmd-x');
+    const part = result[0]?.parts[0] as { state: string; output?: unknown };
+    expect(part.state).toBe('output-available');
+    expect(part.output).toBe('hi\n');
+  });
+
   it('renders a webSearch item', () => {
     const events: SDKMessage[] = [
       makeCodexEvent('item/completed', {

--- a/src/frontend/lib/sdkToUIMessages.test.ts
+++ b/src/frontend/lib/sdkToUIMessages.test.ts
@@ -408,3 +408,285 @@ describe('extractPromptSuggestion', () => {
     expect(extractPromptSuggestion(events)).toBe('do something');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Codex events
+// ---------------------------------------------------------------------------
+
+function makeCodexEvent(method: string, params: unknown): SDKMessage {
+  return {
+    type: `codex.${method}`,
+    data: JSON.stringify({ method, params }),
+  } as unknown as SDKMessage;
+}
+
+describe('sdkToUIMessages — Codex agent message', () => {
+  it('builds a streaming bubble from agentMessage deltas while turn is active', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('turn/started', { threadId: 't', turn: { id: 'turn-1' } }),
+      makeCodexEvent('item/agentMessage/delta', {
+        threadId: 't',
+        turnId: 'turn-1',
+        itemId: 'msg-1',
+        delta: 'Hello',
+      }),
+      makeCodexEvent('item/agentMessage/delta', {
+        threadId: 't',
+        turnId: 'turn-1',
+        itemId: 'msg-1',
+        delta: ' world',
+      }),
+    ];
+    const result = sdkToUIMessages(events, true, noPending);
+    expect(result).toHaveLength(1);
+    const part = result[0]?.parts[0] as {
+      type: string;
+      text: string;
+      state?: string;
+    };
+    expect(part.type).toBe('text');
+    expect(part.text).toBe('Hello world');
+    expect(part.state).toBe('streaming');
+  });
+
+  it('marks the bubble as done after item/completed agentMessage', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('turn/started', { threadId: 't', turn: { id: 'turn-1' } }),
+      makeCodexEvent('item/agentMessage/delta', {
+        threadId: 't',
+        turnId: 'turn-1',
+        itemId: 'msg-1',
+        delta: 'Hi',
+      }),
+      makeCodexEvent('item/completed', {
+        threadId: 't',
+        turnId: 'turn-1',
+        item: { type: 'agentMessage', id: 'msg-1', text: 'Hi there' },
+      }),
+    ];
+    const result = sdkToUIMessages(events, true, noPending);
+    const part = result[0]?.parts[0] as {
+      type: string;
+      text: string;
+      state?: string;
+    };
+    expect(part.text).toBe('Hi there');
+    expect(part.state).toBe('done');
+  });
+
+  it('marks deltas as done after turn/completed', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('turn/started', { threadId: 't', turn: { id: 'turn-1' } }),
+      makeCodexEvent('item/agentMessage/delta', {
+        threadId: 't',
+        turnId: 'turn-1',
+        itemId: 'msg-1',
+        delta: 'Done',
+      }),
+      makeCodexEvent('turn/completed', {
+        threadId: 't',
+        turn: { id: 'turn-1', status: 'completed' },
+      }),
+    ];
+    const result = sdkToUIMessages(events, true, noPending);
+    const part = result[0]?.parts[0] as { state?: string };
+    expect(part.state).toBe('done');
+  });
+
+  it('marks deltas as done when session is no longer running', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('turn/started', { threadId: 't', turn: { id: 'turn-1' } }),
+      makeCodexEvent('item/agentMessage/delta', {
+        threadId: 't',
+        turnId: 'turn-1',
+        itemId: 'msg-1',
+        delta: 'Hi',
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as { state?: string };
+    expect(part.state).toBe('done');
+  });
+});
+
+describe('sdkToUIMessages — Codex user messages', () => {
+  it('renders a userMessage item as a role=user UIMessage', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/completed', {
+        item: {
+          type: 'userMessage',
+          id: 'um-1',
+          content: [{ type: 'text', text: 'hello codex' }],
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.role).toBe('user');
+    const part = result[0]?.parts[0] as { type: string; text: string };
+    expect(part.text).toBe('hello codex');
+  });
+});
+
+describe('sdkToUIMessages — Codex tool items', () => {
+  it('renders a commandExecution as a Bash dynamic-tool with output', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/completed', {
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-1',
+          command: 'ls',
+          cwd: '/tmp',
+          status: 'completed',
+          aggregatedOutput: 'file.txt\n',
+          exitCode: 0,
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(1);
+    const part = result[0]?.parts[0] as {
+      type: string;
+      toolName: string;
+      state: string;
+      input: { command: string };
+      output?: unknown;
+    };
+    expect(part.type).toBe('dynamic-tool');
+    expect(part.toolName).toBe('Bash');
+    expect(part.state).toBe('output-available');
+    expect(part.input.command).toBe('ls');
+    expect(part.output).toBe('file.txt\n');
+  });
+
+  it('renders a failed commandExecution as output-error', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/completed', {
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-2',
+          command: 'false',
+          cwd: '/tmp',
+          status: 'failed',
+          aggregatedOutput: 'failed',
+          exitCode: 1,
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as { state: string; errorText?: string };
+    expect(part.state).toBe('output-error');
+    expect(part.errorText).toBe('failed');
+  });
+
+  it('renders a fileChange as an Edit dynamic-tool', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/completed', {
+        item: {
+          type: 'fileChange',
+          id: 'fc-1',
+          status: 'completed',
+          changes: [
+            { path: 'a.ts', kind: 'update', diff: '...' },
+            { path: 'b.ts', kind: 'add', diff: '...' },
+          ],
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as { toolName: string; output?: unknown };
+    expect(part.toolName).toBe('Edit');
+    expect(part.output).toBe('2 file changes');
+  });
+
+  it('renders an mcpToolCall with namespaced tool name', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/completed', {
+        item: {
+          type: 'mcpToolCall',
+          id: 'mcp-1',
+          server: 'github',
+          tool: 'list_prs',
+          status: 'completed',
+          arguments: { owner: 'foo' },
+          result: { ok: true },
+          error: null,
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as { toolName: string; state: string };
+    expect(part.toolName).toBe('mcp__github__list_prs');
+    expect(part.state).toBe('output-available');
+  });
+
+  it('renders a webSearch item', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/completed', {
+        item: { type: 'webSearch', id: 'ws-1', query: 'how to bun' },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as {
+      toolName: string;
+      input: { query: string };
+    };
+    expect(part.toolName).toBe('WebSearch');
+    expect(part.input.query).toBe('how to bun');
+  });
+
+  it('renders a reasoning item as a reasoning part', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/completed', {
+        item: {
+          type: 'reasoning',
+          id: 'r-1',
+          summary: ['Looking at...'],
+          content: ['detailed thought'],
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as { type: string; text: string };
+    expect(part.type).toBe('reasoning');
+    expect(part.text).toContain('Looking at');
+    expect(part.text).toContain('detailed thought');
+  });
+
+  it('silently skips unknown codex methods', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('thread/tokenUsage/updated', {
+        threadId: 't',
+        tokenUsage: { total: { totalTokens: 10 } },
+      }),
+      makeCodexEvent('account/rateLimits/updated', {}),
+      makeCodexEvent('mcpServer/startupStatus/updated', {}),
+      makeCodexEvent('some/future/method', { foo: 'bar' }),
+    ];
+    expect(() => sdkToUIMessages(events, false, noPending)).not.toThrow();
+    expect(sdkToUIMessages(events, false, noPending)).toHaveLength(0);
+  });
+
+  it('does not crash on malformed codex event data', () => {
+    const events = [
+      { type: 'codex.item/completed', data: 'not json' },
+    ] as unknown as SDKMessage[];
+    expect(() => sdkToUIMessages(events, false, noPending)).not.toThrow();
+  });
+
+  it('mixes Codex and Claude events without interfering', () => {
+    const events: SDKMessage[] = [
+      makeAssistantEvent([{ type: 'text', text: 'Claude here' }], 'claude-1'),
+      makeCodexEvent('turn/started', { threadId: 't', turn: { id: 'turn-1' } }),
+      makeCodexEvent('item/completed', {
+        item: { type: 'agentMessage', id: 'codex-msg', text: 'Codex here' },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    expect(result).toHaveLength(2);
+    const claudePart = result[0]?.parts[0] as { text: string };
+    const codexPart = result[1]?.parts[0] as { text: string };
+    expect(claudePart.text).toBe('Claude here');
+    expect(codexPart.text).toBe('Codex here');
+  });
+});

--- a/src/frontend/lib/sdkToUIMessages.test.ts
+++ b/src/frontend/lib/sdkToUIMessages.test.ts
@@ -718,6 +718,76 @@ describe('sdkToUIMessages — Codex tool items', () => {
     expect(part.state).toBe('input-available');
   });
 
+  it('renders a completed dynamicToolCall with text output', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/completed', {
+        item: {
+          type: 'dynamicToolCall',
+          id: 'dtc-1',
+          tool: 'fetch_weather',
+          arguments: { city: 'Tokyo' },
+          status: 'completed',
+          contentItems: [{ type: 'inputText', text: '21°C, clear' }],
+          success: true,
+          durationMs: 412,
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part).toMatchObject({
+      type: 'dynamic-tool',
+      toolName: 'fetch_weather',
+      state: 'output-available',
+      output: '21°C, clear',
+    });
+  });
+
+  it('renders a failed dynamicToolCall as output-error', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/completed', {
+        item: {
+          type: 'dynamicToolCall',
+          id: 'dtc-2',
+          tool: 'broken_tool',
+          arguments: {},
+          status: 'failed',
+          contentItems: [{ type: 'inputText', text: 'tool exploded' }],
+          success: false,
+          durationMs: 0,
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part).toMatchObject({
+      type: 'dynamic-tool',
+      state: 'output-error',
+      errorText: 'tool exploded',
+    });
+  });
+
+  it('renders a dynamicToolCall item/started as in-progress', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/started', {
+        item: {
+          type: 'dynamicToolCall',
+          id: 'dtc-3',
+          tool: 'long_running',
+          arguments: { x: 1 },
+          status: 'inProgress',
+          contentItems: null,
+          success: null,
+          durationMs: null,
+        },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as { state: string; toolName: string };
+    expect(part.state).toBe('input-available');
+    expect(part.toolName).toBe('long_running');
+  });
+
   it('renders a reasoning item as a reasoning part', () => {
     const events: SDKMessage[] = [
       makeCodexEvent('item/completed', {

--- a/src/frontend/lib/sdkToUIMessages.test.ts
+++ b/src/frontend/lib/sdkToUIMessages.test.ts
@@ -700,9 +700,22 @@ describe('sdkToUIMessages — Codex tool items', () => {
     const part = result[0]?.parts[0] as {
       toolName: string;
       input: { query: string };
+      state: string;
     };
     expect(part.toolName).toBe('WebSearch');
     expect(part.input.query).toBe('how to bun');
+    expect(part.state).toBe('output-available');
+  });
+
+  it('renders a webSearch item/started as in-progress (query is in started payload too)', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/started', {
+        item: { type: 'webSearch', id: 'ws-1', query: 'how to bun' },
+      }),
+    ];
+    const result = sdkToUIMessages(events, false, noPending);
+    const part = result[0]?.parts[0] as { state: string };
+    expect(part.state).toBe('input-available');
   });
 
   it('renders a reasoning item as a reasoning part', () => {

--- a/src/frontend/lib/sdkToUIMessages.ts
+++ b/src/frontend/lib/sdkToUIMessages.ts
@@ -475,7 +475,8 @@ function handleCodexEvent(
         case 'commandExecution':
         case 'fileChange':
         case 'mcpToolCall':
-        case 'webSearch': {
+        case 'webSearch':
+        case 'dynamicToolCall': {
           const part = mapCodexToolItem(item, itemId, true);
           if (!part) return { turnActive };
           upsertCodexToolMessage(messages, itemId, part);
@@ -559,6 +560,39 @@ function mapCodexToolItem(
         status: completed ? 'completed' : 'inProgress',
         output: '',
       });
+    case 'dynamicToolCall': {
+      // User-installed / function tools surface here. Concatenate text content
+      // items into a single output blob; image items are placeholdered until
+      // the UI gains attachment rendering.
+      const contentItems = Array.isArray(item.contentItems)
+        ? (item.contentItems as Array<Record<string, unknown>>)
+        : [];
+      const output = contentItems
+        .map((c) =>
+          c.type === 'inputText'
+            ? String(c.text ?? '')
+            : c.type === 'inputImage'
+              ? '[image]'
+              : '',
+        )
+        .filter(Boolean)
+        .join('');
+      const success = item.success;
+      const status =
+        success === false
+          ? 'failed'
+          : (String(item.status ?? '') as
+              | 'inProgress'
+              | 'completed'
+              | 'failed');
+      return makeCodexToolPart({
+        toolName: String(item.tool ?? 'dynamic'),
+        toolCallId: itemId,
+        input: item.arguments,
+        status,
+        output,
+      });
+    }
     default:
       return null;
   }

--- a/src/frontend/lib/sdkToUIMessages.ts
+++ b/src/frontend/lib/sdkToUIMessages.ts
@@ -146,8 +146,37 @@ export function sdkToUIMessages(
     .filter((e) => e.type === 'assistant')
     .at(-1);
 
+  // Codex agent-message text accumulator (delta → in-place merge)
+  const codexAgentText = new Map<string, string>();
+  // Set of Codex agentMessage itemIds that received an `item/completed`.
+  // These are authoritative — never re-marked as streaming in the post-pass.
+  const codexCompletedAgentIds = new Set<string>();
+  // Track the most recent Codex agentMessage itemId so we can mark it as
+  // 'streaming' when a turn is in flight. Updated as agentMessage events flow.
+  let lastCodexAgentItemId: string | null = null;
+  // Whether a Codex turn is currently in flight (turn/started seen with no
+  // matching turn/completed). When true and isRunning, the most recent
+  // agent-message bubble is marked as streaming.
+  let codexTurnActive = false;
+
   // Second pass: build UIMessage entries
   for (const event of events) {
+    const eventType = (event as { type?: unknown }).type;
+    if (typeof eventType === 'string' && eventType.startsWith('codex.')) {
+      const result = handleCodexEvent(
+        event as unknown as CodexEvent,
+        eventType,
+        messages,
+        codexAgentText,
+        codexCompletedAgentIds,
+        codexTurnActive,
+      );
+      codexTurnActive = result.turnActive;
+      if (result.lastAgentItemId !== undefined) {
+        lastCodexAgentItemId = result.lastAgentItemId;
+      }
+      continue;
+    }
     if (event.type === 'assistant') {
       const msg = event.message as { id?: string; content?: unknown[] };
       const uuid = (event as { uuid?: string }).uuid ?? '';
@@ -292,7 +321,289 @@ export function sdkToUIMessages(
     // 'result', 'system/init' and other types are ignored
   }
 
+  // Final pass: resolve Codex agent-message text states.
+  // Bubbles built from `item/agentMessage/delta` default to 'streaming' so the
+  // typing animation appears live. Once their turn ends OR the session is no
+  // longer running, mark non-completed ones as 'done'. The active bubble
+  // (last id, turn still in flight, session running) keeps 'streaming'.
+  for (const itemId of codexAgentText.keys()) {
+    if (codexCompletedAgentIds.has(itemId)) continue;
+    const idx = messages.findIndex((m) => m.id === itemId);
+    if (idx === -1) continue;
+    const msg = messages[idx];
+    if (!msg) continue;
+    const isLive =
+      isRunning && codexTurnActive && itemId === lastCodexAgentItemId;
+    const targetState = isLive ? 'streaming' : 'done';
+    // biome-ignore lint/suspicious/noExplicitAny: parts union is complex
+    const newParts = (msg.parts as any[]).map((p) =>
+      p.type === 'text' ? { ...p, state: targetState } : p,
+    );
+    messages[idx] = { ...msg, parts: newParts };
+  }
+
   return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Codex event handling
+// ---------------------------------------------------------------------------
+
+type CodexEvent = { type: string; data: string };
+
+interface CodexHandlerResult {
+  turnActive: boolean;
+  /** Updated when an agentMessage item is observed; otherwise undefined. */
+  lastAgentItemId?: string;
+}
+
+/**
+ * Handles a single Codex stream event (`type: 'codex.<method>'`) and mutates
+ * `messages` to reflect Codex thread state. Codex events arrive as buffered
+ * `{ type, data }` rows; `data` is the JSON-serialized notification payload
+ * from `codex-app-server-client`. Unknown methods are silently skipped.
+ */
+function handleCodexEvent(
+  event: CodexEvent,
+  eventType: string,
+  // biome-ignore lint/suspicious/noExplicitAny: UIMessage parts union is complex
+  messages: any[],
+  codexAgentText: Map<string, string>,
+  codexCompletedAgentIds: Set<string>,
+  turnActive: boolean,
+): CodexHandlerResult {
+  const method = eventType.slice('codex.'.length);
+
+  // Parse payload defensively — malformed JSON shouldn't take down the renderer.
+  let payload: Record<string, unknown> = {};
+  try {
+    const data = (event as { data?: unknown }).data;
+    if (typeof data === 'string') {
+      const parsed = JSON.parse(data) as { params?: unknown };
+      const params = (parsed as { params?: unknown }).params;
+      payload = (params ?? {}) as Record<string, unknown>;
+    }
+  } catch {
+    return { turnActive };
+  }
+
+  switch (method) {
+    case 'turn/started':
+      return { turnActive: true };
+    case 'turn/completed':
+      return { turnActive: false };
+    case 'item/agentMessage/delta': {
+      const itemId = String(payload.itemId ?? '');
+      const delta = String(payload.delta ?? '');
+      if (!itemId) return { turnActive };
+      const text = (codexAgentText.get(itemId) ?? '') + delta;
+      codexAgentText.set(itemId, text);
+      upsertCodexAgentMessage(messages, itemId, text);
+      return { turnActive, lastAgentItemId: itemId };
+    }
+    case 'item/completed': {
+      const item = (payload.item ?? {}) as Record<string, unknown>;
+      const itemType = String(item.type ?? '');
+      const itemId = String(item.id ?? '');
+      if (!itemId) return { turnActive };
+
+      switch (itemType) {
+        case 'userMessage': {
+          const content = Array.isArray(item.content)
+            ? (item.content as Array<Record<string, unknown>>)
+            : [];
+          const text = content
+            .filter((c) => c.type === 'text')
+            .map((c) => String(c.text ?? ''))
+            .join('');
+          if (!text) return { turnActive };
+          messages.push({
+            id: `codex-${itemId}`,
+            role: 'user',
+            parts: [{ type: 'text', text }],
+          });
+          return { turnActive };
+        }
+        case 'agentMessage': {
+          const text = String(item.text ?? codexAgentText.get(itemId) ?? '');
+          codexAgentText.set(itemId, text);
+          codexCompletedAgentIds.add(itemId);
+          upsertCodexAgentMessage(messages, itemId, text, 'done');
+          return { turnActive, lastAgentItemId: itemId };
+        }
+        case 'reasoning': {
+          const summary = Array.isArray(item.summary)
+            ? (item.summary as unknown[]).map(String).filter(Boolean)
+            : [];
+          const content = Array.isArray(item.content)
+            ? (item.content as unknown[]).map(String).filter(Boolean)
+            : [];
+          const text = [...summary, ...content].join('\n\n');
+          if (!text) return { turnActive };
+          messages.push({
+            id: `codex-${itemId}`,
+            role: 'assistant',
+            parts: [{ type: 'reasoning', text, state: 'done' }],
+          });
+          return { turnActive };
+        }
+        case 'commandExecution': {
+          const status = String(item.status ?? '');
+          const part = makeCodexToolPart({
+            toolName: 'Bash',
+            toolCallId: itemId,
+            input: { command: item.command, cwd: item.cwd },
+            status,
+            output: item.aggregatedOutput,
+          });
+          messages.push({
+            id: `codex-${itemId}`,
+            role: 'assistant',
+            parts: [part],
+          });
+          return { turnActive };
+        }
+        case 'fileChange': {
+          const status = String(item.status ?? '');
+          const changes = Array.isArray(item.changes) ? item.changes : [];
+          const part = makeCodexToolPart({
+            toolName: 'Edit',
+            toolCallId: itemId,
+            input: { changes },
+            status,
+            output: `${changes.length} file change${changes.length === 1 ? '' : 's'}`,
+          });
+          messages.push({
+            id: `codex-${itemId}`,
+            role: 'assistant',
+            parts: [part],
+          });
+          return { turnActive };
+        }
+        case 'mcpToolCall': {
+          const status = String(item.status ?? '');
+          const server = String(item.server ?? '');
+          const tool = String(item.tool ?? '');
+          const error = item.error as Record<string, unknown> | null;
+          const part = makeCodexToolPart({
+            toolName: `mcp__${server}__${tool}`,
+            toolCallId: itemId,
+            input: item.arguments,
+            status: error ? 'failed' : status,
+            output: item.result,
+            errorText: error
+              ? String(error.message ?? JSON.stringify(error))
+              : undefined,
+          });
+          messages.push({
+            id: `codex-${itemId}`,
+            role: 'assistant',
+            parts: [part],
+          });
+          return { turnActive };
+        }
+        case 'webSearch': {
+          const part = makeCodexToolPart({
+            toolName: 'WebSearch',
+            toolCallId: itemId,
+            input: { query: item.query },
+            status: 'completed',
+            output: '',
+          });
+          messages.push({
+            id: `codex-${itemId}`,
+            role: 'assistant',
+            parts: [part],
+          });
+          return { turnActive };
+        }
+        default:
+          // Unknown / Phase 0+ item types: skip silently
+          return { turnActive };
+      }
+    }
+    default:
+      // Other Codex methods (item/started, thread/*, account/*, mcpServer/*,
+      // tokenUsage, etc.) are not surfaced in Phase 0.
+      return { turnActive };
+  }
+}
+
+/**
+ * Insert or update an in-flight Codex agent-message UIMessage. Multiple
+ * agentMessage items per turn each get their own bubble (keyed by itemId).
+ */
+function upsertCodexAgentMessage(
+  // biome-ignore lint/suspicious/noExplicitAny: UIMessage parts union is complex
+  messages: any[],
+  itemId: string,
+  text: string,
+  state: 'streaming' | 'done' = 'streaming',
+): void {
+  if (!text) return;
+  const id = itemId;
+  const idx = messages.findIndex((m) => m.id === id);
+  const part = { type: 'text', text, state };
+  if (idx === -1) {
+    messages.push({ id, role: 'assistant', parts: [part] });
+  } else {
+    messages[idx] = { ...messages[idx], parts: [part] };
+  }
+}
+
+interface CodexToolPartInput {
+  toolName: string;
+  toolCallId: string;
+  input: unknown;
+  status: string;
+  output?: unknown;
+  errorText?: string;
+}
+
+/** Map a Codex item status to a `DynamicToolUIPart`. */
+function makeCodexToolPart(args: CodexToolPartInput): DynamicToolUIPart {
+  const { toolName, toolCallId, input, status, output, errorText } = args;
+  // biome-ignore lint/suspicious/noExplicitAny: input is intentionally unknown
+  const safeInput = (input ?? {}) as any;
+
+  if (status === 'failed') {
+    return {
+      type: 'dynamic-tool',
+      toolName,
+      toolCallId,
+      state: 'output-error',
+      input: safeInput,
+      errorText: errorText ?? String(output ?? 'Tool call failed'),
+    };
+  }
+  if (status === 'declined') {
+    return {
+      type: 'dynamic-tool',
+      toolName,
+      toolCallId,
+      state: 'output-denied',
+      input: safeInput,
+      approval: { id: toolCallId, approved: false },
+    };
+  }
+  if (status === 'completed') {
+    return {
+      type: 'dynamic-tool',
+      toolName,
+      toolCallId,
+      state: 'output-available',
+      input: safeInput,
+      output: output ?? '',
+    };
+  }
+  // 'inProgress' or unknown — show input only
+  return {
+    type: 'dynamic-tool',
+    toolName,
+    toolCallId,
+    state: 'input-available',
+    input: safeInput,
+  };
 }
 
 /**

--- a/src/frontend/lib/sdkToUIMessages.ts
+++ b/src/frontend/lib/sdkToUIMessages.ts
@@ -401,6 +401,20 @@ function handleCodexEvent(
       upsertCodexAgentMessage(messages, itemId, text);
       return { turnActive, lastAgentItemId: itemId };
     }
+    case 'item/started': {
+      // Phase 0: only emit placeholder messages for tool-like items so
+      // long-running commands / file edits / MCP calls / web searches are
+      // visible in the thread before they complete. Text items
+      // (agentMessage, reasoning, userMessage) finalize on item/completed
+      // or stream via dedicated delta events.
+      const item = (payload.item ?? {}) as Record<string, unknown>;
+      const itemId = String(item.id ?? '');
+      if (!itemId) return { turnActive };
+      const part = mapCodexToolItem(item, itemId);
+      if (!part) return { turnActive };
+      upsertCodexToolMessage(messages, itemId, part);
+      return { turnActive };
+    }
     case 'item/completed': {
       const item = (payload.item ?? {}) as Record<string, unknown>;
       const itemType = String(item.type ?? '');
@@ -458,84 +472,13 @@ function handleCodexEvent(
           });
           return { turnActive };
         }
-        case 'commandExecution': {
-          const status = String(item.status ?? '');
-          const part = makeCodexToolPart({
-            toolName: 'Bash',
-            toolCallId: itemId,
-            input: { command: item.command, cwd: item.cwd },
-            status,
-            output: item.aggregatedOutput,
-          });
-          messages.push({
-            id: `codex-${itemId}`,
-            role: 'assistant',
-            parts: [part],
-          });
-          return { turnActive };
-        }
-        case 'fileChange': {
-          const status = String(item.status ?? '');
-          const changes = Array.isArray(item.changes) ? item.changes : [];
-          const part = makeCodexToolPart({
-            toolName: 'Edit',
-            toolCallId: itemId,
-            input: { changes },
-            status,
-            output: `${changes.length} file change${changes.length === 1 ? '' : 's'}`,
-          });
-          messages.push({
-            id: `codex-${itemId}`,
-            role: 'assistant',
-            parts: [part],
-          });
-          return { turnActive };
-        }
-        case 'mcpToolCall': {
-          const status = String(item.status ?? '');
-          const server = String(item.server ?? '');
-          const tool = String(item.tool ?? '');
-          const error = item.error as Record<string, unknown> | string | null;
-          // Codex may report errors as plain strings (`"timeout"`) or as
-          // structured objects (`{ message: '...' }`). Coerce both shapes
-          // without wrapping bare strings in JSON quotes.
-          let errorText: string | undefined;
-          if (error) {
-            if (typeof error === 'string') {
-              errorText = error;
-            } else {
-              const msg = (error as Record<string, unknown>).message;
-              errorText = typeof msg === 'string' ? msg : JSON.stringify(error);
-            }
-          }
-          const part = makeCodexToolPart({
-            toolName: `mcp__${server}__${tool}`,
-            toolCallId: itemId,
-            input: item.arguments,
-            status: error ? 'failed' : status,
-            output: item.result,
-            errorText,
-          });
-          messages.push({
-            id: `codex-${itemId}`,
-            role: 'assistant',
-            parts: [part],
-          });
-          return { turnActive };
-        }
+        case 'commandExecution':
+        case 'fileChange':
+        case 'mcpToolCall':
         case 'webSearch': {
-          const part = makeCodexToolPart({
-            toolName: 'WebSearch',
-            toolCallId: itemId,
-            input: { query: item.query },
-            status: 'completed',
-            output: '',
-          });
-          messages.push({
-            id: `codex-${itemId}`,
-            role: 'assistant',
-            parts: [part],
-          });
+          const part = mapCodexToolItem(item, itemId);
+          if (!part) return { turnActive };
+          upsertCodexToolMessage(messages, itemId, part);
           return { turnActive };
         }
         default:
@@ -547,6 +490,96 @@ function handleCodexEvent(
       // Other Codex methods (item/started, thread/*, account/*, mcpServer/*,
       // tokenUsage, etc.) are not surfaced in Phase 0.
       return { turnActive };
+  }
+}
+
+/**
+ * Map a Codex tool-shaped `ThreadItem` (from `item/started` or `item/completed`)
+ * to a `DynamicToolUIPart`. Returns `null` for non-tool items so callers can
+ * skip without re-checking the type.
+ */
+function mapCodexToolItem(
+  item: Record<string, unknown>,
+  itemId: string,
+): DynamicToolUIPart | null {
+  const itemType = String(item.type ?? '');
+  switch (itemType) {
+    case 'commandExecution':
+      return makeCodexToolPart({
+        toolName: 'Bash',
+        toolCallId: itemId,
+        input: { command: item.command, cwd: item.cwd },
+        status: String(item.status ?? 'inProgress'),
+        output: item.aggregatedOutput,
+      });
+    case 'fileChange': {
+      const changes = Array.isArray(item.changes) ? item.changes : [];
+      return makeCodexToolPart({
+        toolName: 'Edit',
+        toolCallId: itemId,
+        input: { changes },
+        status: String(item.status ?? 'inProgress'),
+        output: `${changes.length} file change${changes.length === 1 ? '' : 's'}`,
+      });
+    }
+    case 'mcpToolCall': {
+      const server = String(item.server ?? '');
+      const tool = String(item.tool ?? '');
+      const error = item.error as Record<string, unknown> | string | null;
+      // Codex may report errors as plain strings (`"timeout"`) or as
+      // structured objects (`{ message: '...' }`). Coerce both without
+      // wrapping bare strings in JSON quotes.
+      let errorText: string | undefined;
+      if (error) {
+        if (typeof error === 'string') {
+          errorText = error;
+        } else {
+          const msg = (error as Record<string, unknown>).message;
+          errorText = typeof msg === 'string' ? msg : JSON.stringify(error);
+        }
+      }
+      return makeCodexToolPart({
+        toolName: `mcp__${server}__${tool}`,
+        toolCallId: itemId,
+        input: item.arguments,
+        status: error ? 'failed' : String(item.status ?? 'inProgress'),
+        output: item.result,
+        errorText,
+      });
+    }
+    case 'webSearch':
+      return makeCodexToolPart({
+        toolName: 'WebSearch',
+        toolCallId: itemId,
+        input: { query: item.query },
+        // webSearch items have no status field on the ThreadItem; Phase 0
+        // treats `item/started` as in-progress and `item/completed` as done.
+        status: typeof item.query === 'string' ? 'completed' : 'inProgress',
+        output: '',
+      });
+    default:
+      return null;
+  }
+}
+
+/**
+ * Insert or replace a tool-call UIMessage keyed by `codex-${itemId}` so the
+ * same message updates from `item/started` (input-available) → `item/completed`
+ * (output-available / output-error / output-denied).
+ */
+function upsertCodexToolMessage(
+  // biome-ignore lint/suspicious/noExplicitAny: UIMessage parts union is complex
+  messages: any[],
+  itemId: string,
+  part: DynamicToolUIPart,
+): void {
+  const id = `codex-${itemId}`;
+  const idx = messages.findIndex((m) => m.id === id);
+  const msg = { id, role: 'assistant', parts: [part] };
+  if (idx === -1) {
+    messages.push(msg);
+  } else {
+    messages[idx] = msg;
   }
 }
 

--- a/src/frontend/lib/sdkToUIMessages.ts
+++ b/src/frontend/lib/sdkToUIMessages.ts
@@ -328,7 +328,7 @@ export function sdkToUIMessages(
   // (last id, turn still in flight, session running) keeps 'streaming'.
   for (const itemId of codexAgentText.keys()) {
     if (codexCompletedAgentIds.has(itemId)) continue;
-    const idx = messages.findIndex((m) => m.id === itemId);
+    const idx = messages.findIndex((m) => m.id === `codex-${itemId}`);
     if (idx === -1) continue;
     const msg = messages[idx];
     if (!msg) continue;
@@ -412,10 +412,21 @@ function handleCodexEvent(
           const content = Array.isArray(item.content)
             ? (item.content as Array<Record<string, unknown>>)
             : [];
-          const text = content
+          const textParts = content
             .filter((c) => c.type === 'text')
             .map((c) => String(c.text ?? ''))
-            .join('');
+            .filter(Boolean);
+          // Non-text inputs (image/localImage/skill/mention) lose their content
+          // payload in Phase 0 — the UI doesn't render attachments yet — but we
+          // emit a placeholder so the turn boundary stays visible in the thread.
+          const nonTextKinds = content
+            .map((c) => String(c.type ?? ''))
+            .filter((t) => t && t !== 'text');
+          let text = textParts.join('');
+          if (!text && nonTextKinds.length > 0) {
+            const unique = Array.from(new Set(nonTextKinds));
+            text = `[${unique.join(', ')}]`;
+          }
           if (!text) return { turnActive };
           messages.push({
             id: `codex-${itemId}`,
@@ -484,16 +495,26 @@ function handleCodexEvent(
           const status = String(item.status ?? '');
           const server = String(item.server ?? '');
           const tool = String(item.tool ?? '');
-          const error = item.error as Record<string, unknown> | null;
+          const error = item.error as Record<string, unknown> | string | null;
+          // Codex may report errors as plain strings (`"timeout"`) or as
+          // structured objects (`{ message: '...' }`). Coerce both shapes
+          // without wrapping bare strings in JSON quotes.
+          let errorText: string | undefined;
+          if (error) {
+            if (typeof error === 'string') {
+              errorText = error;
+            } else {
+              const msg = (error as Record<string, unknown>).message;
+              errorText = typeof msg === 'string' ? msg : JSON.stringify(error);
+            }
+          }
           const part = makeCodexToolPart({
             toolName: `mcp__${server}__${tool}`,
             toolCallId: itemId,
             input: item.arguments,
             status: error ? 'failed' : status,
             output: item.result,
-            errorText: error
-              ? String(error.message ?? JSON.stringify(error))
-              : undefined,
+            errorText,
           });
           messages.push({
             id: `codex-${itemId}`,
@@ -541,7 +562,7 @@ function upsertCodexAgentMessage(
   state: 'streaming' | 'done' = 'streaming',
 ): void {
   if (!text) return;
-  const id = itemId;
+  const id = `codex-${itemId}`;
   const idx = messages.findIndex((m) => m.id === id);
   const part = { type: 'text', text, state };
   if (idx === -1) {

--- a/src/frontend/lib/sdkToUIMessages.ts
+++ b/src/frontend/lib/sdkToUIMessages.ts
@@ -410,7 +410,7 @@ function handleCodexEvent(
       const item = (payload.item ?? {}) as Record<string, unknown>;
       const itemId = String(item.id ?? '');
       if (!itemId) return { turnActive };
-      const part = mapCodexToolItem(item, itemId);
+      const part = mapCodexToolItem(item, itemId, false);
       if (!part) return { turnActive };
       upsertCodexToolMessage(messages, itemId, part);
       return { turnActive };
@@ -476,7 +476,7 @@ function handleCodexEvent(
         case 'fileChange':
         case 'mcpToolCall':
         case 'webSearch': {
-          const part = mapCodexToolItem(item, itemId);
+          const part = mapCodexToolItem(item, itemId, true);
           if (!part) return { turnActive };
           upsertCodexToolMessage(messages, itemId, part);
           return { turnActive };
@@ -501,6 +501,7 @@ function handleCodexEvent(
 function mapCodexToolItem(
   item: Record<string, unknown>,
   itemId: string,
+  completed: boolean,
 ): DynamicToolUIPart | null {
   const itemType = String(item.type ?? '');
   switch (itemType) {
@@ -552,9 +553,10 @@ function mapCodexToolItem(
         toolName: 'WebSearch',
         toolCallId: itemId,
         input: { query: item.query },
-        // webSearch items have no status field on the ThreadItem; Phase 0
-        // treats `item/started` as in-progress and `item/completed` as done.
-        status: typeof item.query === 'string' ? 'completed' : 'inProgress',
+        // webSearch ThreadItem has no `status` field, and `query` is present in
+        // both item/started and item/completed payloads — so we rely on the
+        // event boundary the caller passes in.
+        status: completed ? 'completed' : 'inProgress',
         output: '',
       });
     default:


### PR DESCRIPTION
## Summary
- `sdkToUIMessages` now handles `codex.<method>` events: `item/agentMessage/delta` streams into the assistant bubble, `item/completed` maps each item kind (`userMessage`, `agentMessage`, `reasoning`, `commandExecution`, `fileChange`, `mcpToolCall`, `webSearch`) to the existing `UIMessage` shape so `ToolCallUI` and `<Reasoning>` render them unchanged.
- New `isThinking` signal in `useHolophyteChat` gates the thinking indicator on Codex turn boundaries — Codex sessions stay `running` between turns, so session status alone left the spinner stuck after `turn/completed`. The hook scans the most recent `codex.turn/*` event and clears the indicator on completion.
- Closes the known gap from PR #277 (Task 6): successful Codex turns now produce visible assistant messages, tool cards, and reasoning sections; the spinner clears.

## Test plan
- [x] `bun run test` — 707 tests pass (12 new Codex sdkToUIMessages tests, 5 new isThinking tests, 2 new SessionThread isThinking tests)
- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] Codex review (`/codex:review`) — flagged missing `userMessage` rendering; fixed in this PR
- [x] Codex adversarial review (`/codex:adversarial-review`) — flagged reasoning `content` exposure; kept as-is per spec (reasoning lives in collapsed `<Reasoning>` block, matches Claude pattern)
- [x] Manual: run a Codex session end-to-end and confirm bubbles + bash/file-change cards render and thinking indicator clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved thinking-indicator control (explicit override) and more accurate display across session types.
  * Added rendering for Codex-style event streams (user turns, agent responses, reasoning, and tool outputs).
  * Updated assistive text from “Claude is thinking” to “Assistant is thinking”.

* **Bug Fixes**
  * Fixed queued-message indicator behavior for multi-turn/streaming sessions.

* **Tests**
  * Added/expanded tests for thinking indicator, Codex handling, and message rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->