### PR TITLE
style: align EffortPicker and PermissionModePicker with ProviderModelPicker

### DIFF
--- a/src/frontend/components/EffortPicker.tsx
+++ b/src/frontend/components/EffortPicker.tsx
@@ -82,7 +82,14 @@ export default function EffortPicker({
       <SelectTrigger
         size="sm"
         aria-label="Reasoning effort"
-        className={cn('h-7 px-2 text-xs', className)}
+        // Mirror ProviderModelPicker so the three launch-row pickers share
+        // one visual style. Descendant selectors override the
+        // SelectTrigger's built-in chevron (size-4 opacity-50) to the
+        // smaller muted variant used by ProviderModelPicker.
+        className={cn(
+          '!h-auto gap-1.5 rounded border-input bg-background px-2 py-1 text-xs font-medium leading-4 text-foreground shadow-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-input focus-visible:ring-1 focus-visible:ring-ring [&_svg]:size-3 [&_svg]:text-muted-foreground [&_svg]:opacity-100',
+          className,
+        )}
       >
         <SelectValue />
       </SelectTrigger>

--- a/src/frontend/components/EffortPicker.tsx
+++ b/src/frontend/components/EffortPicker.tsx
@@ -6,6 +6,7 @@ import {
   STORAGE_LAST_EFFORT_PREFIX,
 } from '@/constants';
 import { cn } from '@/frontend/lib/utils';
+import { LAUNCH_PICKER_TRIGGER_CLASS } from './launchPickerStyles';
 import {
   Select,
   SelectContent,
@@ -82,14 +83,7 @@ export default function EffortPicker({
       <SelectTrigger
         size="sm"
         aria-label="Reasoning effort"
-        // Mirror ProviderModelPicker so the three launch-row pickers share
-        // one visual style. Descendant selectors override the
-        // SelectTrigger's built-in chevron (size-4 opacity-50) to the
-        // smaller muted variant used by ProviderModelPicker.
-        className={cn(
-          '!h-auto gap-1.5 rounded border-input bg-background px-2 py-1 text-xs font-medium leading-4 text-foreground shadow-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-input focus-visible:ring-1 focus-visible:ring-ring [&_svg]:size-3 [&_svg]:text-muted-foreground [&_svg]:opacity-100',
-          className,
-        )}
+        className={cn(LAUNCH_PICKER_TRIGGER_CLASS, className)}
       >
         <SelectValue />
       </SelectTrigger>

--- a/src/frontend/components/PermissionModePicker.tsx
+++ b/src/frontend/components/PermissionModePicker.tsx
@@ -4,6 +4,7 @@ import {
   PERMISSION_MODES,
   type PermissionMode,
 } from '@/permissionMode';
+import { LAUNCH_PICKER_TRIGGER_CLASS } from './launchPickerStyles';
 import {
   Select,
   SelectContent,
@@ -61,12 +62,7 @@ export default function PermissionModePicker({
         size="sm"
         aria-label="Permission mode"
         title={DESCRIPTIONS[value]}
-        // Mirror ProviderModelPicker so the three launch-row pickers share
-        // one visual style. See EffortPicker for the same overrides.
-        className={cn(
-          '!h-auto gap-1.5 rounded border-input bg-background px-2 py-1 text-xs font-medium leading-4 text-foreground shadow-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-input focus-visible:ring-1 focus-visible:ring-ring [&_svg]:size-3 [&_svg]:text-muted-foreground [&_svg]:opacity-100',
-          className,
-        )}
+        className={cn(LAUNCH_PICKER_TRIGGER_CLASS, className)}
       >
         <SelectValue />
       </SelectTrigger>

--- a/src/frontend/components/PermissionModePicker.tsx
+++ b/src/frontend/components/PermissionModePicker.tsx
@@ -61,7 +61,12 @@ export default function PermissionModePicker({
         size="sm"
         aria-label="Permission mode"
         title={DESCRIPTIONS[value]}
-        className={cn('h-7 px-2 text-xs', className)}
+        // Mirror ProviderModelPicker so the three launch-row pickers share
+        // one visual style. See EffortPicker for the same overrides.
+        className={cn(
+          '!h-auto gap-1.5 rounded border-input bg-background px-2 py-1 text-xs font-medium leading-4 text-foreground shadow-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-input focus-visible:ring-1 focus-visible:ring-ring [&_svg]:size-3 [&_svg]:text-muted-foreground [&_svg]:opacity-100',
+          className,
+        )}
       >
         <SelectValue />
       </SelectTrigger>

--- a/src/frontend/components/launchPickerStyles.ts
+++ b/src/frontend/components/launchPickerStyles.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared SelectTrigger class string for the launch-row pickers
+ * (EffortPicker, PermissionModePicker). Mirrors ProviderModelPicker's
+ * plain `<button>` styling so all three pickers look identical.
+ *
+ * Descendant selectors override SelectTrigger's built-in chevron
+ * (size-4 opacity-50) to the smaller muted variant. The `h-auto!`
+ * important override is needed to defeat SelectTrigger's default `h-9`.
+ */
+export const LAUNCH_PICKER_TRIGGER_CLASS =
+  'h-auto! gap-1.5 rounded border-input bg-background px-2 py-1 text-xs font-medium leading-4 text-foreground shadow-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-input focus-visible:ring-1 focus-visible:ring-ring [&_svg]:size-3 [&_svg]:text-muted-foreground [&_svg]:opacity-100';


### PR DESCRIPTION
## Summary
- Mirror `ProviderModelPicker`'s SelectTrigger styling on `EffortPicker` and `PermissionModePicker` so the three launch-row pickers share one visual treatment.
- Override the built-in chevron (size-4 opacity-50) to the smaller muted variant used by `ProviderModelPicker`.

Follow-up to #287 — these tweaks were in the working tree but didn't make it into that PR before merge.

## Test plan
- [x] Visually compare the three pickers on the session launch row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/holophyte/holophyte/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling for multiple picker components to achieve consistent visual appearance and improved spacing throughout the selection interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holophyte/holophyte/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->