### PR TITLE
chore: override @anthropic-ai/sdk to patch GHSA-p7fg-763f-g4gf

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -68,7 +68,7 @@
     },
   },
   "overrides": {
-    "@anthropic-ai/sdk": "^0.92.0",
+    "@anthropic-ai/sdk": "0.92.0",
     "@hono/node-server": "^1.19.14",
     "dompurify": "^3.4.0",
     "hono": "^4.12.14",
@@ -76,7 +76,7 @@
     "picomatch": "^4.0.4",
     "postcss": "^8.5.10",
     "rollup": "^4.60.2",
-    "uuid": "^14.0.0",
+    "uuid": "14.0.0",
     "vite": "^7.3.2",
   },
   "packages": {

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,6 @@
     "picomatch": "^4.0.4",
     "postcss": "^8.5.10",
     "rollup": "^4.60.2",
-    "uuid": "14.0.0",
     "vite": "^7.3.2",
   },
   "packages": {
@@ -1694,7 +1693,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,7 @@
     },
   },
   "overrides": {
+    "@anthropic-ai/sdk": "^0.92.0",
     "@hono/node-server": "^1.19.14",
     "dompurify": "^3.4.0",
     "hono": "^4.12.14",
@@ -75,6 +76,7 @@
     "picomatch": "^4.0.4",
     "postcss": "^8.5.10",
     "rollup": "^4.60.2",
+    "uuid": "^14.0.0",
     "vite": "^7.3.2",
   },
   "packages": {
@@ -108,7 +110,7 @@
 
     "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.126", "", { "os": "win32", "cpu": "x64" }, "sha512-oRV75HwyoOd1/t5+kipAM2g62CaElpKGvSBx3Ys4lCwCiFUyOnmet/O+hRXENsY6ShDeQZEcJL2UWljr2d5NQw=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.92.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
 
@@ -1692,7 +1694,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "hono": "^4.12.14",
     "@hono/node-server": "^1.19.14",
     "postcss": "^8.5.10",
-    "@anthropic-ai/sdk": "0.92.0",
-    "uuid": "14.0.0"
+    "@anthropic-ai/sdk": "0.92.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "dompurify": "^3.4.0",
     "hono": "^4.12.14",
     "@hono/node-server": "^1.19.14",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "@anthropic-ai/sdk": "^0.92.0",
+    "uuid": "^14.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "hono": "^4.12.14",
     "@hono/node-server": "^1.19.14",
     "postcss": "^8.5.10",
-    "@anthropic-ai/sdk": "^0.92.0",
-    "uuid": "^14.0.0"
+    "@anthropic-ai/sdk": "0.92.0",
+    "uuid": "14.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Force the transitive `@anthropic-ai/sdk` past its vulnerable range via a `package.json` override, since `@anthropic-ai/claude-agent-sdk@0.2.137` (latest) still pins `^0.81.0`.

| Override | From | To | Advisory | Severity |
|---|---|---|---|---|
| `@anthropic-ai/sdk` | 0.81.0 | 0.92.0 | [GHSA-p7fg-763f-g4gf](https://github.com/advisories/GHSA-p7fg-763f-g4gf) | Moderate |

A `uuid` override was also considered for [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) but **dropped** — that advisory only triggers when a caller passes `buf` to `v3`/`v5`/`v6`, and our only consumer (mermaid) doesn't. Closed as not exposed in #283.

## Risk

`@anthropic-ai/claude-agent-sdk@0.2.126` (and current 0.2.137) declares `@anthropic-ai/sdk: ^0.81.0`. Forcing 0.92.0 means the agent SDK runs against an SDK version it was never validated with. Pre-1.0 minor bumps in `@anthropic-ai/sdk` have included breaking changes to streaming helpers, beta-client shapes, and tool-call wire formats.

We don't directly import `@anthropic-ai/sdk` ourselves — only the agent SDK does, transitively. So the runtime risk surface is **session spawning and event streaming**, which unit tests do not exercise.

Local `bun run check` (lint + typecheck + 717 unit tests) passes; isolated `bun run test:e2e:isolated` passes (67/67). E2E does not exercise live Claude session spawning against `@anthropic-ai/sdk@0.92`.

If anything breaks at runtime, revert this PR and reopen #282 to wait for upstream.

## Test plan

- [ ] CI green (lint, typecheck, unit, E2E)
- [ ] Vercel preview loads
- [ ] Spawn a Claude session in the preview and verify events stream correctly (exercises agent SDK → @anthropic-ai/sdk path)

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)