### PR TITLE
chore: upgrade to TypeScript 6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -60,10 +60,11 @@
         "jsdom": "^29.1.1",
         "storybook": "^10.4.0",
         "tailwindcss": "^4.3.0",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.6",
       },
       "peerDependencies": {
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
       },
     },
   },
@@ -1738,7 +1739,7 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "uc.micro": ["uc.micro@1.0.6", "", {}, "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="],
 

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
+    "types": ["bun"],
     "lib": ["ESNext"],
     "module": "ESNext",
     "moduleResolution": "bundler",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "jsdom": "^29.1.1",
     "storybook": "^10.4.0",
     "tailwindcss": "^4.3.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
   "dependencies": {
@@ -95,7 +96,7 @@
     "zustand": "^5.0.13"
   },
   "peerDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "overrides": {
     "vite": "^7.3.2",

--- a/src/frontend/global.d.ts
+++ b/src/frontend/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["bun", "vitest/globals"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- Bumps `typescript` from 5.9.3 → 6.0.3 (devDependencies + peerDependencies)
- Adds explicit `types: ["bun", "vitest/globals"]` to `tsconfig.json` — TS 6 narrows default `@types/*` inclusion
- Adds `src/frontend/global.d.ts` with `declare module '*.css'` so CSS imports keep resolving under the narrowed types

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun run lint` clean
- [x] `bun run test` — 750/750 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/holophyte/holophyte/pull/292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript to version 6.0.3
  * Added type definitions for CSS imports
  * Updated TypeScript compiler configuration settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holophyte/holophyte/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->