### PR TITLE
Codex Phase 0 — Tasks 9 & 10: MCP provider arg + Codex session E2E smoke

### DIFF
--- a/e2e/codex-session.spec.ts
+++ b/e2e/codex-session.spec.ts
@@ -1,0 +1,239 @@
+/**
+ * E2E smoke test for a Codex session launched through the picker UI.
+ *
+ * Uses CODEX_FAKE_TRANSPORT=1 (set in playwright.config.ts) so no real
+ * `codex` binary is needed. The fake emits a scripted event stream that
+ * exercises the full turn/approval pipeline.
+ *
+ * Provider/model/effort/permission are seeded via localStorage (same
+ * technique as permission-picker.spec.ts) rather than clicking the inline
+ * ProviderModelPicker whose listbox is clipped by overflow-hidden ancestors
+ * on the task page. The session is then launched by typing the prompt and
+ * clicking Send.
+ */
+
+import { expect, test } from '@playwright/test';
+import { waitForApp } from './helpers';
+
+// ---------------------------------------------------------------------------
+// LocalStorage key constants (mirror src/constants.ts)
+// ---------------------------------------------------------------------------
+const STORAGE_LAST_PROVIDER = 'holophyte.lastProvider';
+const STORAGE_LAST_MODEL_PREFIX = 'holophyte.lastModel.';
+const STORAGE_LAST_EFFORT_PREFIX = 'holophyte.lastEffort.';
+const STORAGE_LAST_PERMISSION_PREFIX = 'holophyte.lastPermission.';
+
+// ---------------------------------------------------------------------------
+// Helpers (adapted from session-panel.spec.ts / permission-picker.spec.ts)
+// ---------------------------------------------------------------------------
+
+async function selectRepo(page: import('@playwright/test').Page) {
+  const repoButton = page
+    .locator('aside[aria-label="Navigation"]')
+    .locator('button')
+    .filter({ hasNotText: /All Tasks|Seed Box|Projects|Add|Command/ })
+    .filter({ hasText: /e2e-/ })
+    .first();
+  await repoButton.click();
+  await expect(
+    page.getByRole('heading', { name: 'To Do', exact: true }),
+  ).toBeVisible({ timeout: 10000 });
+}
+
+async function createTask(
+  page: import('@playwright/test').Page,
+  title: string,
+  prompt?: string,
+) {
+  const todoColumn = page
+    .locator('[role="group"]')
+    .filter({ has: page.getByRole('heading', { name: 'To Do', exact: true }) });
+  await todoColumn.locator('button', { hasText: 'Add' }).click();
+  await page.waitForSelector('[role="dialog"]', { timeout: 5000 });
+  await page.locator('#task-title').fill(title);
+  if (prompt) await page.locator('#task-prompt').fill(prompt);
+  await page.locator('button', { hasText: 'Create' }).click();
+  await expect(page.locator('[role="dialog"]')).toBeHidden({ timeout: 5000 });
+}
+
+async function openTaskPage(
+  page: import('@playwright/test').Page,
+  taskTitle: string,
+) {
+  const card = page.locator('[data-task-id]', { hasText: taskTitle }).first();
+  await card.click();
+  await page
+    .locator(`button[aria-label="Open ${taskTitle} in task page"]`)
+    .first()
+    .click({ timeout: 5000 });
+  await expect(
+    page.locator('text=Send a message to start the conversation'),
+  ).toBeVisible({ timeout: 10000 });
+}
+
+/**
+ * Seed localStorage with Codex provider/model/effort/permission settings.
+ * Then reload the page so `useLaunchDefaults` picks them up on mount.
+ * This avoids clicking the ProviderModelPicker whose listbox is clipped by
+ * overflow-hidden ancestors on the task detail page.
+ */
+async function seedCodexLaunchDefaults(
+  page: import('@playwright/test').Page,
+  opts: {
+    model: string;
+    effort: string;
+    permissionMode: string;
+  },
+) {
+  await page.evaluate(
+    ({ provider, model, effort, permission, keys }) => {
+      window.localStorage.setItem(keys.provider, provider);
+      window.localStorage.setItem(keys.modelPrefix + provider, model);
+      window.localStorage.setItem(keys.effortPrefix + provider, effort);
+      window.localStorage.setItem(keys.permissionPrefix + provider, permission);
+    },
+    {
+      provider: 'codex',
+      model: opts.model,
+      effort: opts.effort,
+      permission: opts.permissionMode,
+      keys: {
+        provider: STORAGE_LAST_PROVIDER,
+        modelPrefix: STORAGE_LAST_MODEL_PREFIX,
+        effortPrefix: STORAGE_LAST_EFFORT_PREFIX,
+        permissionPrefix: STORAGE_LAST_PERMISSION_PREFIX,
+      },
+    },
+  );
+  // Reload so useLaunchDefaults picks up the seeded values.
+  // Don't use waitForApp — it navigates to '/'. Just wait for the picker.
+  await page.reload();
+  // Wait for the provider model picker button to show "Codex" text,
+  // confirming the seeded values were applied.
+  await expect(
+    page.locator('button[aria-haspopup="listbox"]').first(),
+  ).toContainText('Codex', { timeout: 10000 });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Codex session smoke test', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForApp(page);
+    await selectRepo(page);
+  });
+
+  test('full Codex session: launch, first turn, approval, providerSessionId', async ({
+    page,
+  }, testInfo) => {
+    // This test covers multiple round-trips (session launch, first turn, approval
+    // round-trip, second turn completion) — extend the timeout to 120s.
+    testInfo.setTimeout(120000);
+    const title = `E2E Codex ${Date.now()}`;
+    await createTask(page, title, 'say hello and write a one-line README');
+    await openTaskPage(page, title);
+
+    // ── Step 1: configure provider/model/effort/permissionMode via localStorage
+    // and reload so useLaunchDefaults reads the seeded values.
+    await seedCodexLaunchDefaults(page, {
+      model: 'gpt-5.4-mini',
+      effort: 'medium',
+      permissionMode: 'default',
+    });
+
+    // ── Step 2: send a prompt that does NOT trigger an approval ──────────────
+    const textarea = page.locator(
+      'textarea[placeholder*="What would you like"]',
+    );
+    await expect(textarea).toBeVisible({ timeout: 5000 });
+    await textarea.fill('say hello and write a one-line README');
+    await page.locator('button', { hasText: 'Send' }).click();
+
+    // ── Step 3: assert assistant message bubble renders ──────────────────────
+    // The fake transport emits "Hello! I have written a one-line README for you."
+    await expect(
+      page.locator('text=Hello! I have written a one-line README for you.'),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Assert at least one fileChange card renders.
+    // The fake emits a fileChange item mapped to toolName 'Edit'. The ToolCallUI
+    // renders it as a collapsible tool card with header "Edit file" and a
+    // "Completed" status badge when the turn finishes.
+    await expect(page.locator('text=Edit file').first()).toBeVisible({
+      timeout: 30000,
+    });
+
+    // Assert NO permanent thinking spinner remains after turn completes.
+    // The fake emits turn/completed, which clears codexTurnActive — the
+    // ThinkingIndicator (data-testid="thinking-indicator") returns null when
+    // isRunning is false, so it should be hidden/absent in the DOM at this
+    // point. This catches the regression documented in SessionThread.tsx (lines
+    // 67-69) where isThinking stays true between Codex turns if turn boundaries
+    // aren't factored in. We assert at this point specifically — after turn 1
+    // text and "Edit file" card are visible — but before the follow-up send
+    // that starts turn 2, so the assertion is unambiguous about which turn's
+    // spinner we're checking.
+    await expect(page.getByTestId('thinking-indicator')).toBeHidden({
+      timeout: 15000,
+    });
+
+    // ── Step 5: assert providerSessionId is non-null after first turn ────────
+    // SessionPanel exposes data-provider-session-id on its root div once
+    // companionUpdateProviderSessionId writes the fake thread id back to Convex.
+    await expect(page.locator('[data-provider-session-id]')).toHaveAttribute(
+      'data-provider-session-id',
+      /fake-thread-/,
+      { timeout: 15000 },
+    );
+
+    // ── Step 4: send a follow-up that triggers a file-change approval ────────
+    const followUpText = 'update the README with a better title';
+    // The active session uses SessionComposer. The submit button shows
+    // aria-label="Stop session" when the textarea is empty (session still running),
+    // but switches to "Send message" as soon as there is text to send.
+    // Fill the textarea first to trigger chatStatus='ready', then click send.
+    //
+    // We use the SessionComposer's textarea. It has placeholder "Send a follow-up…"
+    // or "Type a follow-up…" (differs by session status). If not found immediately,
+    // wait — the ActiveSession may still be mounting.
+    const sessionComposerTextarea = page
+      .locator(
+        'textarea[placeholder*="follow-up"], textarea[placeholder*="Follow-up"]',
+      )
+      .first();
+    await expect(sessionComposerTextarea).toBeVisible({ timeout: 15000 });
+    await sessionComposerTextarea.fill(followUpText);
+
+    // With text typed, the submit button switches to aria-label="Send message".
+    const activeComposer = page.locator('[aria-label="Send message"]');
+    await expect(activeComposer).toBeVisible({ timeout: 10000 });
+    await activeComposer.click();
+
+    // The fake emits item/fileChange/requestApproval on turn 2.
+    // The approval card should show "Write to file?" as the header.
+    await expect(page.locator('text=Write to file?')).toBeVisible({
+      timeout: 30000,
+    });
+
+    // Assert the approval card rendered with the correct copy ("Write to file?")
+    // — already done above. Now approve it.
+    const approveButton = page
+      .locator('button', { hasText: 'Approve' })
+      .first();
+    await expect(approveButton).toBeVisible({ timeout: 5000 });
+    await approveButton.click();
+
+    // After approval, the fake resumes the turn, emits item/completed and
+    // turn/completed, then the agent message "Done! Updated README.md."
+    await expect(page.locator('text=Done! Updated README.md.')).toBeVisible({
+      timeout: 30000,
+    });
+
+    // Confirm the approval prompt is gone (card flipped to approved/done state)
+    await expect(page.locator('button', { hasText: 'Approve' })).toBeHidden({
+      timeout: 5000,
+    });
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -92,6 +92,12 @@ export default defineConfig({
       ...(process.env.E2E_INTERNAL_API_SECRET && {
         INTERNAL_API_SECRET: process.env.E2E_INTERNAL_API_SECRET,
       }),
+      CODEX_FAKE_TRANSPORT: '1',
+      // Shrink approval poll timeout for E2E so the test doesn't wait 5 minutes
+      CODEX_APPROVAL_POLL_TIMEOUT_MS: '30000',
+      // Allow the companion to sign in anonymously (same as ALLOW_PASSWORD_AUTH).
+      // Without this the companion can't pick up queued sessions in E2E.
+      ALLOW_ANONYMOUS_AUTH: '1',
     },
   },
 });

--- a/src/codex/fakeTransport.ts
+++ b/src/codex/fakeTransport.ts
@@ -1,0 +1,487 @@
+/**
+ * Fake AppServerClient for E2E smoke testing.
+ *
+ * When CODEX_FAKE_TRANSPORT=1 is set, the Codex manager uses this instead of
+ * spawning the real `codex` binary. It emits a scripted, deterministic event
+ * stream that exercises the turn/started → item/agentMessage/delta →
+ * item/started (fileChange) → item/completed → turn/completed pipeline and
+ * the item/fileChange/requestApproval approval bridge.
+ *
+ * Turn behaviour:
+ *   Turn 1 (first call to turn.start): emits agent message + fileChange item,
+ *           then turn/completed. No approval required.
+ *   Turn 2+ (subsequent calls to turn.start): emits fileChange item/started,
+ *            then fires item/fileChange/requestApproval through the approval
+ *            handler, waits for resolution, then emits item/completed and
+ *            turn/completed.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+  AppServerClient,
+  AppServerClientApprovalResponse,
+  AppServerClientInboundApprovalRequest,
+  AppServerClientNotification,
+} from 'codex-app-server-client';
+
+// biome-ignore lint/suspicious/noExplicitAny: mirrors AppServerClient event listener map
+type Listener = (notification: any) => void;
+
+/** Create a fake AppServerClient that the manager can use in place of the real one. */
+export function createFakeClient(): AppServerClient {
+  // Thread id assigned on thread.start and returned via thread/started notification.
+  const threadId = `fake-thread-${randomUUID()}`;
+  let turnCount = 0;
+
+  // Event listeners registered via onEvent()
+  const listeners = new Map<string, Set<Listener>>();
+
+  // Approval handler registered via handleApprovalRequests()
+  let approvalHandler:
+    | ((
+        req: AppServerClientInboundApprovalRequest,
+      ) =>
+        | AppServerClientApprovalResponse
+        | Promise<AppServerClientApprovalResponse>)
+    | null = null;
+
+  function emit(method: string, params: unknown): void {
+    const set = listeners.get(method);
+    if (!set) return;
+    const notification = { method, params };
+    for (const fn of set) {
+      fn(notification as AppServerClientNotification);
+    }
+  }
+
+  function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async function runTurn1(turnId: string): Promise<void> {
+    const agentItemId = `fake-agent-${randomUUID()}`;
+    const fileItemId = `fake-file-${randomUUID()}`;
+
+    // turn/started
+    emit('turn/started', {
+      threadId,
+      turn: {
+        id: turnId,
+        items: [],
+        status: 'inProgress',
+        error: null,
+        startedAt: Math.floor(Date.now() / 1000),
+        completedAt: null,
+        durationMs: null,
+      },
+    });
+
+    await delay(30);
+
+    // Stream agent message text
+    const text = 'Hello! I have written a one-line README for you.';
+    for (let i = 0; i < text.length; i += 8) {
+      emit('item/agentMessage/delta', {
+        threadId,
+        turnId,
+        itemId: agentItemId,
+        delta: text.slice(i, i + 8),
+      });
+      await delay(10);
+    }
+
+    // item/started for fileChange
+    emit('item/started', {
+      threadId,
+      turnId,
+      item: {
+        type: 'fileChange',
+        id: fileItemId,
+        changes: [
+          { path: 'README.md', kind: { type: 'add' }, diff: '+# Hello\n' },
+        ],
+        status: 'inProgress',
+      },
+    });
+
+    await delay(20);
+
+    // item/completed for agentMessage
+    emit('item/completed', {
+      threadId,
+      turnId,
+      item: {
+        type: 'agentMessage',
+        id: agentItemId,
+        text,
+        phase: null,
+        memoryCitation: null,
+      },
+    });
+
+    // item/completed for fileChange
+    emit('item/completed', {
+      threadId,
+      turnId,
+      item: {
+        type: 'fileChange',
+        id: fileItemId,
+        changes: [
+          { path: 'README.md', kind: { type: 'add' }, diff: '+# Hello\n' },
+        ],
+        status: 'completed',
+      },
+    });
+
+    await delay(20);
+
+    // turn/completed
+    emit('turn/completed', {
+      threadId,
+      turn: {
+        id: turnId,
+        items: [],
+        status: 'completed',
+        error: null,
+        startedAt: Math.floor(Date.now() / 1000) - 1,
+        completedAt: Math.floor(Date.now() / 1000),
+        durationMs: 1000,
+      },
+    });
+  }
+
+  async function runTurn2(turnId: string): Promise<void> {
+    const fileItemId = `fake-file-${randomUUID()}`;
+    const agentItemId = `fake-agent-${randomUUID()}`;
+
+    // turn/started
+    emit('turn/started', {
+      threadId,
+      turn: {
+        id: turnId,
+        items: [],
+        status: 'inProgress',
+        error: null,
+        startedAt: Math.floor(Date.now() / 1000),
+        completedAt: null,
+        durationMs: null,
+      },
+    });
+
+    await delay(30);
+
+    // item/started for fileChange
+    emit('item/started', {
+      threadId,
+      turnId,
+      item: {
+        type: 'fileChange',
+        id: fileItemId,
+        changes: [
+          {
+            path: 'README.md',
+            kind: { type: 'update', move_path: null },
+            diff: '-# Hello\n+# Hello World\n',
+          },
+        ],
+        status: 'inProgress',
+      },
+    });
+
+    await delay(20);
+
+    // Fire item/fileChange/requestApproval through the approval handler
+    if (approvalHandler) {
+      const requestId =
+        randomUUID() as unknown as import('codex-app-server-client').AppServerClientInboundApprovalRequest['id'];
+      const rawParams = {
+        threadId,
+        turnId,
+        itemId: fileItemId,
+        reason: null,
+        grantRoot: null,
+      };
+
+      // Construct the normalized approval request shape expected by handleApprovalRequests
+      const request: AppServerClientInboundApprovalRequest = {
+        id: requestId,
+        method: 'item/fileChange/requestApproval',
+        kind: 'fileChange',
+        threadId,
+        turnId,
+        itemId: fileItemId,
+        reason: null,
+        message: null,
+        questions: [],
+        rawParams,
+        approve: () => ({ decision: 'accept' as const }),
+        deny: () => ({ decision: 'decline' as const }),
+        respond: async () => {
+          /* no-op in fake */
+        },
+        respondError: async () => {
+          /* no-op in fake */
+        },
+      } as unknown as AppServerClientInboundApprovalRequest;
+
+      // Call the approval handler and wait for resolution
+      await approvalHandler(request);
+    }
+
+    await delay(20);
+
+    // item/completed for fileChange (after approval)
+    emit('item/completed', {
+      threadId,
+      turnId,
+      item: {
+        type: 'fileChange',
+        id: fileItemId,
+        changes: [
+          {
+            path: 'README.md',
+            kind: { type: 'update', move_path: null },
+            diff: '-# Hello\n+# Hello World\n',
+          },
+        ],
+        status: 'completed',
+      },
+    });
+
+    // Agent message confirming completion
+    emit('item/agentMessage/delta', {
+      threadId,
+      turnId,
+      itemId: agentItemId,
+      delta: 'Done! Updated README.md.',
+    });
+
+    await delay(10);
+
+    emit('item/completed', {
+      threadId,
+      turnId,
+      item: {
+        type: 'agentMessage',
+        id: agentItemId,
+        text: 'Done! Updated README.md.',
+        phase: null,
+        memoryCitation: null,
+      },
+    });
+
+    await delay(20);
+
+    // turn/completed
+    emit('turn/completed', {
+      threadId,
+      turn: {
+        id: turnId,
+        items: [],
+        status: 'completed',
+        error: null,
+        startedAt: Math.floor(Date.now() / 1000) - 1,
+        completedAt: Math.floor(Date.now() / 1000),
+        durationMs: 1000,
+      },
+    });
+  }
+
+  const fakeClient = {
+    thread: {
+      start: async (_opts?: unknown) => {
+        // Emit thread/started
+        emit('thread/started', {
+          thread: {
+            id: threadId,
+            forkedFromId: null,
+            preview: '',
+            ephemeral: false,
+            modelProvider: 'openai',
+            createdAt: Math.floor(Date.now() / 1000),
+            updatedAt: Math.floor(Date.now() / 1000),
+            status: { type: 'idle' },
+            path: null,
+            cwd: '/',
+            cliVersion: '0.0.0',
+            source: 'cli',
+            agentNickname: null,
+            agentRole: null,
+            gitInfo: null,
+            name: null,
+            turns: [],
+          },
+        });
+        return { thread: { id: threadId } };
+      },
+
+      resume: async (params: { threadId: string }) => {
+        emit('thread/started', {
+          thread: {
+            id: params.threadId,
+            forkedFromId: null,
+            preview: '',
+            ephemeral: false,
+            modelProvider: 'openai',
+            createdAt: Math.floor(Date.now() / 1000),
+            updatedAt: Math.floor(Date.now() / 1000),
+            status: { type: 'idle' },
+            path: null,
+            cwd: '/',
+            cliVersion: '0.0.0',
+            source: 'cli',
+            agentNickname: null,
+            agentRole: null,
+            gitInfo: null,
+            name: null,
+            turns: [],
+          },
+        });
+        return { thread: { id: params.threadId } };
+      },
+
+      run: async () => {
+        throw new Error('fakeTransport: thread.run not supported');
+      },
+      read: async () => {
+        throw new Error('fakeTransport: thread.read not supported');
+      },
+      list: async () => ({ threads: [] }),
+      loadedList: async () => ({ threads: [] }),
+    },
+
+    turn: {
+      start: async (_params: { threadId: string }) => {
+        const thisTurn = ++turnCount;
+        const turnId = `fake-turn-${randomUUID()}`;
+        // Run the scripted event stream asynchronously (don't await — manager
+        // subscribes to events and doesn't await turn.start for completion)
+        void (thisTurn === 1 ? runTurn1(turnId) : runTurn2(turnId));
+        return { turn: { id: turnId } };
+      },
+      interrupt: async () => ({}),
+      steer: async () => ({}),
+      run: async () => {
+        throw new Error('fakeTransport: turn.run not supported');
+      },
+    },
+
+    command: {
+      exec: async () => {
+        throw new Error('fakeTransport: command.exec not supported');
+      },
+      write: async () => {
+        throw new Error('fakeTransport: command.write not supported');
+      },
+      resize: async () => {
+        throw new Error('fakeTransport: command.resize not supported');
+      },
+      terminate: async () => {
+        throw new Error('fakeTransport: command.terminate not supported');
+      },
+    },
+
+    fs: {
+      readFile: async () => {
+        throw new Error('fakeTransport: fs.readFile not supported');
+      },
+      writeFile: async () => {
+        throw new Error('fakeTransport: fs.writeFile not supported');
+      },
+      createDirectory: async () => {
+        throw new Error('fakeTransport: fs.createDirectory not supported');
+      },
+      getMetadata: async () => {
+        throw new Error('fakeTransport: fs.getMetadata not supported');
+      },
+      readDirectory: async () => {
+        throw new Error('fakeTransport: fs.readDirectory not supported');
+      },
+      remove: async () => {
+        throw new Error('fakeTransport: fs.remove not supported');
+      },
+      copy: async () => {
+        throw new Error('fakeTransport: fs.copy not supported');
+      },
+    },
+
+    account: {
+      read: async () => {
+        throw new Error('fakeTransport: account.read not supported');
+      },
+      loginStart: async () => {
+        throw new Error('fakeTransport: account.loginStart not supported');
+      },
+      loginCancel: async () => {
+        throw new Error('fakeTransport: account.loginCancel not supported');
+      },
+      logout: async () => {
+        throw new Error('fakeTransport: account.logout not supported');
+      },
+      rateLimitsRead: async () => {
+        throw new Error('fakeTransport: account.rateLimitsRead not supported');
+      },
+    },
+
+    get state() {
+      return 'ready' as const;
+    },
+    get initializationState() {
+      return 'done' as const;
+    },
+
+    start: async () => {},
+    close: async () => {},
+
+    initialize: async () => ({
+      serverInfo: { name: 'fake', version: '0.0.0' },
+      capabilities: {},
+    }),
+
+    initialized: async () => {},
+
+    appList: async () => ({ apps: [] }),
+    modelList: async () => ({ models: [] }),
+    skillsList: async () => ({ skills: [] }),
+
+    onNotification: (_listener: Listener) => () => {},
+
+    onEvent: (method: string, listener: Listener) => {
+      if (!listeners.has(method)) listeners.set(method, new Set());
+      // biome-ignore lint/style/noNonNullAssertion: just set above
+      listeners.get(method)!.add(listener);
+      return () => {
+        listeners.get(method)?.delete(listener);
+      };
+    },
+
+    onRequest: (_listener: Listener) => () => {},
+
+    onApprovalRequest: (_listener: Listener) => () => {},
+
+    onServerRequest: (_method: string, _listener: Listener) => () => {},
+
+    handleRequest: (_method: string, _handler: unknown) => () => {},
+
+    handleApprovals: (_handlers: unknown) => () => {},
+
+    handleApprovalRequests: (
+      handler: (
+        req: AppServerClientInboundApprovalRequest,
+      ) =>
+        | AppServerClientApprovalResponse
+        | Promise<AppServerClientApprovalResponse>,
+    ) => {
+      approvalHandler = handler;
+      return () => {
+        approvalHandler = null;
+      };
+    },
+
+    onError: (_listener: Listener) => () => {},
+
+    onClose: (_listener: Listener) => () => {},
+  };
+
+  return fakeClient as unknown as AppServerClient;
+}

--- a/src/codex/manager.ts
+++ b/src/codex/manager.ts
@@ -11,6 +11,7 @@ import {
 import { DEFAULT_CODEX_MODEL } from '@/constants';
 import { isPermissionMode, type PermissionMode } from '@/permissionMode';
 import { getConvexClient, getConvexHttpClient } from '@/server/convex-client';
+import { createFakeClient } from './fakeTransport';
 
 export type { PermissionMode } from '@/permissionMode';
 
@@ -577,10 +578,13 @@ export async function startSession(opts: {
   delete codexEnv.CLAUDECODE;
   delete codexEnv.CLAUDE_CODE_ENTRYPOINT;
 
-  const client = await createClient({
-    cwd: opts.repoPath,
-    env: codexEnv,
-  });
+  const client: AppServerClient =
+    process.env.CODEX_FAKE_TRANSPORT === '1'
+      ? createFakeClient()
+      : await createClient({
+          cwd: opts.repoPath,
+          env: codexEnv,
+        });
 
   try {
     const threadResponse = opts.resumeProviderSessionId

--- a/src/frontend/components/SessionPanel.tsx
+++ b/src/frontend/components/SessionPanel.tsx
@@ -146,7 +146,10 @@ export default function SessionPanel({ taskId }: SessionPanelProps) {
   const sessionProvider: 'claude' | 'codex' = session?.provider ?? 'claude';
 
   return (
-    <div className="flex h-full flex-col bg-background">
+    <div
+      className="flex h-full flex-col bg-background"
+      data-provider-session-id={session?.providerSessionId ?? undefined}
+    >
       <div className="flex shrink-0 items-center gap-2 border-b border-border/50 px-3 py-2">
         <SessionDropdown taskId={taskId} activeSessionId={sessionId} />
         {sessionId && (

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1137,6 +1137,63 @@ describe('holophyte_launch_session', () => {
       expect.objectContaining({ model: 'claude-opus-4' }),
     );
   });
+
+  it("forwards provider:'codex' to the create mutation", async () => {
+    mockQuery.mockResolvedValueOnce({
+      _id: 'task1',
+      prompt: 'build something',
+      repoId: 'r1',
+    });
+    mockQuery.mockResolvedValueOnce({ lastSeen: Date.now() });
+    mockMutation.mockResolvedValueOnce('session-codex-1');
+
+    await tool('holophyte_launch_session')({
+      taskId: 'task1',
+      provider: 'codex',
+    });
+
+    expect(mockMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ provider: 'codex' }),
+    );
+  });
+
+  it("forwards provider:'claude' to the create mutation", async () => {
+    mockQuery.mockResolvedValueOnce({
+      _id: 'task1',
+      prompt: 'build something',
+      repoId: 'r1',
+    });
+    mockQuery.mockResolvedValueOnce({ lastSeen: Date.now() });
+    mockMutation.mockResolvedValueOnce('session-claude-1');
+
+    await tool('holophyte_launch_session')({
+      taskId: 'task1',
+      provider: 'claude',
+    });
+
+    expect(mockMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ provider: 'claude' }),
+    );
+  });
+
+  it('defaults to DEFAULT_PROVIDER (claude) when provider is omitted', async () => {
+    mockQuery.mockResolvedValueOnce({
+      _id: 'task1',
+      prompt: 'build something',
+      repoId: 'r1',
+    });
+    mockQuery.mockResolvedValueOnce({ lastSeen: Date.now() });
+    mockMutation.mockResolvedValueOnce('session-default-1');
+
+    await tool('holophyte_launch_session')({ taskId: 'task1' });
+
+    expect(mockMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ provider: 'claude' }),
+    );
+  });
 });
 
 // ── holophyte_stop_session ────────────────────────────────────────────

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,7 +19,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { ConvexHttpClient } from 'convex/browser';
 import { z } from 'zod';
-import { DEFAULT_MODEL } from '@/constants';
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from '@/constants';
 import { readApiKeyFile, signInWithApiKey } from '@/server/auth-token';
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -610,7 +610,7 @@ server.tool(
 
 server.tool(
   'holophyte_launch_session',
-  'Launch a new session for a task (requires a running companion process to pick it up)',
+  'Launch a new Claude or Codex session for a task (requires a running companion process to pick it up)',
   {
     taskId: z.string().describe('Task ID to launch session for'),
     prompt: z
@@ -621,8 +621,14 @@ server.tool(
       .string()
       .optional()
       .describe(`Model to use (default: ${DEFAULT_MODEL})`),
+    provider: z
+      .enum(['claude', 'codex'])
+      .optional()
+      .describe(
+        `AI provider to use: 'claude' (Anthropic Claude Code) or 'codex' (OpenAI Codex). Default: ${DEFAULT_PROVIDER}`,
+      ),
   },
-  async ({ taskId, prompt, model }) => {
+  async ({ taskId, prompt, model, provider }) => {
     const client = requireClient();
 
     // Verify task exists and has a prompt
@@ -657,7 +663,7 @@ server.tool(
       taskId: taskId as Id<'tasks'>,
       prompt: effectivePrompt,
       model,
-      provider: 'claude',
+      provider: provider ?? DEFAULT_PROVIDER,
     });
 
     return textResponse(

--- a/src/server/subscriptions.ts
+++ b/src/server/subscriptions.ts
@@ -68,6 +68,14 @@ async function handleQueuedSession(session: QueuedSession): Promise<void> {
   const provider = session.provider ?? 'claude';
   const manager = provider === 'codex' ? codex : claude;
 
+  // E2E fake-transport mode (CODEX_FAKE_TRANSPORT=1) exercises only the Codex
+  // path via a scripted in-process transport. Leave non-codex sessions queued
+  // so specs that assert the queued-session UI (composer-enhancements.spec.ts)
+  // continue to behave as if the companion is idle for Claude launches.
+  if (process.env.CODEX_FAKE_TRANSPORT === '1' && provider !== 'codex') {
+    return;
+  }
+
   inFlightClaims.add(session._id);
   try {
     const claimed = await client.mutation(api.sessions.companionClaimQueued, {


### PR DESCRIPTION
Completes the final two tasks of Codex Phase 0.

## Task 9 — MCP \`holophyte_launch_session\` provider arg
- Adds optional \`provider: 'claude' | 'codex'\` to the tool schema, forwarded to \`api.sessions.create\`, defaulting to \`DEFAULT_PROVIDER\` when omitted.
- Updates the tool description to mention both providers.
- Adds tests for codex/claude forwarding and the no-provider default.

Spec: `wiki/core/codex-integration-spec.md` § Task 9.

## Task 10 — Codex session E2E smoke
End-to-end Playwright smoke for the full Codex path, with **no real `codex` binary**.

- **`src/codex/fakeTransport.ts`** — scripted `AppServerClient` emitting a deterministic two-turn event stream (agent message + `fileChange`, then a follow-up `fileChange` approval that resolves through the real `pendingApprovals` bridge).
- **`src/codex/manager.ts`** — env-gated seam: `createFakeClient()` when `CODEX_FAKE_TRANSPORT=1`, real `createClient()` otherwise. **Production path unchanged when the env var is unset.**
- **`src/server/subscriptions.ts`** — under `CODEX_FAKE_TRANSPORT` the companion only claims `codex` sessions, so Claude launches stay queued and the queued-state specs (`composer-enhancements`) keep passing.
- **`playwright.config.ts`** — enables the fake transport + anonymous companion auth + shortened approval poll for the E2E webServer.
- **`SessionPanel.tsx`** — exposes `data-provider-session-id` for the assertion.
- **`e2e/codex-session.spec.ts`** — asserts: assistant bubble renders, ≥1 fileChange card renders, thinking spinner clears after `turn/completed`, follow-up file-change approval shows "Write to file?" and approve round-trips to completion, and `providerSessionId` is non-null on the Convex record.

Spec: `wiki/core/codex-integration-spec.md` § Task 10.

## Verification
- `bun run check` — lint + typecheck + 754 unit tests green.
- `bun run test:e2e -- composer-enhancements codex-session` — 12/12 pass.

## Note: pre-existing unrelated failures
The full `bun run test:e2e` shows 10 `api-keys.spec.ts` failures ("Generate Key" button rendering off-viewport on `/settings`). These fail **identically with this branch's `playwright.config.ts` reverted to baseline**, so they are pre-existing/environmental and unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now support Codex as an AI provider option, alongside the existing Claude provider.

* **Tests**
  * Added end-to-end smoke test for Codex session workflows, including multi-turn conversations and file approval handling.
  * Expanded provider parameter test coverage in session creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holophyte/holophyte/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->