### PR TITLE
feat(tui): ambient tmux status line maintained by holod

### DIFF
--- a/tui/README.md
+++ b/tui/README.md
@@ -46,6 +46,11 @@ holo (CLI)
   (codex has no end hook; the sweep also covers hard kills).
 - **Queue scoring**: permission 100, needs_input 60, error 50, idle 30, plus
   +2/min waiting (capped +40). Quick wins first; no panic UI.
+- **Ambient status line**: holod owns the holo tmux session's `status-right`
+  (session-scoped — your global tmux config is untouched), so attention counts
+  and the top queue item are visible in every agent window. It's pushed on
+  every state change, re-asserted each 5s sweep (heals a recreated session),
+  and reset to "holod stopped" on graceful daemon stop.
 
 ## TUI keys (window 0 only — zero key capture inside agent windows)
 

--- a/tui/src/cli.test.ts
+++ b/tui/src/cli.test.ts
@@ -368,6 +368,7 @@ function makeDeps(overrides: Partial<CliDeps> = {}): TestDeps {
       newWindow: async (_opts) => '@1',
       selectWindow: async (_id) => {},
       listWindowIds: async () => [],
+      setStatusRight: async () => {},
       installReturnBinding: async () => {},
     },
     tuiArgv: ['bun', 'index.tsx', 'tui'],
@@ -403,6 +404,7 @@ describe('runCli attach', () => {
         newWindow: async () => '@1',
         selectWindow: async () => {},
         listWindowIds: async () => [],
+        setStatusRight: async () => {},
         installReturnBinding: async () => {},
       },
     });
@@ -749,6 +751,7 @@ describe('runCli setup', () => {
         newWindow: async () => '@1',
         selectWindow: async () => {},
         listWindowIds: async () => [],
+        setStatusRight: async () => {},
         installReturnBinding: async () => {},
       },
     });
@@ -769,6 +772,7 @@ describe('runCli setup', () => {
         newWindow: async () => '@1',
         selectWindow: async () => {},
         listWindowIds: async () => [],
+        setStatusRight: async () => {},
         installReturnBinding: async () => {},
       },
     });
@@ -784,6 +788,7 @@ describe('runCli setup', () => {
         newWindow: async () => '@1',
         selectWindow: async () => {},
         listWindowIds: async () => [],
+        setStatusRight: async () => {},
         installReturnBinding: async () => {
           throw new Error('no server');
         },

--- a/tui/src/daemon/server.test.ts
+++ b/tui/src/daemon/server.test.ts
@@ -874,6 +874,13 @@ describe('status line', () => {
     expect(tmux.statusRight).toBe(STATUS_STOPPED_LINE);
   });
 
+  it('stop() resolves even when the tombstone write hangs', async () => {
+    const { daemon, tmux } = await startDaemon();
+    // wedged tmux: the write never settles — the deadline must unblock stop()
+    tmux.setStatusRight = () => new Promise<void>(() => {});
+    await daemon.stop();
+  });
+
   it("never touches the new owner's line after a takeover", async () => {
     const { daemon, tmux } = await startDaemon();
     await newSession();

--- a/tui/src/daemon/server.test.ts
+++ b/tui/src/daemon/server.test.ts
@@ -28,6 +28,7 @@ import type {
   StateSnapshot,
 } from '../types';
 import { Daemon, type DaemonOptions } from './server';
+import { STATUS_STOPPED_LINE } from './status-line';
 
 const HARNESSES: HarnessInfo[] = [
   { id: 'claude', configured: true },
@@ -719,5 +720,178 @@ describe('restart persistence', () => {
     expect(state.recentCwds).toEqual(['/repo/a']);
     const session = expectSession(await newSession('claude', '/repo/b'));
     expect(session.id).toBe('claude-2'); // counter never reused
+  });
+});
+
+describe('status line', () => {
+  const NO_SESSIONS_LINE =
+    '#[fg=#4EA876,bold]holo#[default] #[dim]no sessions#[default]';
+
+  function statusCalls(tmux: FakeTmux) {
+    return tmux.calls.filter((call) => call.method === 'setStatusRight');
+  }
+
+  it('asserts the line on daemon start', async () => {
+    const { tmux } = await startDaemon();
+    await until(() => tmux.statusRight !== null, 'initial status line');
+    expect(tmux.statusRight).toBe(NO_SESSIONS_LINE);
+  });
+
+  it('updates on spawn with the top queue item', async () => {
+    const { tmux } = await startDaemon();
+    await newSession();
+    await until(
+      () => tmux.statusRight?.includes('1 idle') === true,
+      'spawn status line',
+    );
+    expect(tmux.statusRight).toContain('claude-1');
+    expect(tmux.statusRight).toContain('starting…');
+  });
+
+  it('shows permission counts, then releases back to running', async () => {
+    const { tmux } = await startDaemon();
+    await newSession();
+    await hook('claude-1', { kind: 'prompt' });
+    clock.now += 10;
+    const held = request(
+      {
+        cmd: 'permission',
+        sessionId: 'claude-1',
+        tool: 'Bash',
+        input: null,
+        timeoutMs: 5000,
+        ts: clock.now,
+      },
+      { timeoutMs: 4000 },
+    );
+    await until(async () => (await status('claude-1')) === 'permission');
+    await until(
+      () => tmux.statusRight?.includes('1 perm') === true,
+      'permission status line',
+    );
+    expect(tmux.statusRight).toContain('#[fg=yellow,bold]1 perm#[default]');
+    expect(tmux.statusRight).toContain('approve: Bash');
+
+    await request({
+      cmd: 'respondPermission',
+      sessionId: 'claude-1',
+      allow: true,
+    });
+    expect(await held).toEqual({ ok: true, decision: 'allow' });
+    await until(
+      () =>
+        tmux.statusRight?.includes('1 run') === true &&
+        tmux.statusRight.includes('nothing needs you'),
+      'released status line',
+    );
+  });
+
+  it('dedupes byte-identical renders between sweeps', async () => {
+    const { tmux } = await startDaemon();
+    await newSession();
+    await hook('claude-1', { kind: 'prompt' });
+    await hook('claude-1', { kind: 'stop', lastMessage: 'a' });
+    await until(
+      () => tmux.statusRight?.includes('review / next prompt') === true,
+      'idle status line',
+    );
+    const count = statusCalls(tmux).length;
+    // lastMessage changes → registry change + broadcast, render identical
+    await hook('claude-1', { kind: 'stop', lastMessage: 'b' });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(statusCalls(tmux).length).toBe(count);
+  });
+
+  it('re-asserts the identical line once per sweep', async () => {
+    const { daemon, tmux } = await startDaemon();
+    await newSession();
+    await until(
+      () => tmux.statusRight?.includes('claude-1') === true,
+      'spawn status line',
+    );
+    const before = statusCalls(tmux);
+    const last = before[before.length - 1];
+    await daemon.sweepOnce();
+    await until(
+      () => statusCalls(tmux).length === before.length + 1,
+      're-assert call',
+    );
+    expect(statusCalls(tmux)[before.length]).toEqual(last);
+  });
+
+  it('keeps serving when setStatusRight rejects and heals on the next sweep', async () => {
+    const { daemon, tmux } = await startDaemon();
+    await newSession();
+    await until(
+      () => tmux.statusRight?.includes('claude-1') === true,
+      'spawn status line',
+    );
+    const orig = tmux.setStatusRight.bind(tmux);
+    tmux.setStatusRight = async () => {
+      throw new Error('boom');
+    };
+    expect(await hook('claude-1', { kind: 'prompt' })).toEqual({ ok: true });
+    await daemon.sweepOnce();
+    expect(await request({ cmd: 'ping' })).toEqual({ ok: true });
+    expect(tmux.statusRight).toContain('starting…'); // stale while tmux is down
+
+    tmux.setStatusRight = orig;
+    await daemon.sweepOnce();
+    await until(
+      () => tmux.statusRight?.includes('1 run') === true,
+      'healed status line',
+    );
+  });
+
+  it('writes the stopped tombstone on graceful stop', async () => {
+    const { daemon, tmux } = await startDaemon();
+    await until(() => tmux.statusRight !== null, 'initial status line');
+    await daemon.stop();
+    expect(tmux.statusRight).toBe(STATUS_STOPPED_LINE);
+  });
+
+  it('a spawn resuming after stop() cannot overwrite the tombstone', async () => {
+    const { daemon, tmux } = await startDaemon();
+    // hold the spawn mid-flight so its broadcast resumes after stop()
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const origNewWindow = tmux.newWindow.bind(tmux);
+    tmux.newWindow = async (opts) => {
+      const id = await origNewWindow(opts);
+      await gate;
+      return id;
+    };
+    const pending = newSession().catch(() => {}); // stop() drops the connection
+    await until(() => tmux.windows.size === 1, 'window creation');
+    await daemon.stop();
+    expect(tmux.statusRight).toBe(STATUS_STOPPED_LINE);
+
+    release(); // the spawn's persist/broadcast now runs after the tombstone
+    await pending;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(tmux.statusRight).toBe(STATUS_STOPPED_LINE);
+  });
+
+  it("never touches the new owner's line after a takeover", async () => {
+    const { daemon, tmux } = await startDaemon();
+    await newSession();
+    await until(
+      () => tmux.statusRight?.includes('claude-1') === true,
+      'spawn status line',
+    );
+    const before = tmux.statusRight;
+    unlinkSync(socketPath()); // another daemon took the path over
+    writeFileSync(statePath(), '{"sessions":[],"counters":{},"recentCwds":[]}');
+    await daemon.sweepOnce();
+    await expect(
+      request({ cmd: 'ping' }, { timeoutMs: 250 }),
+    ).rejects.toThrow();
+    expect(tmux.statusRight).toBe(before);
+    expect(tmux.calls).not.toContainEqual({
+      method: 'setStatusRight',
+      args: [STATUS_STOPPED_LINE],
+    });
   });
 });

--- a/tui/src/daemon/server.test.ts
+++ b/tui/src/daemon/server.test.ts
@@ -881,6 +881,40 @@ describe('status line', () => {
     await daemon.stop();
   });
 
+  it('a failed write un-latches so the next broadcast retries before the sweep', async () => {
+    const { tmux } = await startDaemon();
+    await newSession('claude', '/repo/a');
+    await newSession('claude', '/repo/b');
+    await hook('claude-1', { kind: 'prompt' });
+    clock.now += 10;
+    await hook('claude-1', { kind: 'stop', lastMessage: 'x' });
+    clock.now += 10;
+    await hook('claude-2', { kind: 'prompt' });
+    clock.now += 10;
+    await until(
+      () => tmux.statusRight?.includes('1 run 1 idle') === true,
+      'mixed status line',
+    );
+    // next write fails at the spawn level (tmux could not be asked)
+    const original = tmux.setStatusRight.bind(tmux);
+    tmux.setStatusRight = async () => {
+      tmux.setStatusRight = original;
+      throw new Error('boom');
+    };
+    await hook('claude-2', { kind: 'stop', lastMessage: 'a' }); // "2 idle" render fails
+    await until(
+      () => tmux.setStatusRight === original,
+      'failed write attempted',
+    );
+    clock.now += 10;
+    // byte-identical render (only lastMessage changed) must retry, not dedupe
+    await hook('claude-2', { kind: 'stop', lastMessage: 'b' });
+    await until(
+      () => tmux.statusRight?.includes('2 idle') === true,
+      'retried status line',
+    );
+  });
+
   it("never touches the new owner's line after a takeover", async () => {
     const { daemon, tmux } = await startDaemon();
     await newSession();

--- a/tui/src/daemon/server.ts
+++ b/tui/src/daemon/server.ts
@@ -27,6 +27,7 @@ import type {
 import { SessionRegistry } from './registry';
 import { buildQueue } from './scoring';
 import { loadStateFile, saveStateFile } from './state-file';
+import { renderStatusLine, STATUS_STOPPED_LINE } from './status-line';
 
 export interface DaemonOptions {
   tmux: Tmux;
@@ -63,6 +64,10 @@ export class Daemon {
   private harnesses: HarnessInfo[];
   /** queue of the last push — aging changes scores with time, not events */
   private lastBroadcastQueue: QueueItem[] | null = null;
+  /** rendered line of the last push — dedupe, cleared each sweep so the line is re-asserted */
+  private lastStatusLine: string | null = null;
+  /** serializes set-option calls so rapid broadcasts can't land out of order */
+  private statusChain: Promise<void> = Promise.resolve();
   /** window ids missing on the previous sweep — two consecutive misses terminate */
   private missingWindows = new Set<string>();
   private readonly now: () => number;
@@ -181,8 +186,8 @@ export class Daemon {
     if (server) {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
-    // when another daemon took over, the socket path and state.json are ITS
-    // now — persisting or unlinking here would clobber the live daemon
+    // when another daemon took over, the socket path, state.json, and the
+    // status line are ITS now — touching them here would clobber the live daemon
     if (!this.takenOver) {
       this.persist();
       try {
@@ -190,6 +195,14 @@ export class Daemon {
       } catch {
         // already gone (node unlinks unix sockets on server close)
       }
+      // honest tombstone — counts are no longer live. Routed through the chain
+      // so a content write queued before it can't land after it (writes queued
+      // later are blocked by pushStatusLine's stopping guard); awaited because
+      // main.ts calls process.exit right after stop() resolves.
+      this.statusChain = this.statusChain
+        .then(() => this.opts.tmux.setStatusRight(STATUS_STOPPED_LINE))
+        .catch(() => {});
+      await this.statusChain;
     }
   }
 
@@ -202,6 +215,10 @@ export class Daemon {
       await this.stop();
       return;
     }
+    // session options die with the tmux session and set-option against a
+    // missing session is a silent no-op — re-assert once per sweep so a
+    // recreated or externally clobbered holo session heals within one tick
+    this.lastStatusLine = null;
     const liveIds = await this.opts.tmux.listWindowIds();
     // Two-strike termination: one bad list-windows sample must not destroy
     // session tracking, so a first-time-missing window still counts as live.
@@ -228,6 +245,9 @@ export class Daemon {
     } else if (harnessesChanged || this.queueChanged()) {
       // aging bonus / configured-ness move with time, not with events
       this.broadcast();
+    } else {
+      const snap = this.snapshot();
+      this.pushStatusLine(renderStatusLine(snap.sessions, snap.queue));
     }
   }
 
@@ -512,6 +532,24 @@ export class Daemon {
         subscriber.destroy();
       }
     }
+    this.pushStatusLine(renderStatusLine(push.sessions, push.queue));
+  }
+
+  /**
+   * Optimistic latch: a failed write claims success for at most one sweep
+   * interval — bounded by the per-sweep re-assert. The catch keeps the chain
+   * resolved and the daemon alive through any tmux failure.
+   */
+  private pushStatusLine(line: string): void {
+    // a continuation resuming after stop() began (in-flight sweep, spawn)
+    // must not chain a live-content write onto the tombstone — doStop writes
+    // the tombstone through the chain directly, so this blocks only content
+    if (this.stopping) return;
+    if (line === this.lastStatusLine) return;
+    this.lastStatusLine = line;
+    this.statusChain = this.statusChain
+      .then(() => this.opts.tmux.setStatusRight(line))
+      .catch((err) => console.error('holod status line update failed:', err));
   }
 
   private persist(): void {

--- a/tui/src/daemon/server.ts
+++ b/tui/src/daemon/server.ts
@@ -48,6 +48,9 @@ interface Hold {
   timer: NodeJS.Timeout;
 }
 
+/** longest stop() waits for the tombstone status write before giving up */
+const TOMBSTONE_DEADLINE_MS = 1000;
+
 export class Daemon {
   private registry = new SessionRegistry();
   private server: net.Server | null = null;
@@ -198,11 +201,17 @@ export class Daemon {
       // honest tombstone — counts are no longer live. Routed through the chain
       // so a content write queued before it can't land after it (writes queued
       // later are blocked by pushStatusLine's stopping guard); awaited because
-      // main.ts calls process.exit right after stop() resolves.
+      // main.ts calls process.exit right after stop() resolves — but raced
+      // against a deadline so a wedged tmux can't hold shutdown hostage.
       this.statusChain = this.statusChain
         .then(() => this.opts.tmux.setStatusRight(STATUS_STOPPED_LINE))
         .catch(() => {});
-      await this.statusChain;
+      await Promise.race([
+        this.statusChain,
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, TOMBSTONE_DEADLINE_MS).unref();
+        }),
+      ]);
     }
   }
 

--- a/tui/src/daemon/server.ts
+++ b/tui/src/daemon/server.ts
@@ -545,9 +545,9 @@ export class Daemon {
   }
 
   /**
-   * Optimistic latch: a failed write claims success for at most one sweep
-   * interval — bounded by the per-sweep re-assert. The catch keeps the chain
-   * resolved and the daemon alive through any tmux failure.
+   * Dedupe latch: a failed write un-latches so the next state change retries
+   * immediately; the per-sweep re-assert stays the backstop. The catch keeps
+   * the chain resolved and the daemon alive through any tmux failure.
    */
   private pushStatusLine(line: string): void {
     // a continuation resuming after stop() began (in-flight sweep, spawn)
@@ -558,7 +558,12 @@ export class Daemon {
     this.lastStatusLine = line;
     this.statusChain = this.statusChain
       .then(() => this.opts.tmux.setStatusRight(line))
-      .catch((err) => console.error('holod status line update failed:', err));
+      .catch((err) => {
+        // a failed write must not claim success — un-latch so the next
+        // broadcast retries before the sweep gets to it
+        this.lastStatusLine = null;
+        console.error('holod status line update failed:', err);
+      });
   }
 
   private persist(): void {

--- a/tui/src/daemon/status-line.test.ts
+++ b/tui/src/daemon/status-line.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import type { QueueItem, Session, SessionStatus } from '../types';
+import {
+  renderStatusLine,
+  STATUS_STOPPED_LINE,
+  sanitizeStatusText,
+} from './status-line';
+
+const BRAND = '#[fg=#4EA876,bold]holo#[default]';
+const POINTER = '#[fg=#4EA876]▸#[default]';
+
+function session(
+  id: string,
+  status: SessionStatus,
+  extra: Partial<Session> = {},
+): Session {
+  return {
+    id,
+    harness: 'claude',
+    cwd: '/repo/a',
+    tmuxWindow: '@1',
+    status,
+    createdAt: 0,
+    statusSince: 0,
+    ...extra,
+  };
+}
+
+function item(sessionId: string, score: number, reason: string): QueueItem {
+  return { sessionId, score, reason };
+}
+
+describe('renderStatusLine', () => {
+  it('renders the worked example: 1 permission, 2 running, 1 idle', () => {
+    const sessions = [
+      session('claude-1', 'permission', {
+        pendingPermission: { tool: 'Bash', input: null, respondBy: 5000 },
+      }),
+      session('claude-2', 'running'),
+      session('codex-1', 'running'),
+      session('claude-3', 'idle'),
+    ];
+    const queue = [
+      item('claude-1', 100, 'approve: Bash'),
+      item('claude-3', 30, 'review / next prompt'),
+    ];
+    expect(renderStatusLine(sessions, queue)).toBe(
+      `${BRAND} #[fg=yellow,bold]1 perm#[default] #[dim]2 run 1 idle#[default] ${POINTER} claude-1 #[dim]approve: Bash#[default]`,
+    );
+  });
+
+  it('renders "no sessions" for an empty board', () => {
+    expect(renderStatusLine([], [])).toBe(
+      `${BRAND} #[dim]no sessions#[default]`,
+    );
+  });
+
+  it('treats an only-exited board as "no sessions"', () => {
+    const sessions = [
+      session('claude-1', 'exited'),
+      session('codex-1', 'exited'),
+    ];
+    expect(renderStatusLine(sessions, [])).toBe(
+      `${BRAND} #[dim]no sessions#[default]`,
+    );
+  });
+
+  it('renders "nothing needs you" when only running sessions remain', () => {
+    const sessions = [
+      session('claude-1', 'running'),
+      session('claude-2', 'running'),
+      session('codex-1', 'running'),
+    ];
+    expect(renderStatusLine(sessions, [])).toBe(
+      `${BRAND} #[dim]3 run#[default] ${POINTER} #[dim]nothing needs you#[default]`,
+    );
+  });
+
+  it('orders buckets perm → need → err and omits zero buckets', () => {
+    const sessions = [
+      session('claude-1', 'permission', {
+        pendingPermission: { tool: 'Edit', input: null, respondBy: 5000 },
+      }),
+      session('claude-2', 'needs_input'),
+      session('codex-1', 'error'),
+    ];
+    const queue = [
+      item('claude-1', 100, 'approve: Edit'),
+      item('claude-2', 60, 'needs input'),
+      item('codex-1', 50, 'error'),
+    ];
+    expect(renderStatusLine(sessions, queue)).toBe(
+      `${BRAND} #[fg=yellow,bold]1 perm#[default] #[fg=yellow]1 need#[default] #[fg=red]1 err#[default] ${POINTER} claude-1 #[dim]approve: Edit#[default]`,
+    );
+  });
+
+  it('omits the idle half of the dim segment when zero', () => {
+    const sessions = [
+      session('claude-1', 'needs_input'),
+      session('claude-2', 'running'),
+      session('codex-1', 'running'),
+    ];
+    const queue = [item('claude-1', 60, 'needs input')];
+    expect(renderStatusLine(sessions, queue)).toBe(
+      `${BRAND} #[fg=yellow]1 need#[default] #[dim]2 run#[default] ${POINTER} claude-1 #[dim]needs input#[default]`,
+    );
+  });
+
+  it('omits the run half of the dim segment when zero', () => {
+    const sessions = [session('claude-1', 'idle')];
+    const queue = [item('claude-1', 30, 'starting…')];
+    expect(renderStatusLine(sessions, queue)).toBe(
+      `${BRAND} #[dim]1 idle#[default] ${POINTER} claude-1 #[dim]starting…#[default]`,
+    );
+  });
+
+  it('sanitizes the top reason (agent-derived text)', () => {
+    const sessions = [session('claude-1', 'needs_input')];
+    const queue = [item('claude-1', 60, '#(rm -rf ~)')];
+    expect(renderStatusLine(sessions, queue)).toBe(
+      `${BRAND} #[fg=yellow]1 need#[default] ${POINTER} claude-1 #[dim]##(rm -rf ~)#[default]`,
+    );
+  });
+});
+
+describe('STATUS_STOPPED_LINE', () => {
+  it('is the branded tombstone', () => {
+    expect(STATUS_STOPPED_LINE).toBe(`${BRAND} #[dim]holod stopped#[default]`);
+  });
+});
+
+describe('sanitizeStatusText', () => {
+  it('neutralizes #() command injection', () => {
+    expect(sanitizeStatusText('#(rm -rf ~)', 24)).toBe('##(rm -rf ~)');
+  });
+
+  it('neutralizes #[] style injection', () => {
+    expect(sanitizeStatusText('#[fg=red]x', 24)).toBe('##[fg=red]x');
+  });
+
+  it('neutralizes % so strftime cannot expand it', () => {
+    expect(sanitizeStatusText('tests 80% done', 24)).toBe('tests 80%% done');
+  });
+
+  it('collapses newlines and tabs to single spaces', () => {
+    expect(sanitizeStatusText('a\nb\tc', 24)).toBe('a b c');
+  });
+
+  it('strips control characters', () => {
+    expect(sanitizeStatusText('a\u0007b\u001bc', 24)).toBe('a b c');
+    expect(sanitizeStatusText('\u0000x\u007fy', 24)).toBe('x y');
+  });
+
+  it('clamps long text to max code points with a trailing ellipsis', () => {
+    expect(sanitizeStatusText('a'.repeat(30), 24)).toBe(`${'a'.repeat(23)}…`);
+    expect([...sanitizeStatusText('a'.repeat(30), 24)]).toHaveLength(24);
+  });
+
+  it('leaves text at the limit untouched', () => {
+    expect(sanitizeStatusText('a'.repeat(24), 24)).toBe('a'.repeat(24));
+  });
+
+  it('clamps before escaping — a ## pair is never split by the clamp', () => {
+    // 23 hashes kept, each doubled to 46, plus the ellipsis; escape-then-clamp
+    // would cut through a doubled pair and leave a dangling '#'
+    expect(sanitizeStatusText('#'.repeat(30), 24)).toBe(`${'#'.repeat(46)}…`);
+  });
+
+  it('clamps before escaping — a %% pair is never split by the clamp', () => {
+    expect(sanitizeStatusText('%'.repeat(30), 24)).toBe(`${'%'.repeat(46)}…`);
+  });
+});

--- a/tui/src/daemon/status-line.test.ts
+++ b/tui/src/daemon/status-line.test.ts
@@ -121,6 +121,14 @@ describe('renderStatusLine', () => {
       `${BRAND} #[fg=yellow]1 need#[default] ${POINTER} claude-1 #[dim]##(rm -rf ~)#[default]`,
     );
   });
+
+  it('sanitizes the top session id (future-proofing harness names)', () => {
+    const sessions = [session('my#harness-1', 'idle')];
+    const queue = [item('my#harness-1', 30, 'review / next prompt')];
+    expect(renderStatusLine(sessions, queue)).toContain(
+      `${POINTER} my##harness-1 `,
+    );
+  });
 });
 
 describe('STATUS_STOPPED_LINE', () => {

--- a/tui/src/daemon/status-line.ts
+++ b/tui/src/daemon/status-line.ts
@@ -68,10 +68,11 @@ export function renderStatusLine(
   if (top === undefined) {
     segments.push(`${pointer} #[dim]nothing needs you#[default]`);
   } else {
-    // session ids are daemon-generated ("claude-1"); only reasons carry
-    // arbitrary agent output and need sanitizing
+    // session ids are daemon-generated ("claude-1") and harmless today —
+    // sanitized anyway so a future harness name containing '#' or '%'
+    // can't silently inject a style sequence or strftime directive
     segments.push(
-      `${pointer} ${top.sessionId} #[dim]${sanitizeStatusText(top.reason, REASON_MAX)}#[default]`,
+      `${pointer} ${sanitizeStatusText(top.sessionId, REASON_MAX)} #[dim]${sanitizeStatusText(top.reason, REASON_MAX)}#[default]`,
     );
   }
   return segments.join(' ');

--- a/tui/src/daemon/status-line.ts
+++ b/tui/src/daemon/status-line.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure formatter for the holo tmux session's status-right — no I/O. The
+ * daemon pushes the rendered line on every state change so attention counts
+ * and the top queue item are visible in every agent window. Segment order is
+ * the truncation policy: tmux clips the rendered status-right at the right
+ * edge, so the reason tail drops first and the brand + counts survive longest.
+ */
+
+import type { QueueItem, Session } from '../types';
+import { ACCENT } from '../ui/theme';
+
+const REASON_MAX = 24;
+
+const BRAND = `#[fg=${ACCENT},bold]holo#[default]`;
+
+export const STATUS_STOPPED_LINE = `${BRAND} #[dim]holod stopped#[default]`;
+
+/**
+ * Make agent-derived text safe inside a tmux format string: strip control
+ * chars, collapse whitespace, clamp, then escape `#` → `##` (neutralizes
+ * `#(cmd)` command injection and `#[fg=…]` style injection) and `%` → `%%`
+ * (tmux runs status-right through strftime, so a bare `%d` would render the
+ * day of month). Escaping AFTER clamping means a `##`/`%%` pair can never be
+ * split by the clamp, which would leave a dangling escape that fuses with
+ * the next character.
+ */
+export function sanitizeStatusText(text: string, max: number): string {
+  const collapsed = text
+    .replace(/\p{Cc}/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const points = [...collapsed]; // code points, so the clamp never splits a surrogate pair
+  const clamped =
+    points.length > max ? `${points.slice(0, max - 1).join('')}…` : collapsed;
+  return clamped.replaceAll('#', '##').replaceAll('%', '%%');
+}
+
+export function renderStatusLine(
+  sessions: Session[],
+  queue: QueueItem[],
+): string {
+  const active = sessions.filter((session) => session.status !== 'exited');
+  if (active.length === 0) return `${BRAND} #[dim]no sessions#[default]`;
+
+  const count = (status: Session['status']) =>
+    active.filter((session) => session.status === status).length;
+
+  const segments = [BRAND];
+  const permission = count('permission');
+  if (permission > 0) {
+    segments.push(`#[fg=yellow,bold]${permission} perm#[default]`);
+  }
+  const needsInput = count('needs_input');
+  if (needsInput > 0) segments.push(`#[fg=yellow]${needsInput} need#[default]`);
+  const errored = count('error');
+  if (errored > 0) segments.push(`#[fg=red]${errored} err#[default]`);
+  const running = count('running');
+  const idle = count('idle');
+  if (running > 0 || idle > 0) {
+    const halves = [];
+    if (running > 0) halves.push(`${running} run`);
+    if (idle > 0) halves.push(`${idle} idle`);
+    segments.push(`#[dim]${halves.join(' ')}#[default]`);
+  }
+
+  const pointer = `#[fg=${ACCENT}]▸#[default]`;
+  const top = queue[0];
+  if (top === undefined) {
+    segments.push(`${pointer} #[dim]nothing needs you#[default]`);
+  } else {
+    // session ids are daemon-generated ("claude-1"); only reasons carry
+    // arbitrary agent output and need sanitizing
+    segments.push(
+      `${pointer} ${top.sessionId} #[dim]${sanitizeStatusText(top.reason, REASON_MAX)}#[default]`,
+    );
+  }
+  return segments.join(' ');
+}

--- a/tui/src/tmux.test.ts
+++ b/tui/src/tmux.test.ts
@@ -338,6 +338,58 @@ describe('RealTmux', () => {
     });
   });
 
+  describe('setStatusRight', () => {
+    it('sets status-right-length and status-right in one invocation', async () => {
+      const { runner, calls } = fakeRunner([{}]);
+      const tmux = new RealTmux(runner, 'holo');
+      await tmux.setStatusRight('#[dim]x#[default]');
+      expect(calls).toEqual([
+        [
+          'set-option',
+          '-t',
+          'holo',
+          'status-right-length',
+          '80',
+          ';',
+          'set-option',
+          '-t',
+          'holo',
+          'status-right',
+          '#[dim]x#[default]',
+        ],
+      ]);
+    });
+
+    it('uses the configured session name', async () => {
+      const { runner, calls } = fakeRunner([{}]);
+      const tmux = new RealTmux(runner, 'custom');
+      await tmux.setStatusRight('x');
+      expect(calls).toEqual([
+        [
+          'set-option',
+          '-t',
+          'custom',
+          'status-right-length',
+          '80',
+          ';',
+          'set-option',
+          '-t',
+          'custom',
+          'status-right',
+          'x',
+        ],
+      ]);
+    });
+
+    it('resolves on non-zero exit (session gone is normal)', async () => {
+      const { runner } = fakeRunner([
+        { status: 1, stderr: 'session not found' },
+      ]);
+      const tmux = new RealTmux(runner, 'holo');
+      await expect(tmux.setStatusRight('x')).resolves.toBeUndefined();
+    });
+  });
+
   describe('installReturnBinding', () => {
     it('binds prefix+Space to select the tui window', async () => {
       const { runner, calls } = fakeRunner([{}]);
@@ -422,6 +474,14 @@ describe('FakeTmux', () => {
     const tmux = new FakeTmux();
     await tmux.installReturnBinding();
     expect(tmux.calls).toEqual([{ method: 'installReturnBinding', args: [] }]);
+  });
+
+  it('setStatusRight records the call and stores the text', async () => {
+    const tmux = new FakeTmux();
+    expect(tmux.statusRight).toBeNull();
+    await tmux.setStatusRight('text');
+    expect(tmux.statusRight).toBe('text');
+    expect(tmux.calls).toEqual([{ method: 'setStatusRight', args: ['text'] }]);
   });
 
   it('round-trips newWindow → listWindowIds → closeWindow → listWindowIds', async () => {

--- a/tui/src/tmux.ts
+++ b/tui/src/tmux.ts
@@ -72,6 +72,13 @@ export interface Tmux {
   /** window ids in the holo session; [] when the session is gone; rejects when tmux could not be asked */
   listWindowIds(): Promise<string[]>;
   /**
+   * Session-scoped status line (status-right + status-right-length 80),
+   * owned by holod. Resolves even on non-zero tmux exit (session doesn't
+   * exist yet — nothing to update; the daemon's sweep re-asserts once it
+   * does); rejects only when tmux could not be asked at all.
+   */
+  setStatusRight(text: string): Promise<void>;
+  /**
    * prefix+<key> (default Space, HOLO_RETURN_KEY overrides) → jump back to
    * the TUI window. tmux bindings are server-global — they cannot be scoped
    * to one session, so this is a documented deviation from the spec's
@@ -186,6 +193,27 @@ export class RealTmux implements Tmux {
       .filter((line) => line !== '');
   }
 
+  async setStatusRight(text: string): Promise<void> {
+    // one invocation, two commands — the lone ';' is tmux's command separator
+    // (execFile, no shell, passed literally). Re-sending the length on every
+    // call makes a recreated session self-heal past tmux's 40-col default
+    // status-right-length, which silently truncates. Non-zero exit is ignored
+    // (session gone is normal); spawn-level rejections propagate.
+    await this.run([
+      'set-option',
+      '-t',
+      this.sessionName,
+      'status-right-length',
+      '80',
+      ';',
+      'set-option',
+      '-t',
+      this.sessionName,
+      'status-right',
+      text,
+    ]);
+  }
+
   async installReturnBinding(): Promise<void> {
     await this.run([
       'bind-key',
@@ -209,6 +237,7 @@ export class FakeTmux implements Tmux {
   readonly windows = new Map<string, FakeWindow>();
   readonly calls: Array<{ method: string; args: unknown[] }> = [];
   selected: string | null = null;
+  statusRight: string | null = null;
   /** models the dedicated "tui" window apart from agent windows so agent window ids stay stable */
   tuiWindow: { argv: string[]; env?: Record<string, string> } | null = null;
   private created = false;
@@ -257,6 +286,11 @@ export class FakeTmux implements Tmux {
 
   async listWindowIds(): Promise<string[]> {
     return [...this.windows.keys()];
+  }
+
+  async setStatusRight(text: string): Promise<void> {
+    this.calls.push({ method: 'setStatusRight', args: [text] });
+    this.statusRight = text;
   }
 
   async installReturnBinding(): Promise<void> {


### PR DESCRIPTION
## What

Every window of the holo tmux session now shows an ambient one-line summary in `status-right`: attention counts and the top queue item. When you're attached to an agent's window, you no longer lose track of what else needs you.

Format (priority-ordered so tmux right-edge clipping drops the tail first):

```
holo  1 perm  2 need  3 run 1 idle  ▸ claude-2 approve: Bash
```

- `perm` is yellow-bold, `need` yellow, `err` red, run/idle dim, brand + pointer in the logo's ACCENT green; zero buckets are omitted
- empty board → `holo  no sessions`; nothing queued → `▸ nothing needs you`

## How

- **`Tmux.setStatusRight(text)`** (`tmux.ts`) — one invocation sets `status-right-length 80` + `status-right`, session-scoped (`-t holo`, never touches global config). Non-zero exit resolves: the session not existing yet is normal.
- **Pure formatter** (`daemon/status-line.ts`) — no I/O; agent-derived reasons are control-stripped, whitespace-collapsed, clamped to 24 code points, then escaped `#`→`##` (format/command injection) and `%`→`%%` (tmux runs status-right through strftime — a reason like "tests 80% done" would otherwise render the day of month).
- **Daemon push** (`daemon/server.ts`) — rendered from `broadcast()` with byte-identical dedupe, serialized through a chain so rapid updates can't land out of order, and re-asserted once per 5s sweep so a recreated or externally clobbered session heals within a tick. Graceful stop writes a `holod stopped` tombstone, guarded against in-flight live writes racing past `stop()`; the takeover path leaves the new owner's line alone.

## Design process

Two competing designs (daemon-push vs tmux `#()` polling) were judged; push won on KISS + the per-sweep re-assert covering the polling design's only real advantage (healing after restarts/clobbering). Adversarial review caught two real bugs pre-merge — the post-stop tombstone race and the missing `%` escaping — both fixed and pinned with tests.

## Tests

29 new tests: 16 formatter (exact-string worked example, sanitization incl. clamp-then-escape pins), 4 tmux argv/recording, 9 daemon-level (spawn/permission flows, dedupe, re-assert, tmux-failure tolerance + heal, tombstone, takeover, stop-race). Full tui suite: **411 passed, 2 skipped** (HOLO_SMOKE-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ambient tmux status line showing live daemon state: session counts (permissions needed, errors, running, idle) and the top queued item; reasserts across session recreation and shows “holod stopped” on graceful shutdown. Deduping and retry behavior reduce noise and improve resilience to transient failures.

* **Documentation**
  * README updated with ambient status line behavior and shutdown semantics.

* **Tests**
  * Added integration and unit coverage for status-line rendering, lifecycle, and tmux interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->