### PR TITLE
feat(tui): splash with brand art + auto-opened session picker on empty start

### DIFF
--- a/tui/README.md
+++ b/tui/README.md
@@ -46,6 +46,10 @@ holo (CLI)
   (codex has no end hook; the sweep also covers hard kills).
 - **Queue scoring**: permission 100, needs_input 60, error 50, idle 30, plus
   +2/min waiting (capped +40). Quick wins first; no panic UI.
+- **Empty board = splash**: with zero sessions the main pane shows the
+  holophyte sprout splash, and on first connect to an empty board the
+  new-session picker opens automatically — `esc` dismisses it and it will not
+  reopen on its own (press `n` to bring it back).
 
 ## TUI keys (window 0 only — zero key capture inside agent windows)
 

--- a/tui/src/ui/App.test.tsx
+++ b/tui/src/ui/App.test.tsx
@@ -244,4 +244,77 @@ describe('App', () => {
     expect(frame()).toContain('New Session');
     unmount();
   });
+
+  // Splash sentinels: never assert on 'holo' here — FakeGateway cwds contain
+  // '/Users/x/Development/holophyte'. Use the tagline or the widest art row.
+  // The centered modal occludes the art's middle rows, so never assert art
+  // rows while the modal is open.
+  const TAGLINE = 'what should I look at next?';
+  const WIDE_ROW = '████████████▌▐████████████';
+
+  it('shows the connecting splash before the first push', async () => {
+    const { frame, unmount } = await mount();
+    const out = frame();
+    expect(out).toContain(TAGLINE);
+    expect(out).toContain('connecting to daemon…');
+    expect(out).not.toContain('New Session');
+    unmount();
+  });
+
+  it('auto-opens the picker on an empty first snapshot', async () => {
+    const { push, input, frame, update, unmount } = await mount();
+    await push(snapshot([]));
+    expect(frame()).toContain('New Session');
+    // The very first keystroke drives session creation.
+    input.pressKey('1');
+    await update();
+    expect(frame()).toContain('New claude session — where?');
+    unmount();
+  });
+
+  it('esc is final — the picker never auto-reopens, manual n still works', async () => {
+    const { push, input, frame, update, unmount } = await mount();
+    await push(snapshot([]));
+    await input.pressEscape();
+    await update();
+    const out = frame();
+    expect(out).toContain('n: new session');
+    expect(out).toContain(WIDE_ROW);
+    expect(out).not.toContain('New Session');
+    await push(snapshot([]));
+    expect(frame()).not.toContain('New Session');
+    input.pressKey('n');
+    await update();
+    expect(frame()).toContain('New Session');
+    unmount();
+  });
+
+  it('non-empty first snapshot never auto-opens; later drain shows the splash without the modal', async () => {
+    const { push, frame, unmount } = await mount();
+    await push(snapshot([running()]));
+    const board = frame();
+    expect(board).toContain('codex-1');
+    expect(board).not.toContain('New Session');
+    expect(board).not.toContain(TAGLINE);
+    await push(snapshot([]));
+    const splash = frame();
+    expect(splash).toContain(TAGLINE);
+    expect(splash).toContain(WIDE_ROW);
+    expect(splash).not.toContain('New Session');
+    unmount();
+  });
+
+  it('disconnected banner and the splash coexist', async () => {
+    const { push, gw, input, frame, update, unmount } = await mount();
+    await push(snapshot([]));
+    await input.pressEscape();
+    await act(async () => {
+      gw.dropConnection();
+    });
+    await update();
+    const out = frame();
+    expect(out).toContain('daemon disconnected — retrying…');
+    expect(out).toContain(TAGLINE);
+    unmount();
+  });
 });

--- a/tui/src/ui/App.tsx
+++ b/tui/src/ui/App.tsx
@@ -13,6 +13,7 @@ import { NewSessionModal } from './NewSessionModal';
 import { PreviewPane } from './PreviewPane';
 import { QueuePane } from './QueuePane';
 import { formatElapsed, SessionsPane, statusLabel } from './SessionsPane';
+import { Splash } from './Splash';
 import type { DaemonStatus } from './StatusBar';
 import { StatusBar } from './StatusBar';
 
@@ -52,6 +53,11 @@ export function App({
   const [modalOpen, setModalOpen] = useState(false);
   const [now, setNow] = useState(() => Date.now());
 
+  // One-shot: auto-open the picker if the FIRST snapshot says the board is
+  // empty. A ref, not state — read/flipped inside the subscription handler;
+  // must never re-arm on reconnect, esc, or later sessions-all-exited pushes.
+  const autoOpened = useRef(false);
+
   // Subscription lifecycle — external system: subscribe on mount, retry every
   // second after the connection drops until the daemon is back.
   useEffect(() => {
@@ -65,6 +71,10 @@ export function App({
           onState: (s) => {
             setPush(s);
             setDaemon('up');
+            if (!autoOpened.current) {
+              autoOpened.current = true;
+              if (s.sessions.length === 0) setModalOpen(true);
+            }
           },
           onClose: () => {
             sub = null;
@@ -281,11 +291,9 @@ export function App({
           overflow="hidden"
         >
           {push === null ? (
-            <box padding={1}>
-              <text>
-                <span attributes={DIM}>connecting to daemon…</span>
-              </text>
-            </box>
+            <Splash mode="connecting" />
+          ) : sessions.length === 0 ? (
+            <Splash mode="empty" />
           ) : (
             <PreviewPane
               session={previewSession}

--- a/tui/src/ui/Splash.test.tsx
+++ b/tui/src/ui/Splash.test.tsx
@@ -1,0 +1,53 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { Splash } from './Splash';
+import { renderSetup } from './test-utils';
+
+beforeAll(() => {
+  process.env.HOLO_HOME = mkdtempSync(join(tmpdir(), 'holo-ui-'));
+});
+
+// Widest art row — contiguous across the color seam in the char frame.
+const WIDE_ROW = '████████████▌▐████████████';
+
+describe('Splash', () => {
+  it('full tier, empty mode: art, wordmark, tagline, and n hint', async () => {
+    const { frame, unmount } = await renderSetup(<Splash mode="empty" />);
+    const out = frame();
+    expect(out).toContain(WIDE_ROW);
+    expect(out).toContain('holo');
+    expect(out).toContain('what should I look at next?');
+    expect(out).toContain('n: new session');
+    expect(out).not.toContain('connecting to daemon…');
+    unmount();
+  });
+
+  it('full tier, connecting mode: connecting subtitle, no n hint', async () => {
+    const { frame, unmount } = await renderSetup(<Splash mode="connecting" />);
+    const out = frame();
+    expect(out).toContain('connecting to daemon…');
+    expect(out).toContain(WIDE_ROW);
+    expect(out).not.toContain('n: new session');
+    unmount();
+  });
+
+  it('compact tier: one-line splash, no art', async () => {
+    const { frame, unmount } = await renderSetup(<Splash mode="empty" />, {
+      width: 50,
+      height: 14,
+    });
+    const out = frame();
+    expect(out).not.toContain('▌▐');
+    expect(out).not.toContain('▄▄█████▄');
+    expect(out).toContain('holo — n: new session');
+    unmount();
+  });
+
+  it('centers the art (top row is not flush-left)', async () => {
+    const { frame, unmount } = await renderSetup(<Splash mode="empty" />);
+    expect(frame()).toMatch(/ {10,}▄▄█████▄/);
+    unmount();
+  });
+});

--- a/tui/src/ui/Splash.test.tsx
+++ b/tui/src/ui/Splash.test.tsx
@@ -1,13 +1,6 @@
-import { mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { Splash } from './Splash';
 import { renderSetup } from './test-utils';
-
-beforeAll(() => {
-  process.env.HOLO_HOME = mkdtempSync(join(tmpdir(), 'holo-ui-'));
-});
 
 // Widest art row — contiguous across the color seam in the char frame.
 const WIDE_ROW = '████████████▌▐████████████';

--- a/tui/src/ui/Splash.tsx
+++ b/tui/src/ui/Splash.tsx
@@ -1,0 +1,100 @@
+import { createTextAttributes } from '@opentui/core';
+import { useTerminalDimensions } from '@opentui/react';
+import { ACCENT, ACCENT_DARK } from './theme';
+
+const BOLD = createTextAttributes({ bold: true });
+const DIM = createTextAttributes({ dim: true });
+
+const TAGLINE = 'what should I look at next?';
+const CONNECTING = 'connecting to daemon…';
+
+/** Two-lobed sprout from public/favicon.svg — [left lobe, right lobe] per
+ *  row. Halves are exactly 13 chars each (equal width is load-bearing for
+ *  alignment); the ▌▐ seam stands in for the logo's center vein. */
+const SPROUT: ReadonlyArray<readonly [string, string]> = [
+  ['   ▄▄█████▄  ', '  ▄█████▄▄   '],
+  [' ▄██████████▌', '▐██████████▄ '],
+  ['▄███████████▌', '▐███████████▄'],
+  ['████████████▌', '▐████████████'],
+  ['▀███████████▌', '▐███████████▀'],
+  ['  ▀█████████▌', '▐█████████▀  '],
+  ['    ▀███████▌', '▐███████▀    '],
+  ['       ▀████▌', '▐████▀       '],
+  ['          ▀█▌', '▐█▀          '],
+];
+const ART_WIDTH = 26;
+
+// Full tier needs sidebar(30) + pane border(2) + art(26) + margin cols, and
+// 14 content rows + status bar/border/banner chrome. Thresholds are on
+// terminal dims — Splash only ever renders in the main pane, so the 30-col
+// sidebar is baked in rather than plumbed through props.
+const MIN_FULL_WIDTH = 62;
+const MIN_FULL_HEIGHT = 20;
+
+export type SplashMode = 'connecting' | 'empty';
+
+export interface SplashProps {
+  mode: SplashMode;
+}
+
+export function Splash({ mode }: SplashProps) {
+  const dims = useTerminalDimensions();
+  const full = dims.width >= MIN_FULL_WIDTH && dims.height >= MIN_FULL_HEIGHT;
+  if (!full) {
+    return (
+      <box
+        flexGrow={1}
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <text>
+          <span fg={ACCENT} attributes={BOLD}>
+            holo
+          </span>
+          <span attributes={DIM}>
+            {mode === 'connecting' ? ` — ${CONNECTING}` : ' — n: new session'}
+          </span>
+        </text>
+      </box>
+    );
+  }
+  return (
+    <box
+      flexGrow={1}
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <box flexDirection="column" width={ART_WIDTH} flexShrink={0}>
+        {SPROUT.map(([left, right], i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static art rows
+          <text key={i}>
+            <span fg={ACCENT}>{left}</span>
+            <span fg={ACCENT_DARK}>{right}</span>
+          </text>
+        ))}
+      </box>
+      <text> </text>
+      <text>
+        <span fg={ACCENT} attributes={BOLD}>
+          holo
+        </span>
+      </text>
+      <text>
+        <span attributes={DIM}>{TAGLINE}</span>
+      </text>
+      <text> </text>
+      {mode === 'connecting' ? (
+        <text>
+          <span attributes={DIM}>{CONNECTING}</span>
+        </text>
+      ) : (
+        <text>
+          <span fg={ACCENT}>n</span>
+          <span attributes={DIM}>: new session</span>
+        </text>
+      )}
+    </box>
+  );
+}

--- a/tui/src/ui/Splash.tsx
+++ b/tui/src/ui/Splash.tsx
@@ -27,7 +27,8 @@ const ART_WIDTH = 26;
 // Full tier needs sidebar(30) + pane border(2) + art(26) + margin cols, and
 // 14 content rows + status bar/border/banner chrome. Thresholds are on
 // terminal dims — Splash only ever renders in the main pane, so the 30-col
-// sidebar is baked in rather than plumbed through props.
+// sidebar width (App.tsx SIDEBAR_WIDTH) is baked in rather than plumbed
+// through props. Update these if SIDEBAR_WIDTH changes.
 const MIN_FULL_WIDTH = 62;
 const MIN_FULL_HEIGHT = 20;
 

--- a/tui/src/ui/test-utils.tsx
+++ b/tui/src/ui/test-utils.tsx
@@ -15,10 +15,13 @@ export async function renderFrame(node: ReactNode): Promise<{
   };
 }
 
-export async function renderSetup(node: ReactNode) {
+export async function renderSetup(
+  node: ReactNode,
+  opts?: { width?: number; height?: number },
+) {
   const setup = await testRender(node, {
-    width: 100,
-    height: 50,
+    width: opts?.width ?? 100,
+    height: opts?.height ?? 50,
     targetFps: 60,
   });
   await act(async () => {

--- a/tui/src/ui/theme.ts
+++ b/tui/src/ui/theme.ts
@@ -1,2 +1,5 @@
 /** Brand green from the holophyte logo (public/favicon.svg). */
 export const ACCENT = '#4EA876';
+
+/** Right-lobe green from the holophyte logo (public/favicon.svg). */
+export const ACCENT_DARK = '#3A8A5C';


### PR DESCRIPTION
## What

Starting `holo` on an empty board no longer drops you on a bare two-pane skeleton:

- The main pane shows a **splash** — the holophyte sprout as 26×9 two-tone block art (left lobe `#4EA876`, right lobe `#3A8A5C`, `▌▐` vein seam), the `holo` wordmark, and the spec's tagline *"what should I look at next?"*
- The **new-session picker auto-opens** when the first snapshot says the board is empty, so the very first keystroke creates a session

## How

- **`Splash` component** (`ui/Splash.tsx`) with two modes: `connecting` (replaces the old plain "connecting to daemon…" line, so the cold-start window is the brand moment) and `empty` (zero sessions — shows `n: new session`). Degrades to a single branded line under 62×20 terminals.
- **One-shot auto-open** — a ref flipped inside the existing subscription `onState` handler (no new effects, per the project's useEffect rules). Only the *first* push counts: esc stays closed, reconnects and later all-sessions-exited pushes never re-trigger it, manual `n` is unaffected.
- `theme.ts` gains `ACCENT_DARK`; `renderSetup` accepts optional dims so the compact tier is testable.

## Design process

Two competing designs (ambient empty-state vs dedicated boot-splash screen) were judged; the mode-based ambient approach won, with the stronger candidate's art grafted in. Adversarial review (correctness + simplicity lenses) found zero issues.

## Tests

9 new tests: 4 Splash (both tiers, both modes, centering) + 5 App (connecting splash pre-push; empty first snapshot auto-opens and first keystroke reaches the picker; esc is final; non-empty first snapshot never auto-opens but draining to zero shows the splash without the modal; daemon-down banner coexists). Full tui suite: **389 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a splash screen that displays when connecting to the daemon or when the board is empty.
  * Session picker now auto-opens on first connection to an empty board.
  * Session picker can be dismissed with Escape and reopened by pressing 'n'.
  * Enhanced visual presentation with ASCII art display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->