### PR TITLE
chore: upgrade @anthropic-ai/claude-agent-sdk to 0.3.143

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,7 @@
     "": {
       "name": "holophyte",
       "dependencies": {
-        "@ai-sdk/react": "^3.0.186",
         "@anthropic-ai/claude-agent-sdk": "0.3.143",
-        "@anthropic-ai/sdk": "^0.93.0",
         "@auth/core": "0.37.0",
         "@convex-dev/auth": "^0.0.92",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -91,8 +89,6 @@
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
-
-    "@ai-sdk/react": ["@ai-sdk/react@3.0.186", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.27", "ai": "6.0.184", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-fy8wuy8pBghYD1ECw/M5vAsGsZp2D3y/oSTp1iOlAnJqRXzvz4rWLBz1n+rjL+aHZNgJK3kR3NHlnifoKYERfA=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
@@ -1688,8 +1684,6 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "swr": ["swr@2.4.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA=="],
-
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
@@ -1697,8 +1691,6 @@
     "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
-
-    "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,8 @@
       "name": "holophyte",
       "dependencies": {
         "@ai-sdk/react": "^3.0.186",
-        "@anthropic-ai/claude-agent-sdk": "^0.2.141",
+        "@anthropic-ai/claude-agent-sdk": "0.3.143",
+        "@anthropic-ai/sdk": "^0.93.0",
         "@auth/core": "0.37.0",
         "@convex-dev/auth": "^0.0.92",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -69,8 +70,8 @@
     },
   },
   "overrides": {
-    "@anthropic-ai/sdk": "^0.93.0",
     "@hono/node-server": "^1.19.14",
+    "brace-expansion": "^5.0.6",
     "dompurify": "^3.4.0",
     "fast-uri": "^3.1.2",
     "hono": "^4.12.19",
@@ -95,23 +96,23 @@
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.141", "", { "dependencies": { "@anthropic-ai/sdk": "^0.93.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.143", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.143", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.143", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.143", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.143", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.143", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.143", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.143", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.143" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-JnxOTRpSBpFqKFMfV5cW4QjpeDOHUNr31rRislmOVWEPsRmCjsy9jYwKxDf7kxcwxyZ6h/YHz1ACvMaUWy6o6A=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.143", "", { "os": "darwin", "cpu": "arm64" }, "sha512-41WuTuP+bk4NxrjpG9IJGffsjh1ivyiiAmqgb5QoxPltDAA0p3gs+iZ3lTgDmY4Ga68wDoN05Lt18oCE+DQb7g=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141", "", { "os": "darwin", "cpu": "x64" }, "sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.143", "", { "os": "darwin", "cpu": "x64" }, "sha512-3WrJ6MjjwQKvPnPbzUOm08qftlHYobkp/tmM1P/Vk/ldSjoPfFIgLFfzSzUmCKJiKEh2ZlHLJr8ORNrTxXhgQg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.141", "", { "os": "linux", "cpu": "arm64" }, "sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.143", "", { "os": "linux", "cpu": "arm64" }, "sha512-/9oP/FCewrPnwVN+QUS5rlO3kMa07w+hOrpWrz24aEpBYhcHzr0zoNMBriPDAkTr3ao/z1k40UZ2dHmgsSODzA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141", "", { "os": "linux", "cpu": "arm64" }, "sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.143", "", { "os": "linux", "cpu": "arm64" }, "sha512-9UeV1W2vjOVwJSJrq9aw3UeMo82Ir59FfJ5mchh7OXZEaevkANvHYn25bTCnIpqfqOx7qFEosJW2ELIoV1nprg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.141", "", { "os": "linux", "cpu": "x64" }, "sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.143", "", { "os": "linux", "cpu": "x64" }, "sha512-kwqnbHo4Zj6TzO1V/83uLhsTt0xBp/BN5V/aHIX+khM4UuNO6NOKNaZvr8Int3sF0ARF95Hjr4l/hMKxry6DhQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141", "", { "os": "linux", "cpu": "x64" }, "sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.143", "", { "os": "linux", "cpu": "x64" }, "sha512-rr4334GOLl9caYDeyWsbwMaVJCiNvKHE9nLdey8opIkq7/FHHu712U6tDk0tcoCdsGU/S3/BBaZParOgF+s5qw=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141", "", { "os": "win32", "cpu": "arm64" }, "sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.143", "", { "os": "win32", "cpu": "arm64" }, "sha512-q5UaLZ9ABbqQN8UXpqHUqjW6akI1zMrV5Jvtq0yueKP4nIRbBBZBQ80M4bpdrc0+SiRmjVRV3p8lsCCAd8azgg=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141", "", { "os": "win32", "cpu": "x64" }, "sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.143", "", { "os": "win32", "cpu": "x64" }, "sha512-46L2mkskvIRfwzHP3p0uUE5u9Oc7Eb/DRVmXuGNk5Z8jiahlDSv0SHP1vnWSWw5nWIu4DWOKyXZelRmYc9LxCg=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
 
@@ -857,7 +858,7 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.186",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.141",
+    "@anthropic-ai/claude-agent-sdk": "0.3.143",
+    "@anthropic-ai/sdk": "^0.93.0",
     "@auth/core": "0.37.0",
     "@convex-dev/auth": "^0.0.92",
     "@modelcontextprotocol/sdk": "^1.29.0",
@@ -110,6 +111,6 @@
     "mermaid": "^11.15.0",
     "@hono/node-server": "^1.19.14",
     "postcss": "^8.5.10",
-    "@anthropic-ai/sdk": "^0.93.0"
+    "brace-expansion": "^5.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,9 +63,7 @@
     "vitest": "^4.1.6"
   },
   "dependencies": {
-    "@ai-sdk/react": "^3.0.186",
     "@anthropic-ai/claude-agent-sdk": "0.3.143",
-    "@anthropic-ai/sdk": "^0.93.0",
     "@auth/core": "0.37.0",
     "@convex-dev/auth": "^0.0.92",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/claude/manager.test.ts
+++ b/src/claude/manager.test.ts
@@ -533,6 +533,54 @@ describe('claude/manager (SDK-based)', () => {
       }
     });
 
+    it('calls companionCreate for TaskStop (destructive, not in SAFE_TOOLS)', async () => {
+      vi.mocked(mockSdkQuery).mockImplementation((params: unknown) => {
+        const { options } = params as {
+          options: {
+            canUseTool: CanUseTool;
+            abortController: AbortController;
+          };
+        };
+        return {
+          // biome-ignore lint/correctness/useYield: blocking mock — parks via await without yielding events
+          async *[Symbol.asyncIterator]() {
+            await options.canUseTool(
+              'TaskStop',
+              { task_id: 'abc' },
+              {
+                toolUseID: 'ts1',
+                signal: options.abortController.signal,
+              },
+            );
+          },
+          streamInput: vi.fn().mockResolvedValue(undefined),
+          supportedCommands: vi.fn().mockResolvedValue([]),
+          supportedModels: vi.fn().mockResolvedValue([]),
+        } as never;
+      });
+
+      const { startSession } = await import('./manager');
+      await startSession({
+        sessionId: 'taskstop-test',
+        repoPath: '/tmp',
+        prompt: 'test',
+        permissionMode: 'safe-auto',
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      const createCalls = mockMutation.mock.calls.filter(
+        (call) =>
+          typeof call[1] === 'object' &&
+          'requestId' in (call[1] as Record<string, unknown>),
+      );
+      expect(
+        createCalls.some(
+          (c) => (c[1] as Record<string, unknown>).requestId === 'ts1',
+        ),
+      ).toBe(true);
+    });
+
     it('calls companionCreate for write-side tools (Write, Edit)', async () => {
       vi.mocked(mockSdkQuery).mockImplementation((params: unknown) => {
         const { options } = params as {

--- a/src/claude/manager.test.ts
+++ b/src/claude/manager.test.ts
@@ -417,6 +417,10 @@ describe('claude/manager (SDK-based)', () => {
         'WebFetch',
         'WebSearch',
         'TodoRead',
+        'TaskCreate',
+        'TaskUpdate',
+        'TaskGet',
+        'TaskList',
       ]) {
         const result = await canUseTool(
           tool,

--- a/src/claude/manager.test.ts
+++ b/src/claude/manager.test.ts
@@ -416,7 +416,6 @@ describe('claude/manager (SDK-based)', () => {
         'Grep',
         'WebFetch',
         'WebSearch',
-        'TodoRead',
         'TaskCreate',
         'TaskUpdate',
         'TaskGet',

--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -82,14 +82,13 @@ const SAFE_BASH_PATTERNS = [
 /** Shell operators and redirects — never auto-approve commands containing these. */
 const SHELL_OPERATOR_PATTERN = /[;&|`$\n<>]|\$\(/;
 
-/** Tools that are always safe to auto-approve (read-only operations). */
+/** Tools that are always safe to auto-approve (read-only lookups and internal task-tracker writes). */
 const SAFE_TOOLS = new Set([
   'Read',
   'Glob',
   'Grep',
   'WebFetch',
   'WebSearch',
-  'TodoRead',
   'TaskCreate',
   'TaskUpdate',
   'TaskGet',

--- a/src/claude/manager.ts
+++ b/src/claude/manager.ts
@@ -90,6 +90,10 @@ const SAFE_TOOLS = new Set([
   'WebFetch',
   'WebSearch',
   'TodoRead',
+  'TaskCreate',
+  'TaskUpdate',
+  'TaskGet',
+  'TaskList',
 ]);
 
 /**

--- a/src/frontend/lib/toolDisplay.ts
+++ b/src/frontend/lib/toolDisplay.ts
@@ -35,6 +35,7 @@ export function toolIcon(name: string): ReactElement {
     case 'TaskUpdate':
     case 'TaskGet':
     case 'TaskList':
+    case 'TaskStop':
       return createElement(ListTodo, { className: 'h-3.5 w-3.5' });
     default:
       return createElement(Wrench, { className: 'h-3.5 w-3.5' });
@@ -100,6 +101,10 @@ export function toolSummary(
     }
     case 'TaskList':
       return 'List tasks';
+    case 'TaskStop': {
+      const task_id = typeof input.task_id === 'string' ? input.task_id : '';
+      return task_id ? `Stop task ${task_id}` : 'Stop task';
+    }
     default:
       return JSON.stringify(input).slice(0, 80);
   }

--- a/src/frontend/lib/toolDisplay.ts
+++ b/src/frontend/lib/toolDisplay.ts
@@ -85,15 +85,18 @@ export function toolSummary(
             : '';
       return url.length > 80 ? `${url.slice(0, 80)}…` : url || name;
     }
-    case 'TaskCreate':
-      return 'Create task';
+    case 'TaskCreate': {
+      const subject = typeof input.subject === 'string' ? input.subject : '';
+      if (!subject) return 'Create task';
+      return subject.length > 80 ? `${subject.slice(0, 80)}…` : subject;
+    }
     case 'TaskUpdate': {
-      const id = typeof input.id === 'string' ? input.id : '';
-      return id ? `Update task ${id}` : 'Update task';
+      const taskId = typeof input.taskId === 'string' ? input.taskId : '';
+      return taskId ? `Update task ${taskId}` : 'Update task';
     }
     case 'TaskGet': {
-      const id = typeof input.id === 'string' ? input.id : '';
-      return id ? `Get task ${id}` : 'Get task';
+      const taskId = typeof input.taskId === 'string' ? input.taskId : '';
+      return taskId ? `Get task ${taskId}` : 'Get task';
     }
     case 'TaskList':
       return 'List tasks';

--- a/src/frontend/lib/toolDisplay.ts
+++ b/src/frontend/lib/toolDisplay.ts
@@ -3,6 +3,7 @@ import {
   FileSearch,
   FileText,
   Globe,
+  ListTodo,
   Search,
   Terminal,
   Wrench,
@@ -30,6 +31,11 @@ export function toolIcon(name: string): ReactElement {
     case 'WebFetch':
     case 'WebSearch':
       return createElement(Globe, { className: 'h-3.5 w-3.5' });
+    case 'TaskCreate':
+    case 'TaskUpdate':
+    case 'TaskGet':
+    case 'TaskList':
+      return createElement(ListTodo, { className: 'h-3.5 w-3.5' });
     default:
       return createElement(Wrench, { className: 'h-3.5 w-3.5' });
   }
@@ -79,6 +85,18 @@ export function toolSummary(
             : '';
       return url.length > 80 ? `${url.slice(0, 80)}…` : url || name;
     }
+    case 'TaskCreate':
+      return 'Create task';
+    case 'TaskUpdate': {
+      const id = typeof input.id === 'string' ? input.id : '';
+      return id ? `Update task ${id}` : 'Update task';
+    }
+    case 'TaskGet': {
+      const id = typeof input.id === 'string' ? input.id : '';
+      return id ? `Get task ${id}` : 'Get task';
+    }
+    case 'TaskList':
+      return 'List tasks';
     default:
       return JSON.stringify(input).slice(0, 80);
   }


### PR DESCRIPTION
## Summary
- Bump `@anthropic-ai/claude-agent-sdk` from `^0.2.141` to `0.3.143`.
- Replace `TodoWrite` handling with the new `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` tools across the safe-tool allowlist, manager tests, and tool-display helpers.
- Move `@anthropic-ai/sdk` from `overrides` into direct dependencies — it's a peer dep in SDK 0.3 (runtime still bundled per changelog). `brace-expansion` security override retained.

## Notes
- No code in Holophyte used the removed v2 session APIs (`unstable_v2_*`, `SDKSession`, `SDKSessionOptions`).
- MCP servers now connect in the background and may appear `pending` in the `init` event. Holophyte doesn't render per-server MCP status, so no UI changes were needed; sessions using slow MCP servers may briefly have those tools unavailable at startup.
- Subagent task tracking continues to work — the new Task* tools are auto-allowed under the Safe permission profile and render with a `ListTodo` icon plus a short summary string.

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run lint`
- [x] `bunx vitest run src/claude src/frontend/lib src/frontend/hooks` (212/212)
- [x] `bun audit` (no vulnerabilities)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/holophyte/holophyte/pull/294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task management tools show proper icons and human-readable summaries (create, update, get, list, stop).
* **Behavior Changes**
  * In safe-auto mode, task creation/view/update/list actions are auto-approved; one legacy read action is no longer auto-approved.
* **Tests**
  * Tests updated to cover expanded auto-approval rules and to ensure one stop action is treated as unsafe.
* **Chores**
  * SDK versions and a package override were updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holophyte/holophyte/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->