### PR TITLE
feat(codex): Task 8 — render approval cards for shell + file change

### DIFF
--- a/convex/sessions.test.ts
+++ b/convex/sessions.test.ts
@@ -69,24 +69,33 @@ describe('sessions.create', () => {
     expect(session?.permissionMode).toBe('bypass');
   });
 
-  it("accepts provider: 'codex' without permissionMode (companion dispatcher provides the fallback)", async () => {
-    // The boundary intentionally accepts an omitted permissionMode — the
-    // companion dispatcher in src/server/subscriptions.ts coalesces undefined
-    // to 'bypass' for Codex (Task 3's approvalPolicyForMode currently only
-    // supports bypass; widens in Task 5) and 'safe-auto' for Claude
-    // (preserves the Claude manager's pre-existing default). Document that
-    // invariant here so a future reviewer sees the boundary doesn't reject.
+  it("defaults Codex sessions without permissionMode to 'default'", async () => {
+    // Task 8 dropped the companion-side fallback ('bypass' for Codex). The
+    // mutation now stamps 'default' for Codex sessions launched without an
+    // explicit mode, so approvals route through the bridge + UI shipped
+    // alongside this task. Claude sessions still allow undefined — the
+    // Claude manager has its own 'safe-auto' default.
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
-    const sessionId = await authed.mutation(api.sessions.create, {
+    const codexSessionId = await authed.mutation(api.sessions.create, {
       taskId,
       provider: 'codex',
     });
+    const codexSession = await authed.query(api.sessions.get, {
+      id: codexSessionId,
+    });
+    expect(codexSession?.provider).toBe('codex');
+    expect(codexSession?.permissionMode).toBe('default');
 
-    const session = await authed.query(api.sessions.get, { id: sessionId });
-    expect(session?.provider).toBe('codex');
-    expect(session?.permissionMode).toBeUndefined();
+    const claudeSessionId = await authed.mutation(api.sessions.create, {
+      taskId,
+      provider: 'claude',
+    });
+    const claudeSession = await authed.query(api.sessions.get, {
+      id: claudeSessionId,
+    });
+    expect(claudeSession?.permissionMode).toBeUndefined();
   });
 
   it('requires member role', async () => {

--- a/convex/sessions.test.ts
+++ b/convex/sessions.test.ts
@@ -69,12 +69,13 @@ describe('sessions.create', () => {
     expect(session?.permissionMode).toBe('bypass');
   });
 
-  it("defaults Codex sessions without permissionMode to 'default'", async () => {
-    // Task 8 dropped the companion-side fallback ('bypass' for Codex). The
-    // mutation now stamps 'default' for Codex sessions launched without an
-    // explicit mode, so approvals route through the bridge + UI shipped
-    // alongside this task. Claude sessions still allow undefined — the
-    // Claude manager has its own 'safe-auto' default.
+  it("defaults Codex sessions without permissionMode to 'bypass'", async () => {
+    // Task 8 dropped the companion-side fallback for Codex. The mutation
+    // stamps 'bypass' for Codex sessions launched without an explicit mode
+    // — Phase 0 only renders 2 of 7 Codex approval methods, so a stricter
+    // default would silently auto-deny common operations. Claude sessions
+    // still allow undefined — the Claude manager has its own 'safe-auto'
+    // default.
     const t = convexTest(schema);
     const { authed, taskId } = await setupTaskEnv(t);
 
@@ -86,7 +87,7 @@ describe('sessions.create', () => {
       id: codexSessionId,
     });
     expect(codexSession?.provider).toBe('codex');
-    expect(codexSession?.permissionMode).toBe('default');
+    expect(codexSession?.permissionMode).toBe('bypass');
 
     const claudeSessionId = await authed.mutation(api.sessions.create, {
       taskId,

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -151,13 +151,17 @@ export const create = mutation({
     const now = Date.now();
     // Codex sessions require a permissionMode at the companion layer
     // (companion no longer applies a fallback as of Task 8). Until the
-    // launch UI surfaces a permissionMode picker, default to 'default' so
-    // approvals route through the bridge + UI shipped with Tasks 5/7/8.
-    // Claude sessions still allow undefined — the Claude manager tolerates
-    // it via its own 'safe-auto' default.
+    // launch UI surfaces a permissionMode picker, default to 'bypass'.
+    // 'default' (untrusted) is intentionally NOT the default yet — Phase 0
+    // only renders 2 of the 7 Codex approval methods, so 'default' would
+    // silently auto-deny the other 5 (applyPatchApproval, execCommand-
+    // Approval, item/permissions/requestApproval, item/tool/requestUser-
+    // Input, mcpServer/elicitation/request). Opt into 'default' or
+    // 'safe-auto' via the dev script until Phase 0.1 covers the full
+    // approval surface. Claude sessions still allow undefined — the Claude
+    // manager tolerates it via its own 'safe-auto' default.
     const permissionMode =
-      args.permissionMode ??
-      (args.provider === 'codex' ? 'default' : undefined);
+      args.permissionMode ?? (args.provider === 'codex' ? 'bypass' : undefined);
     return await ctx.db.insert('sessions', {
       taskId: args.taskId,
       orgId: repo.orgId,

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -149,6 +149,15 @@ export const create = mutation({
     const { membership } = await requireOrgMembership(ctx, repo.orgId);
     requireRole(membership, 'member');
     const now = Date.now();
+    // Codex sessions require a permissionMode at the companion layer
+    // (companion no longer applies a fallback as of Task 8). Until the
+    // launch UI surfaces a permissionMode picker, default to 'default' so
+    // approvals route through the bridge + UI shipped with Tasks 5/7/8.
+    // Claude sessions still allow undefined — the Claude manager tolerates
+    // it via its own 'safe-auto' default.
+    const permissionMode =
+      args.permissionMode ??
+      (args.provider === 'codex' ? 'default' : undefined);
     return await ctx.db.insert('sessions', {
       taskId: args.taskId,
       orgId: repo.orgId,
@@ -158,7 +167,7 @@ export const create = mutation({
       queuedPrompt: args.prompt,
       queuedReasoningEffort: args.reasoningEffort,
       model: args.model,
-      permissionMode: args.permissionMode,
+      permissionMode,
       provider: args.provider,
     });
   },

--- a/docs/docs/codex-permissionmode-picker.md
+++ b/docs/docs/codex-permissionmode-picker.md
@@ -1,0 +1,86 @@
+---
+title: Codex permission-mode picker (follow-up)
+draft: true
+---
+
+# Codex permission-mode picker (follow-up)
+
+**Status:** Not started. Tracking note only.
+
+**Discovered while shipping:** Task 8 — Codex approval renderer (PR #285, branch `feat/codex-task-8`).
+
+## Problem
+
+Task 8 added the FE renderer for Codex approval cards (`Run shell command?` /
+`Write to file?`) and removed the companion-side `'bypass'` coercion for Codex
+sessions. The renderer works, but there is no UI to set `permissionMode` on a
+Codex session. `convex/sessions.create` defaults Codex sessions to `'bypass'`
+to preserve pre-Task-8 UX, so approval cards never fire through the normal
+launch flow.
+
+Net effect: the renderer is dead code from a user's POV until the picker
+ships. Manual testing requires either temporarily flipping the default in
+`convex/sessions.ts` or calling `sessions.create` directly via
+`bunx convex run` / Convex dashboard.
+
+## What needs to ship
+
+A single `<Select>` (or similar) in the Codex session launch surface that lets
+the user choose between:
+
+- `default` — every supported approval method prompts.
+- `safe-auto` — Codex's built-in safe profile (auto-approves read-only ops).
+- `bypass` — current behavior; no prompts.
+
+Default should be `bypass` to preserve the existing one-click launch UX. Last
+choice should persist per-repo or per-task to match the existing
+`selectedModel` pattern.
+
+The companion side and Convex side already accept the value end-to-end:
+
+- `convex/sessions.create` `args.permissionMode` — already validated, plumbed
+  to the row (`convex/sessions.ts:163-164`).
+- `src/server/subscriptions.ts handleQueuedSession` — passes the row's
+  `permissionMode` to `codex.startSession`; only falls back to `'bypass'` for
+  pre-Task-8 in-flight rows (migration shim, see TSDoc on that function).
+- `src/codex/manager.ts startSession` — accepts `permissionMode: PermissionMode`
+  and configures the SDK accordingly.
+
+So the work is purely frontend wiring + a state-persistence hook.
+
+## Estimated effort
+
+~30-60 min for the picker + ~15 min for a unit test. Low risk — pure UI
+delta, no schema or contract changes.
+
+## Suggested approach
+
+1. Find the Codex session launch surface (model picker / launch button in
+   `src/frontend/components/session/`).
+2. Add a permission-mode dropdown next to the model dropdown. Reuse the same
+   Radix `Select` primitive.
+3. Persist last choice via Zustand (mirror `selectedModel`).
+4. Thread into the existing `api.sessions.create` mutation call.
+5. Unit test: render the dropdown, change it, assert mutation arg.
+6. Optional E2E: launch a Codex session in `default`, verify the approval
+   card appears for a write op.
+
+## Why this isn't bundled into PR #285
+
+PR #285 is scoped to Task 8 (renderer + companion cleanup). Bundling a new
+picker drags Task 6's unfinished work into a different branch's review
+surface. Cleaner as a stacked follow-up PR on top of `feat/codex-task-8`
+once merged, per the project's "stacked PRs for incremental features" rule
+in `CLAUDE.md`.
+
+## Workaround until then
+
+To exercise the renderer manually, edit `convex/sessions.ts:164` to default
+Codex to `'default'`:
+
+```ts
+args.permissionMode ?? (args.provider === 'codex' ? 'default' : undefined);
+```
+
+Convex hot-reloads. Launch a Codex session, trigger a file write or shell
+command. Revert before committing.

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -533,7 +533,7 @@ export async function startSession(opts: {
   repoPath: string;
   prompt: string;
   model?: string;
-  permissionMode: PermissionMode;
+  permissionMode?: PermissionMode;
   reasoningEffort?: string;
   resumeProviderSessionId?: string;
 }): Promise<{ sessionId: string; warning?: string }> {
@@ -553,18 +553,6 @@ export async function startSession(opts: {
   const mode = opts.permissionMode;
   if (!mode || !VALID_PERMISSION_MODES.has(mode)) {
     throw new Error(`Invalid permissionMode: ${mode}`);
-  }
-
-  // Phase 0: the approval bridge persists rows, but no UI surface yet renders
-  // Codex approval prompts (`codex.item/*` notifications aren't bridged into
-  // sdkToUIMessages until Tasks 7+8). A non-bypass session that hits an
-  // approval will park the turn until the 5-min poll timeout, then auto-deny.
-  // The companion dispatch falls back to 'bypass' for null-mode Codex
-  // sessions, so this only fires for explicit opt-in (e.g. dev helper script).
-  if (mode !== 'bypass') {
-    console.warn(
-      `[codex session ${opts.sessionId}] permissionMode=${mode} selected, but Phase 0 has no Codex approval UI yet — approval prompts will park until the 5-min poll timeout and then auto-deny. Use 'bypass' for non-test sessions until Tasks 7+8 land.`,
-    );
   }
 
   let initialBatchIndex = 0;

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -533,7 +533,7 @@ export async function startSession(opts: {
   repoPath: string;
   prompt: string;
   model?: string;
-  permissionMode?: PermissionMode;
+  permissionMode: PermissionMode;
   reasoningEffort?: string;
   resumeProviderSessionId?: string;
 }): Promise<{ sessionId: string; warning?: string }> {

--- a/src/frontend/components/ai-elements/terminal.tsx
+++ b/src/frontend/components/ai-elements/terminal.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import Ansi from 'ansi-to-react';
+// `ansi-to-react` is CJS; Bun's browser bundler can hand us the module
+// namespace object (with a `.default` property) instead of the component
+// function depending on HMR state. Coerce both shapes to the same function so
+// React.createElement always gets a component, not an object.
+import AnsiImport from 'ansi-to-react';
+
+const Ansi = ((AnsiImport as unknown as { default?: typeof AnsiImport })
+  .default ?? AnsiImport) as typeof AnsiImport;
+
 import { CheckIcon, CopyIcon, TerminalIcon, Trash2Icon } from 'lucide-react';
 import type { ComponentProps, HTMLAttributes } from 'react';
 import {

--- a/src/frontend/components/ai-elements/terminal.tsx
+++ b/src/frontend/components/ai-elements/terminal.tsx
@@ -1,14 +1,5 @@
 'use client';
 
-// `ansi-to-react` is CJS; Bun's browser bundler can hand us the module
-// namespace object (with a `.default` property) instead of the component
-// function depending on HMR state. Coerce both shapes to the same function so
-// React.createElement always gets a component, not an object.
-import AnsiImport from 'ansi-to-react';
-
-const Ansi = ((AnsiImport as unknown as { default?: typeof AnsiImport })
-  .default ?? AnsiImport) as typeof AnsiImport;
-
 import { CheckIcon, CopyIcon, TerminalIcon, Trash2Icon } from 'lucide-react';
 import type { ComponentProps, HTMLAttributes } from 'react';
 import {
@@ -21,6 +12,11 @@ import {
   useState,
 } from 'react';
 import { Button } from '@/frontend/components/ui/Button';
+// CUSTOMIZED: imports the normalized `Ansi` from `@/frontend/lib/ansi`
+// instead of `ansi-to-react` directly to work around Bun's browser-bundle
+// CJS interop. If this file is regenerated via `bunx shadcn add terminal`,
+// reapply this import change. See `src/frontend/lib/ansi.ts` for context.
+import { Ansi } from '@/frontend/lib/ansi';
 import { cn } from '@/frontend/lib/utils';
 
 interface TerminalContextType {

--- a/src/frontend/components/session/ToolCallUI.test.tsx
+++ b/src/frontend/components/session/ToolCallUI.test.tsx
@@ -449,6 +449,28 @@ describe('ToolCallUI', () => {
       expect(screen.getByText('/tmp/x.ts')).toBeInTheDocument();
     });
 
+    it('uses plural "Write to files?" header when multiple paths', () => {
+      const part = makePart({
+        toolName: 'Edit',
+        toolCallId: 'fc-plural',
+        state: 'approval-requested',
+        input: {},
+        approval: {
+          id: 'fc-plural',
+          codex: {
+            tool: 'codex.item/fileChange/requestApproval',
+            input: {
+              changes: [{ path: '/tmp/a.ts' }, { path: '/tmp/b.ts' }],
+            },
+          },
+        },
+      } as unknown as DynamicToolUIPart);
+      render(<ToolCallUI part={part} />, { wrapper: withSessionActions() });
+      expect(screen.getByTestId('collapsible-trigger').textContent).toContain(
+        'Write to files?',
+      );
+    });
+
     it('renders "+N more" suffix when fileChange approval lists multiple paths', () => {
       const part = makePart({
         toolName: 'Edit',

--- a/src/frontend/components/session/ToolCallUI.test.tsx
+++ b/src/frontend/components/session/ToolCallUI.test.tsx
@@ -410,12 +410,12 @@ describe('ToolCallUI', () => {
         toolName: 'Bash',
         toolCallId: 'cmd-1',
         state: 'approval-requested',
-        input: { command: 'ls' },
+        input: { command: 'ls -la', cwd: '/tmp' },
         approval: {
           id: 'cmd-1',
           codex: {
             tool: 'codex.item/commandExecution/requestApproval',
-            input: { command: 'ls -la', cwd: '/tmp' },
+            input: {},
           },
         },
       } as unknown as DynamicToolUIPart);
@@ -423,8 +423,9 @@ describe('ToolCallUI', () => {
       expect(screen.getByTestId('collapsible-trigger').textContent).toContain(
         'Run shell command?',
       );
-      // Command preview comes from the approval payload (input.command),
-      // not the placeholder tool input.
+      // Command/cwd come from the tool part's `input` (set by
+      // `mapCodexToolItem` from `item/started`). The Codex approval
+      // `rawParams` itself only carries thread/turn/item ids.
       expect(screen.getByTestId('terminal').textContent).toContain('ls -la');
     });
 
@@ -433,12 +434,12 @@ describe('ToolCallUI', () => {
         toolName: 'Edit',
         toolCallId: 'fc-1',
         state: 'approval-requested',
-        input: {},
+        input: { changes: [{ path: '/tmp/x.ts' }] },
         approval: {
           id: 'fc-1',
           codex: {
             tool: 'codex.item/fileChange/requestApproval',
-            input: { changes: [{ path: '/tmp/x.ts' }] },
+            input: {},
           },
         },
       } as unknown as DynamicToolUIPart);
@@ -454,14 +455,14 @@ describe('ToolCallUI', () => {
         toolName: 'Edit',
         toolCallId: 'fc-plural',
         state: 'approval-requested',
-        input: {},
+        input: {
+          changes: [{ path: '/tmp/a.ts' }, { path: '/tmp/b.ts' }],
+        },
         approval: {
           id: 'fc-plural',
           codex: {
             tool: 'codex.item/fileChange/requestApproval',
-            input: {
-              changes: [{ path: '/tmp/a.ts' }, { path: '/tmp/b.ts' }],
-            },
+            input: {},
           },
         },
       } as unknown as DynamicToolUIPart);
@@ -476,18 +477,18 @@ describe('ToolCallUI', () => {
         toolName: 'Edit',
         toolCallId: 'fc-multi',
         state: 'approval-requested',
-        input: {},
+        input: {
+          changes: [
+            { path: '/tmp/a.ts' },
+            { path: '/tmp/b.ts' },
+            { path: '/tmp/c.ts' },
+          ],
+        },
         approval: {
           id: 'fc-multi',
           codex: {
             tool: 'codex.item/fileChange/requestApproval',
-            input: {
-              changes: [
-                { path: '/tmp/a.ts' },
-                { path: '/tmp/b.ts' },
-                { path: '/tmp/c.ts' },
-              ],
-            },
+            input: {},
           },
         },
       } as unknown as DynamicToolUIPart);

--- a/src/frontend/components/session/ToolCallUI.test.tsx
+++ b/src/frontend/components/session/ToolCallUI.test.tsx
@@ -404,6 +404,99 @@ describe('ToolCallUI', () => {
     });
   });
 
+  describe('Codex approval markers', () => {
+    it('renders "Run shell command?" header for commandExecution approvals', () => {
+      const part = makePart({
+        toolName: 'Bash',
+        toolCallId: 'cmd-1',
+        state: 'approval-requested',
+        input: { command: 'ls' },
+        approval: {
+          id: 'cmd-1',
+          codex: {
+            tool: 'codex.item/commandExecution/requestApproval',
+            input: { command: 'ls -la', cwd: '/tmp' },
+          },
+        },
+      } as unknown as DynamicToolUIPart);
+      render(<ToolCallUI part={part} />, { wrapper: withSessionActions() });
+      expect(screen.getByTestId('collapsible-trigger').textContent).toContain(
+        'Run shell command?',
+      );
+      // Command preview comes from the approval payload (input.command),
+      // not the placeholder tool input.
+      expect(screen.getByTestId('terminal').textContent).toContain('ls -la');
+    });
+
+    it('renders "Write to file?" header and shows path for fileChange approvals', () => {
+      const part = makePart({
+        toolName: 'Edit',
+        toolCallId: 'fc-1',
+        state: 'approval-requested',
+        input: {},
+        approval: {
+          id: 'fc-1',
+          codex: {
+            tool: 'codex.item/fileChange/requestApproval',
+            input: { changes: [{ path: '/tmp/x.ts' }] },
+          },
+        },
+      } as unknown as DynamicToolUIPart);
+      render(<ToolCallUI part={part} />, { wrapper: withSessionActions() });
+      expect(screen.getByTestId('collapsible-trigger').textContent).toContain(
+        'Write to file?',
+      );
+      expect(screen.getByText('/tmp/x.ts')).toBeInTheDocument();
+    });
+
+    it('renders "+N more" suffix when fileChange approval lists multiple paths', () => {
+      const part = makePart({
+        toolName: 'Edit',
+        toolCallId: 'fc-multi',
+        state: 'approval-requested',
+        input: {},
+        approval: {
+          id: 'fc-multi',
+          codex: {
+            tool: 'codex.item/fileChange/requestApproval',
+            input: {
+              changes: [
+                { path: '/tmp/a.ts' },
+                { path: '/tmp/b.ts' },
+                { path: '/tmp/c.ts' },
+              ],
+            },
+          },
+        },
+      } as unknown as DynamicToolUIPart);
+      render(<ToolCallUI part={part} />, { wrapper: withSessionActions() });
+      expect(screen.getByText('/tmp/a.ts')).toBeInTheDocument();
+      expect(screen.getByText(/and 2 more/)).toBeInTheDocument();
+    });
+
+    it('routes Approve click through approve(toolCallId) for codex parts', async () => {
+      const approve = vi.fn();
+      const part = makePart({
+        toolName: 'Bash',
+        toolCallId: 'cmd-route',
+        state: 'approval-requested',
+        input: {},
+        approval: {
+          id: 'cmd-route',
+          codex: {
+            tool: 'codex.item/commandExecution/requestApproval',
+            input: { command: 'ls' },
+          },
+        },
+      } as unknown as DynamicToolUIPart);
+      render(<ToolCallUI part={part} />, {
+        wrapper: withSessionActions(approve),
+      });
+      await userEvent.click(screen.getByRole('button', { name: /approve/i }));
+      expect(approve).toHaveBeenCalledWith('cmd-route');
+    });
+  });
+
   describe('state: output-denied', () => {
     it('does not show approval buttons for output-denied state', () => {
       const part = makePart({

--- a/src/frontend/components/session/ToolCallUI.tsx
+++ b/src/frontend/components/session/ToolCallUI.tsx
@@ -26,6 +26,119 @@ interface ToolCallUIProps {
 
 const BASH_TOOLS = new Set(['Bash']);
 
+interface CodexApprovalMarker {
+  tool: string;
+  input: Record<string, unknown>;
+}
+
+/**
+ * Pull the Codex approval marker off a `dynamic-tool` part if present.
+ * Bridge-routed Codex approvals carry `approval.codex = { tool, input }`
+ * (see `sdkToUIMessages.ts`). Returns `null` for SDK / non-Codex parts.
+ */
+function getCodexApproval(part: DynamicToolUIPart): CodexApprovalMarker | null {
+  if (
+    part.state !== 'approval-requested' &&
+    part.state !== 'approval-responded' &&
+    part.state !== 'output-denied'
+  ) {
+    return null;
+  }
+  const approval = (part as { approval?: unknown }).approval;
+  if (!approval || typeof approval !== 'object') return null;
+  const codex = (approval as { codex?: unknown }).codex;
+  if (!codex || typeof codex !== 'object') return null;
+  const c = codex as { tool?: unknown; input?: unknown };
+  if (typeof c.tool !== 'string') return null;
+  return {
+    tool: c.tool,
+    input: (c.input ?? {}) as Record<string, unknown>,
+  };
+}
+
+/**
+ * Phase 0 Codex approval copy. The companion bridges only two methods:
+ * `item/commandExecution/requestApproval` and `item/fileChange/requestApproval`.
+ * Title is plain text — path is rendered as inline code in the body when
+ * applicable, not embedded in the header.
+ */
+function codexApprovalTitle(marker: CodexApprovalMarker): string {
+  switch (marker.tool) {
+    case 'codex.item/commandExecution/requestApproval':
+      return 'Run shell command?';
+    case 'codex.item/fileChange/requestApproval': {
+      const path = firstFileChangePath(marker.input);
+      return path ? `Write to file?` : 'Write to files?';
+    }
+    default:
+      return 'Approve Codex action?';
+  }
+}
+
+function firstFileChangePath(
+  input: Record<string, unknown>,
+): string | undefined {
+  // Codex `item/fileChange/requestApproval` carries the request payload —
+  // shape varies by Codex version. Probe a few common keys defensively.
+  const changes = (input.changes ?? input.files) as unknown;
+  if (Array.isArray(changes) && changes.length > 0) {
+    const first = changes[0] as Record<string, unknown> | undefined;
+    if (first && typeof first === 'object') {
+      const path = first.path ?? first.file;
+      if (typeof path === 'string') return path;
+    }
+  }
+  if (typeof input.path === 'string') return input.path;
+  return undefined;
+}
+
+function fileChangeCount(input: Record<string, unknown>): number {
+  const changes = (input.changes ?? input.files) as unknown;
+  if (Array.isArray(changes)) return changes.length;
+  return 0;
+}
+
+/**
+ * Phase 0 Codex approval preview. Command approvals render the proposed
+ * shell command in a terminal-styled block; file-change approvals render
+ * the path(s) inline. Diff / syntax-highlight previews are deferred to
+ * Phase 0.1.
+ */
+function CodexApprovalPreview({ marker }: { marker: CodexApprovalMarker }) {
+  if (marker.tool === 'codex.item/commandExecution/requestApproval') {
+    const command = String(marker.input.command ?? '');
+    const cwd =
+      typeof marker.input.cwd === 'string' ? marker.input.cwd : undefined;
+    return (
+      <div className="px-4 pb-2">
+        {command && <Terminal output={command} />}
+        {cwd && (
+          <p className="mt-1.5 text-xs text-muted-foreground">
+            in <code className="font-mono">{cwd}</code>
+          </p>
+        )}
+      </div>
+    );
+  }
+  if (marker.tool === 'codex.item/fileChange/requestApproval') {
+    const path = firstFileChangePath(marker.input);
+    const count = fileChangeCount(marker.input);
+    return (
+      <div className="px-4 pb-2 text-xs text-muted-foreground">
+        {path ? (
+          <span>
+            <code className="font-mono">{path}</code>
+            {count > 1 && <span> and {count - 1} more</span>}
+          </span>
+        ) : (
+          <span>{count > 0 ? `${count} files` : 'unknown path'}</span>
+        )}
+      </div>
+    );
+  }
+  return null;
+}
+
 export default function ToolCallUI({ part }: ToolCallUIProps) {
   const { approve, deny } = useSessionActions();
   const [denyMode, setDenyMode] = useState(false);
@@ -44,10 +157,10 @@ export default function ToolCallUI({ part }: ToolCallUIProps) {
     if (isApprovalRequested) setOpen(true);
   }, [isApprovalRequested]);
 
-  const titleSummary = toolSummary(
-    part.toolName,
-    part.input as Record<string, unknown>,
-  );
+  const codexMarker = getCodexApproval(part);
+  const titleSummary = codexMarker
+    ? codexApprovalTitle(codexMarker)
+    : toolSummary(part.toolName, part.input as Record<string, unknown>);
 
   const handleApprove = () => {
     approve(part.toolCallId);
@@ -95,7 +208,11 @@ export default function ToolCallUI({ part }: ToolCallUIProps) {
         title={titleSummary || part.toolName}
       />
       <ToolContent>
-        <ToolInput input={part.input} />
+        {codexMarker ? (
+          <CodexApprovalPreview marker={codexMarker} />
+        ) : (
+          <ToolInput input={part.input} />
+        )}
         {renderOutput()}
 
         {/* Approval UI — rendered inline within the tool content */}

--- a/src/frontend/components/session/ToolCallUI.tsx
+++ b/src/frontend/components/session/ToolCallUI.tsx
@@ -69,12 +69,15 @@ function getCodexApproval(part: DynamicToolUIPart): CodexApprovalMarker | null {
  * Title is plain text — path is rendered as inline code in the body when
  * applicable, not embedded in the header.
  */
-function codexApprovalTitle(marker: CodexApprovalMarker): string {
+function codexApprovalTitle(
+  marker: CodexApprovalMarker,
+  partInput: Record<string, unknown>,
+): string {
   switch (marker.tool) {
     case 'codex.item/commandExecution/requestApproval':
       return 'Run shell command?';
     case 'codex.item/fileChange/requestApproval': {
-      const count = fileChangeCount(marker.input);
+      const count = fileChangeCount(partInput);
       return count > 1 ? 'Write to files?' : 'Write to file?';
     }
     default:
@@ -121,11 +124,19 @@ function fileChangeCount(input: Record<string, unknown>): number {
  * the path(s) inline. Diff / syntax-highlight previews are deferred to
  * Phase 0.1.
  */
-function CodexApprovalPreview({ marker }: { marker: CodexApprovalMarker }) {
+function CodexApprovalPreview({
+  marker,
+  partInput,
+}: {
+  marker: CodexApprovalMarker;
+  partInput: Record<string, unknown>;
+}) {
   if (marker.tool === 'codex.item/commandExecution/requestApproval') {
-    const command = String(marker.input.command ?? '');
-    const cwd =
-      typeof marker.input.cwd === 'string' ? marker.input.cwd : undefined;
+    // Command/cwd come from the rendered tool item's input (set by
+    // `mapCodexToolItem` from `item/started`), not the approval params —
+    // `CommandExecutionRequestApprovalParams` only carries thread/turn/item ids.
+    const command = String(partInput.command ?? '');
+    const cwd = typeof partInput.cwd === 'string' ? partInput.cwd : undefined;
     return (
       <div className="px-4 pb-2">
         {command && <Terminal output={command} />}
@@ -138,8 +149,8 @@ function CodexApprovalPreview({ marker }: { marker: CodexApprovalMarker }) {
     );
   }
   if (marker.tool === 'codex.item/fileChange/requestApproval') {
-    const path = firstFileChangePath(marker.input);
-    const count = fileChangeCount(marker.input);
+    const path = firstFileChangePath(partInput);
+    const count = fileChangeCount(partInput);
     return (
       <div className="px-4 pb-2 text-xs text-muted-foreground">
         {path ? (
@@ -185,9 +196,10 @@ export default function ToolCallUI({ part }: ToolCallUIProps) {
   }, [isApprovalRequested]);
 
   const codexMarker = getCodexApproval(part);
+  const partInput = (part.input ?? {}) as Record<string, unknown>;
   const titleSummary = codexMarker
-    ? codexApprovalTitle(codexMarker)
-    : toolSummary(part.toolName, part.input as Record<string, unknown>);
+    ? codexApprovalTitle(codexMarker, partInput)
+    : toolSummary(part.toolName, partInput);
 
   const handleApprove = () => {
     approve(part.toolCallId);
@@ -236,7 +248,7 @@ export default function ToolCallUI({ part }: ToolCallUIProps) {
       />
       <ToolContent>
         {codexMarker ? (
-          <CodexApprovalPreview marker={codexMarker} />
+          <CodexApprovalPreview marker={codexMarker} partInput={partInput} />
         ) : (
           <ToolInput input={part.input} />
         )}

--- a/src/frontend/components/session/ToolCallUI.tsx
+++ b/src/frontend/components/session/ToolCallUI.tsx
@@ -26,6 +26,13 @@ interface ToolCallUIProps {
 
 const BASH_TOOLS = new Set(['Bash']);
 
+/**
+ * Codex-side approval metadata threaded onto a `dynamic-tool` part by
+ * `sdkToUIMessages`. `tool` is the Codex method (e.g.
+ * `'codex.item/commandExecution/requestApproval'`); `input` is the
+ * request's `rawParams` payload (shape varies by method and by Codex
+ * version, hence the `Record<string, unknown>`).
+ */
 interface CodexApprovalMarker {
   tool: string;
   input: Record<string, unknown>;
@@ -75,11 +82,16 @@ function codexApprovalTitle(marker: CodexApprovalMarker): string {
   }
 }
 
+/**
+ * Pulls the first changed path out of an `item/fileChange/requestApproval`
+ * payload. The Codex protocol's request shape isn't tightly versioned —
+ * `changes`, `files`, and a top-level `path` have all surfaced — so probe
+ * each common key. Returns `undefined` when the shape is unrecognised, so
+ * callers can fall back to a path-less label.
+ */
 function firstFileChangePath(
   input: Record<string, unknown>,
 ): string | undefined {
-  // Codex `item/fileChange/requestApproval` carries the request payload —
-  // shape varies by Codex version. Probe a few common keys defensively.
   const changes = (input.changes ?? input.files) as unknown;
   if (Array.isArray(changes) && changes.length > 0) {
     const first = changes[0] as Record<string, unknown> | undefined;
@@ -92,6 +104,11 @@ function firstFileChangePath(
   return undefined;
 }
 
+/**
+ * Counts entries in an `item/fileChange/requestApproval` payload. Returns
+ * `0` when the shape is unrecognised — used by the title to pick singular
+ * vs. plural copy and by the body to render an "and N more" suffix.
+ */
 function fileChangeCount(input: Record<string, unknown>): number {
   const changes = (input.changes ?? input.files) as unknown;
   if (Array.isArray(changes)) return changes.length;
@@ -139,6 +156,16 @@ function CodexApprovalPreview({ marker }: { marker: CodexApprovalMarker }) {
   return null;
 }
 
+/**
+ * Renders a single `dynamic-tool` UIMessage part — Claude SDK tool calls
+ * (`Bash`, `Edit`, etc.) and Codex tool items (`commandExecution`,
+ * `fileChange`, `mcpToolCall`, ...) share this surface. Branches on
+ * `part.state` to render input only / streaming output / final output /
+ * error / approval prompt. Codex approvals are detected via the
+ * `approval.codex` marker (see {@link CodexApprovalMarker}); the title
+ * and preview swap to Codex copy while the Approve / Deny buttons keep
+ * the same shape.
+ */
 export default function ToolCallUI({ part }: ToolCallUIProps) {
   const { approve, deny } = useSessionActions();
   const [denyMode, setDenyMode] = useState(false);

--- a/src/frontend/components/session/ToolCallUI.tsx
+++ b/src/frontend/components/session/ToolCallUI.tsx
@@ -67,8 +67,8 @@ function codexApprovalTitle(marker: CodexApprovalMarker): string {
     case 'codex.item/commandExecution/requestApproval':
       return 'Run shell command?';
     case 'codex.item/fileChange/requestApproval': {
-      const path = firstFileChangePath(marker.input);
-      return path ? `Write to file?` : 'Write to files?';
+      const count = fileChangeCount(marker.input);
+      return count > 1 ? 'Write to files?' : 'Write to file?';
     }
     default:
       return 'Approve Codex action?';

--- a/src/frontend/lib/ansi.ts
+++ b/src/frontend/lib/ansi.ts
@@ -1,0 +1,20 @@
+/**
+ * Normalized re-export of `ansi-to-react`.
+ *
+ * `ansi-to-react` is published as CJS. Bun's browser bundler can hand the
+ * `import Ansi from 'ansi-to-react'` form out as either:
+ *  - the component function directly, or
+ *  - the module namespace object `{ default: fn }`, depending on HMR state.
+ *
+ * The second shape causes `React.createElement(Ansi, ...)` to throw
+ * "Element type is invalid... got: object". This wrapper unwraps `.default`
+ * defensively so callers always receive the component function.
+ *
+ * Lives outside `components/ai-elements/` because that directory is
+ * shadcn-generated (`bunx shadcn add`); putting the workaround there would
+ * be overwritten on regeneration.
+ */
+import AnsiImport from 'ansi-to-react';
+
+export const Ansi = ((AnsiImport as unknown as { default?: typeof AnsiImport })
+  .default ?? AnsiImport) as typeof AnsiImport;

--- a/src/frontend/lib/sdkToUIMessages.test.ts
+++ b/src/frontend/lib/sdkToUIMessages.test.ts
@@ -827,6 +827,114 @@ describe('sdkToUIMessages — Codex tool items', () => {
     expect(() => sdkToUIMessages(events, false, noPending)).not.toThrow();
   });
 
+  it('flips a commandExecution tool message to approval-requested when a matching Codex pendingApproval is unresolved', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/started', {
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-approve',
+          command: 'rm -rf /',
+          cwd: '/tmp',
+          status: 'inProgress',
+        },
+      }),
+    ];
+    const pending: PendingApproval[] = [
+      {
+        requestId: 'cmd-approve',
+        tool: 'codex.item/commandExecution/requestApproval',
+        input: { command: 'rm -rf /', cwd: '/tmp' },
+        resolved: undefined,
+      },
+    ];
+    const result = sdkToUIMessages(events, true, pending);
+    expect(result).toHaveLength(1);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part.state).toBe('approval-requested');
+    expect(part.toolCallId).toBe('cmd-approve');
+    const approval = part.approval as {
+      id: string;
+      codex: { tool: string; input: { command: string } };
+    };
+    expect(approval.id).toBe('cmd-approve');
+    expect(approval.codex.tool).toBe(
+      'codex.item/commandExecution/requestApproval',
+    );
+    expect(approval.codex.input.command).toBe('rm -rf /');
+  });
+
+  it('flips an approved fileChange to approval-responded with codex marker', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/started', {
+        item: {
+          type: 'fileChange',
+          id: 'fc-approve',
+          status: 'inProgress',
+          changes: [{ path: '/tmp/x.ts', kind: 'add', diff: '...' }],
+        },
+      }),
+    ];
+    const pending: PendingApproval[] = [
+      {
+        requestId: 'fc-approve',
+        tool: 'codex.item/fileChange/requestApproval',
+        input: { changes: [{ path: '/tmp/x.ts' }] },
+        resolved: { approved: true },
+      },
+    ];
+    const result = sdkToUIMessages(events, false, pending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part.state).toBe('approval-responded');
+    const approval = part.approval as { approved: boolean; codex: unknown };
+    expect(approval.approved).toBe(true);
+    expect(approval.codex).toBeDefined();
+  });
+
+  it('flips a denied commandExecution to output-denied with codex marker', () => {
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/started', {
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-deny',
+          command: 'ls',
+          cwd: '/tmp',
+          status: 'inProgress',
+        },
+      }),
+    ];
+    const pending: PendingApproval[] = [
+      {
+        requestId: 'cmd-deny',
+        tool: 'codex.item/commandExecution/requestApproval',
+        input: { command: 'ls' },
+        resolved: { approved: false },
+      },
+    ];
+    const result = sdkToUIMessages(events, false, pending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part.state).toBe('output-denied');
+    const approval = part.approval as { approved: boolean; codex: unknown };
+    expect(approval.approved).toBe(false);
+    expect(approval.codex).toBeDefined();
+  });
+
+  it('synthesizes a placeholder tool message when the approval arrives before item/started', () => {
+    const pending: PendingApproval[] = [
+      {
+        requestId: 'cmd-orphan',
+        tool: 'codex.item/commandExecution/requestApproval',
+        input: { command: 'echo hi' },
+        resolved: undefined,
+      },
+    ];
+    const result = sdkToUIMessages([], false, pending);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('codex-cmd-orphan');
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part.state).toBe('approval-requested');
+    expect(part.toolName).toBe('Bash');
+  });
+
   it('mixes Codex and Claude events without interfering', () => {
     const events: SDKMessage[] = [
       makeAssistantEvent([{ type: 'text', text: 'Claude here' }], 'claude-1'),

--- a/src/frontend/lib/sdkToUIMessages.test.ts
+++ b/src/frontend/lib/sdkToUIMessages.test.ts
@@ -918,6 +918,46 @@ describe('sdkToUIMessages — Codex tool items', () => {
     expect(approval.codex).toBeDefined();
   });
 
+  it('preserves item/completed output when the approval row is later resolved-approved', () => {
+    // After Codex emits item/completed with output, the resolved approval
+    // row stays in pendingApprovals for the session lifetime. The overlay
+    // must not clobber the terminal output state.
+    const events: SDKMessage[] = [
+      makeCodexEvent('item/started', {
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-done',
+          command: 'echo hi',
+          cwd: '/tmp',
+          status: 'inProgress',
+        },
+      }),
+      makeCodexEvent('item/completed', {
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-done',
+          command: 'echo hi',
+          cwd: '/tmp',
+          status: 'completed',
+          aggregatedOutput: 'hi\n',
+          exitCode: 0,
+        },
+      }),
+    ];
+    const pending: PendingApproval[] = [
+      {
+        requestId: 'cmd-done',
+        tool: 'codex.item/commandExecution/requestApproval',
+        input: { command: 'echo hi' },
+        resolved: { approved: true },
+      },
+    ];
+    const result = sdkToUIMessages(events, false, pending);
+    const part = result[0]?.parts[0] as Record<string, unknown>;
+    expect(part.state).toBe('output-available');
+    expect(part.output).toBe('hi\n');
+  });
+
   it('synthesizes a placeholder tool message when the approval arrives before item/started', () => {
     const pending: PendingApproval[] = [
       {

--- a/src/frontend/lib/sdkToUIMessages.ts
+++ b/src/frontend/lib/sdkToUIMessages.ts
@@ -80,8 +80,14 @@ type DynamicToolUIPart =
  * @param events - Accumulated SDK events from `useSession`.
  * @param isRunning - When `true`, the last assistant message is marked as
  *   streaming (text parts get `state: 'streaming'`); otherwise `'done'`.
- * @param pendingApprovals - Unresolved approval requests annotate tool parts
- *   with `approval-requested` state.
+ * @param pendingApprovals - Approval requests from the Convex
+ *   `pendingApprovals` table. Rows whose `tool` name matches an SDK
+ *   `tool_use_id` flip the corresponding part to `approval-requested`
+ *   (or `approval-responded` / `output-denied` once resolved). Rows
+ *   whose `tool` is prefixed `codex.` are bridged from the Codex
+ *   approval handler — the renderer overlays them onto the matching
+ *   Codex tool message keyed by `codex-${itemId}` and stamps an
+ *   `approval.codex` marker so the consuming UI can render Codex copy.
  */
 export function sdkToUIMessages(
   events: SDKMessage[],

--- a/src/frontend/lib/sdkToUIMessages.ts
+++ b/src/frontend/lib/sdkToUIMessages.ts
@@ -401,6 +401,19 @@ export function sdkToUIMessages(
     // biome-ignore lint/suspicious/noExplicitAny: parts union is complex
     const newParts = (msg.parts as any[]).map((p) => {
       if (p.type !== 'dynamic-tool') return p;
+      // Skip parts that already reached a terminal output state. Once Codex
+      // emits `item/completed` with output / error / declined, that result
+      // is the source of truth — overlaying a stale `approval-responded`
+      // would hide the actual command output indefinitely (the resolved
+      // approval row stays in `pendingApprovals` for the life of the
+      // session).
+      if (
+        p.state === 'output-available' ||
+        p.state === 'output-error' ||
+        p.state === 'output-denied'
+      ) {
+        return p;
+      }
       const codexMarker = { tool: approval.tool, input: approval.input };
       if (!approval.resolved) {
         return {

--- a/src/frontend/lib/sdkToUIMessages.ts
+++ b/src/frontend/lib/sdkToUIMessages.ts
@@ -27,7 +27,10 @@ type DynamicToolUIPart =
       toolCallId: string;
       state: 'approval-requested';
       input: unknown;
-      approval: { id: string };
+      approval: {
+        id: string;
+        codex?: { tool: string; input: Record<string, unknown> };
+      };
     }
   | {
       type: 'dynamic-tool';
@@ -51,7 +54,11 @@ type DynamicToolUIPart =
       toolCallId: string;
       state: 'approval-responded';
       input: unknown;
-      approval: { id: string; approved: true };
+      approval: {
+        id: string;
+        approved: true;
+        codex?: { tool: string; input: Record<string, unknown> };
+      };
     }
   | {
       type: 'dynamic-tool';
@@ -59,7 +66,11 @@ type DynamicToolUIPart =
       toolCallId: string;
       state: 'output-denied';
       input: unknown;
-      approval: { id: string; approved: false };
+      approval: {
+        id: string;
+        approved: false;
+        codex?: { tool: string; input: Record<string, unknown> };
+      };
     };
 
 /**
@@ -88,6 +99,18 @@ export function sdkToUIMessages(
       .filter((a) => a.resolved !== undefined)
       .map((a) => [a.requestId, a.resolved?.approved ?? false]),
   );
+
+  // Codex approvals are bridged through `pendingApprovals` with
+  // `tool: 'codex.<method>'` and `requestId` keyed by the Codex item id
+  // (which equals the rendered tool message's `toolCallId`). Indexed
+  // separately so the Codex post-pass can override the tool part state
+  // without mixing with SDK approval matching above.
+  const codexApprovalsByItemId = new Map<string, PendingApproval>();
+  for (const a of pendingApprovals) {
+    if (a.tool?.startsWith('codex.')) {
+      codexApprovalsByItemId.set(a.requestId, a);
+    }
+  }
 
   // First pass: collect tool results keyed by tool_use_id
   const toolResults = new Map<string, { result: string; isError: boolean }>();
@@ -342,7 +365,93 @@ export function sdkToUIMessages(
     messages[idx] = { ...msg, parts: newParts };
   }
 
+  // Final pass: overlay Codex pending approvals onto their matching tool
+  // message. The bridge persists `pendingApprovals` rows keyed by the Codex
+  // item id, which equals the rendered tool message's `codex-${itemId}`.
+  // Unresolved → approval-requested; resolved approve → approval-responded;
+  // resolved deny → output-denied. Carries a `codex` marker on the approval
+  // object so `ToolCallUI` can render Codex-specific copy.
+  for (const [itemId, approval] of codexApprovalsByItemId) {
+    let idx = messages.findIndex((m) => m.id === `codex-${itemId}`);
+    if (idx === -1) {
+      // Approval arrived before the matching item/started event (or the
+      // event was dropped). Synthesize a placeholder tool message keyed
+      // by the same id so the post-pass below can apply state — input
+      // is left empty; the `codex` marker on the approval carries the
+      // request payload for the renderer to display.
+      const toolName = approvalToolName(approval.tool);
+      messages.push({
+        id: `codex-${itemId}`,
+        role: 'assistant',
+        parts: [
+          {
+            type: 'dynamic-tool',
+            toolName,
+            toolCallId: itemId,
+            state: 'input-available',
+            input: {},
+          },
+        ],
+        // biome-ignore lint/suspicious/noExplicitAny: UIMessage parts union is complex
+      } as any);
+      idx = messages.length - 1;
+    }
+    const msg = messages[idx];
+    if (!msg) continue;
+    // biome-ignore lint/suspicious/noExplicitAny: parts union is complex
+    const newParts = (msg.parts as any[]).map((p) => {
+      if (p.type !== 'dynamic-tool') return p;
+      const codexMarker = { tool: approval.tool, input: approval.input };
+      if (!approval.resolved) {
+        return {
+          type: 'dynamic-tool',
+          toolName: p.toolName,
+          toolCallId: p.toolCallId,
+          state: 'approval-requested',
+          input: p.input,
+          approval: { id: itemId, codex: codexMarker },
+        };
+      }
+      if (approval.resolved.approved) {
+        return {
+          type: 'dynamic-tool',
+          toolName: p.toolName,
+          toolCallId: p.toolCallId,
+          state: 'approval-responded',
+          input: p.input,
+          approval: { id: itemId, approved: true, codex: codexMarker },
+        };
+      }
+      return {
+        type: 'dynamic-tool',
+        toolName: p.toolName,
+        toolCallId: p.toolCallId,
+        state: 'output-denied',
+        input: p.input,
+        approval: { id: itemId, approved: false, codex: codexMarker },
+      };
+    });
+    messages[idx] = { ...msg, parts: newParts };
+  }
+
   return messages;
+}
+
+/**
+ * Derive a sensible `toolName` from a Codex approval `tool` string when
+ * synthesizing a placeholder tool message (no matching `item/started` was
+ * observed). Phase 0 only bridges two methods; unknown tools fall back to
+ * a generic 'Codex' label.
+ */
+function approvalToolName(tool: string): string {
+  switch (tool) {
+    case 'codex.item/commandExecution/requestApproval':
+      return 'Bash';
+    case 'codex.item/fileChange/requestApproval':
+      return 'Edit';
+    default:
+      return 'Codex';
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/subscriptions.ts
+++ b/src/server/subscriptions.ts
@@ -57,18 +57,16 @@ async function handleQueuedSession(session: QueuedSession): Promise<void> {
     });
     if (!claimed.ok) return;
 
-    // Phase 0 only routes the two `item/*` binary approval methods through
-    // the bridge; structured methods (user input, MCP elicitation,
-    // permissions) and top-level methods (applyPatch, execCommand) are
-    // denied upstream. For null-permissionMode Codex sessions the
-    // 'safe-auto' fallback would silently auto-deny those flows — a
-    // regression for sessions that previously ran fine under Phase 0's
-    // bypass-only Codex. Keep the Codex fallback on 'bypass' until Phase 0.1
-    // ships full structured-method coverage.
-    const fallback: PermissionMode =
-      provider === 'codex' ? 'bypass' : 'safe-auto';
-    const permissionMode =
-      (session.permissionMode as PermissionMode | undefined) ?? fallback;
+    // Claude sessions tolerate a missing permissionMode and fall back to
+    // 'safe-auto'. Codex sessions must carry an explicit mode set by the
+    // picker (Task 6); a null mode flows through unchanged and Codex's
+    // `startSession` rejects it via `Invalid permissionMode`. The earlier
+    // `'bypass'` fallback was a Task 5 holdover from when Codex had no
+    // approval UI — Tasks 7 + 8 surfaced approvals, so the fallback is
+    // gone.
+    const permissionMode: PermissionMode | undefined =
+      (session.permissionMode as PermissionMode | undefined) ??
+      (provider === 'codex' ? undefined : 'safe-auto');
 
     // Note: any stop request that arrived while claiming was deferred by
     // handleStoppedSession (it skips sessions with in-flight claims). It will

--- a/src/server/subscriptions.ts
+++ b/src/server/subscriptions.ts
@@ -58,15 +58,16 @@ async function handleQueuedSession(session: QueuedSession): Promise<void> {
     if (!claimed.ok) return;
 
     // Claude sessions tolerate a missing permissionMode and fall back to
-    // 'safe-auto'. Codex sessions must carry an explicit mode set by the
-    // picker (Task 6); a null mode flows through unchanged and Codex's
-    // `startSession` rejects it via `Invalid permissionMode`. The earlier
-    // `'bypass'` fallback was a Task 5 holdover from when Codex had no
-    // approval UI — Tasks 7 + 8 surfaced approvals, so the fallback is
-    // gone.
-    const permissionMode: PermissionMode | undefined =
+    // 'safe-auto'. Codex sessions are stamped with a default ('bypass')
+    // by `sessions.create` post-Task-8, so freshly-queued rows always
+    // carry a value. The `'bypass'` coalesce here is a migration shim
+    // for queued Codex rows created before Task 8 deployed (queued rows
+    // can outlive a deploy). Drop once the in-flight queue is known
+    // empty, e.g. once a Phase 0.1 picker ships and supersedes this
+    // path.
+    const permissionMode: PermissionMode =
       (session.permissionMode as PermissionMode | undefined) ??
-      (provider === 'codex' ? undefined : 'safe-auto');
+      (provider === 'codex' ? 'bypass' : 'safe-auto');
 
     // Note: any stop request that arrived while claiming was deferred by
     // handleStoppedSession (it skips sessions with in-flight claims). It will

--- a/src/server/subscriptions.ts
+++ b/src/server/subscriptions.ts
@@ -39,6 +39,20 @@ const inFlightClaims = new Set<string>();
 const inFlightStops = new Set<string>();
 const inFlightMessages = new Set<string>();
 
+/**
+ * Claim a queued session out of Convex and hand it to the matching
+ * provider manager (`claude` or `codex`). Idempotent against a manager
+ * that already owns the session and against in-flight claims (the
+ * Convex subscription can fire multiple times before the claim mutation
+ * resolves). On `claim` failure the session is left for a future tick;
+ * on `startSession` failure the session is patched to `failed`.
+ *
+ * `permissionMode` is taken from the session row directly. New rows
+ * always carry a value (Codex defaults to `'bypass'` upstream in
+ * `sessions.create` — see Task 8). The `'bypass'` / `'safe-auto'`
+ * coalesce here is a migration shim for in-flight queued rows that
+ * pre-date Task 8 and can be removed once the queue has drained.
+ */
 async function handleQueuedSession(session: QueuedSession): Promise<void> {
   if (!session.queuedPrompt) return;
   if (findOwningManager(session._id)) return;


### PR DESCRIPTION
## Summary
- Render Phase 0 Codex approval cards (`Run shell command?` `Write to file?`) in the session thread, wired to the existing `pendingApprovals` bridge.
- Stop the post-pass overlay from clobbering completed Codex tool output once the approval row has resolved.
- Default new Codex sessions to `permissionMode: 'bypass'` upstream in `sessions.create`. Keep a migration shim in the companion dispatch for in-flight queued rows that pre-date this deploy.
- Drop the stale Phase 0 Codex warning that referred to Tasks 7 + 8 as not-yet-shipped.

## Background

Spec: `wiki/core/codex-integration-spec.md` § Task 8.

Task 5 (PR #276) shipped the bridge that persists Codex approvals to `pendingApprovals` keyed by `request.itemId`. Task 7 (PR #279) shipped the Codex event renderer. This PR closes the loop by surfacing those rows as approval cards.

Phase 0 only bridges two methods (`item/commandExecution/requestApproval`, `item/fileChange/requestApproval`) — the other five are denied at the bridge with no persisted row. The renderer therefore only needs copy for those two.

## Notes on `permissionMode`

The original spec said: "drop the bypass fallback so `permissionMode` flows through unchanged — the picker / dev-script path is the only way to set it." LaunchButton / SessionPanel don't yet pass `permissionMode`, so a strict null-mode-fails interpretation would break every Codex launch. Two adversarial findings (`/codex:adversarial-review`) pushed the resolution toward:

- `'bypass'` (not `'default'`) as the upstream Codex default — Phase 0 only renders 2 of 7 Codex approval methods, so `'default'` would silently auto-deny the other 5 (`applyPatchApproval`, `execCommandApproval`, `item/permissions/requestApproval`, `item/tool/requestUserInput`, `mcpServer/elicitation/request`).
- Keep a migration-shim fallback in `subscriptions.ts` so queued Codex rows created pre-deploy don't immediately fail.

A picker that exposes the approval modes is Phase 0.1.

## Test plan
- [x] `bun run check` (lint + typecheck + unit tests, 726 passing)
- [x] `bun run test:e2e:isolated` (67 passing)
- [x] `/codex:review` clean
- [x] `/codex:adversarial-review` clean
- [ ] Manual: launch a Codex session with `permissionMode: 'default'` via the dev script, trigger a file write, confirm the approval card renders `Write to file?` with the path; approve → file is written; deny → Codex receives the deny.
- [ ] Manual: same with `run \\`ls\\`\` → \Run shell command?` with command preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex approval UI: richer approval markers with command and file-change previews and an inline approve action.
  * UI messages now surface Codex approval overlays and synthesize placeholders when approvals arrive early.

* **Bug Fixes**
  * Codex sessions default permission mode to bypass when unspecified.
  * Removed an unnecessary startup console warning.

* **Documentation**
  * Added a guide for the Codex permission-mode picker (follow-up).

* **Tests**
  * Added coverage for Codex approval flows and UI rendering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holophyte/holophyte/pull/285)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->