### PR TITLE
feat(tui): resume exited sessions with the r key

### DIFF
--- a/tui/README.md
+++ b/tui/README.md
@@ -48,7 +48,8 @@ holo (CLI)
   resumable with `r` — a fresh process in a fresh window continues the prior
   conversation (`claude --resume`, `codex resume`). Conversation ids are
   captured from each harness's `SessionStart` hook payload (`session_id`);
-  harnesses without resume support (cursor/devin) ignore `r`.
+  harnesses without resume support (cursor/devin) reject the request with
+  "harness cannot resume".
 - **Queue scoring**: permission 100, needs_input 60, error 50, idle 30, plus
   +2/min waiting (capped +40). Quick wins first; no panic UI.
 - **Ambient status line**: holod owns the holo tmux session's `status-right`

--- a/tui/README.md
+++ b/tui/README.md
@@ -44,6 +44,11 @@ holo (CLI)
   normal in-pane dialog.
 - **Session end**: Claude's `SessionEnd` hook, plus a 5s tmux liveness sweep
   (codex has no end hook; the sweep also covers hard kills).
+- **Resume**: exited sessions stay on the board (dim) for 30 minutes and are
+  resumable with `r` — a fresh process in a fresh window continues the prior
+  conversation (`claude --resume`, `codex resume`). Conversation ids are
+  captured from each harness's `SessionStart` hook payload (`session_id`);
+  harnesses without resume support (cursor/devin) ignore `r`.
 - **Queue scoring**: permission 100, needs_input 60, error 50, idle 30, plus
   +2/min waiting (capped +40). Quick wins first; no panic UI.
 - **Ambient status line**: holod owns the holo tmux session's `status-right`
@@ -64,6 +69,7 @@ holo (CLI)
 | `enter` | jump to session's tmux window |
 | `n` | new session (harness picker → fuzzy cwd picker) |
 | `a` / `d` | approve / deny pending permission on selected item |
+| `r` | resume an exited session — continues the conversation in a fresh window |
 | `tab` | toggle focus sessions ↔ queue |
 | `q` | quit TUI (daemon + sessions keep running) |
 

--- a/tui/docs/hooks-research.md
+++ b/tui/docs/hooks-research.md
@@ -130,6 +130,15 @@ does and more, so holo leaves `notify` alone entirely.
 
 - No `--session-id` equivalent — codex generates a UUIDv7; capture it from
   the `SessionStart` hook payload (`session_id`) if needed for `codex resume`.
+- **`codex resume` flag placement (verified 2026-06-12, codex 0.139.0)**:
+  `-C`, `-c`, and `--dangerously-bypass-hook-trust` are global args — they
+  appear in both `codex --help` and `codex resume --help`, and BOTH orders
+  parse (`codex -C <dir> -c <kv> --dangerously-bypass-hook-trust resume <id>`
+  and `codex resume -C <dir> ... <id>`; parse-checked via trailing `--help`).
+  holo uses the globals-before-subcommand form:
+  `codex <hook flags> resume <session_id>`. Live hook firing on a resumed
+  session not yet verified — if codex ignores `-c hooks.*` on `resume`, the
+  resumed session loses hooks (sweep still tracks exit).
 - `-C <dir>` sets the working root; appears as `cwd` in every hook payload.
 - The TUI process stays alive between turns: one process = one session.
   Process/window exit = session end.

--- a/tui/src/adapters/claude.test.ts
+++ b/tui/src/adapters/claude.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
 import { sessionSettingsPath } from '../paths';
 import type { Session } from '../types';
 import { buildClaudeSettings, ClaudeAdapter, hookCommand } from './claude';
@@ -193,5 +194,40 @@ describe('ClaudeAdapter', () => {
     await adapter.spawnCommand(makeSession());
     const written = readFileSync(sessionSettingsPath('claude-1'), 'utf8');
     expect(written).toContain(`HOLO_HOME='${holoHomeDir}'`);
+  });
+
+  it('resumeCommand returns claude --resume with settings written under the NEW session id', async () => {
+    const adapter = new ClaudeAdapter({ configured: () => true });
+    const session = makeSession({
+      id: 'claude-9',
+      harnessSessionId: 'a1b2c3d4-0000-4000-8000-000000000000',
+    });
+
+    const argv = await adapter.resumeCommand(session);
+    const settingsPath = sessionSettingsPath('claude-9');
+
+    expect(argv).toEqual([
+      'claude',
+      '--resume',
+      'a1b2c3d4-0000-4000-8000-000000000000',
+      '--settings',
+      settingsPath,
+    ]);
+    expect(existsSync(settingsPath)).toBe(true);
+    // injected hooks must target the NEW holo session id, not the old one
+    const written = readFileSync(settingsPath, 'utf8');
+    expect(written).toContain("'claude' 'claude-9'");
+    expect(JSON.parse(written)).toEqual(
+      JSON.parse(
+        JSON.stringify(buildClaudeSettings(hookCommand('claude', 'claude-9'))),
+      ),
+    );
+  });
+
+  it('resumeCommand throws without a captured conversation id', async () => {
+    const adapter = new ClaudeAdapter({ configured: () => true });
+    await expect(adapter.resumeCommand(makeSession())).rejects.toThrow(
+      /requires a captured conversation id/,
+    );
   });
 });

--- a/tui/src/adapters/claude.ts
+++ b/tui/src/adapters/claude.ts
@@ -84,17 +84,37 @@ export class ClaudeAdapter implements HarnessAdapter {
     return this.isConfigured();
   }
 
-  async spawnCommand(session: Session): Promise<string[]> {
-    mkdirSync(sessionDir(session.id), { recursive: true });
-    const settings = buildClaudeSettings(hookCommand('claude', session.id));
-    const settingsPath = sessionSettingsPath(session.id);
+  private writeSettings(sessionId: string): string {
+    mkdirSync(sessionDir(sessionId), { recursive: true });
+    const settings = buildClaudeSettings(hookCommand('claude', sessionId));
+    const settingsPath = sessionSettingsPath(sessionId);
     writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+    return settingsPath;
+  }
+
+  async spawnCommand(session: Session): Promise<string[]> {
     return [
       'claude',
       '--session-id',
       session.harnessSessionId ?? randomUUID(),
       '--settings',
-      settingsPath,
+      this.writeSettings(session.id),
+    ];
+  }
+
+  // Deliberately no --session-id alongside --resume (composition unverified);
+  // the SessionStart capture recovers the resumed conversation's actual id
+  // whether claude keeps it or forks a new one.
+  async resumeCommand(session: Session): Promise<string[]> {
+    if (session.harnessSessionId === undefined) {
+      throw new Error('claude resume requires a captured conversation id');
+    }
+    return [
+      'claude',
+      '--resume',
+      session.harnessSessionId,
+      '--settings',
+      this.writeSettings(session.id),
     ];
   }
 }

--- a/tui/src/adapters/codex.test.ts
+++ b/tui/src/adapters/codex.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { describe, expect, it } from 'vitest';
 import type { Session } from '../types';
 import { hookCommand } from './claude';
 import {
@@ -187,6 +188,52 @@ describe('CodexAdapter', () => {
     const argv = await adapter.spawnCommand(makeSession());
     expect(argv.join(' ')).not.toContain('notify');
     expect(adapter.setup).toBeUndefined();
+  });
+
+  it('resumeCommand puts the verified global flags BEFORE the resume subcommand', async () => {
+    const adapter = new CodexAdapter({ configured: () => true });
+    const session = makeSession({ harnessSessionId: 'conv-uuid-7' });
+    const command = hookCommand('codex', 'codex-1');
+
+    // flag placement parse-verified against codex 0.139.0 — see
+    // docs/hooks-research.md "codex resume flag placement"
+    expect(await adapter.resumeCommand(session)).toEqual([
+      'codex',
+      '-C',
+      '/Users/ko/Development/relos',
+      '-c',
+      'check_for_update_on_startup=false',
+      '-c',
+      codexHookOverride('UserPromptSubmit', command),
+      '-c',
+      codexHookOverride('PreToolUse', command),
+      '-c',
+      codexHookOverride('PermissionRequest', command, 150),
+      '-c',
+      codexHookOverride('Stop', command),
+      '-c',
+      codexHookOverride('SessionStart', command),
+      '--dangerously-bypass-hook-trust',
+      'resume',
+      'conv-uuid-7',
+    ]);
+  });
+
+  it('resumeCommand argv is spawnCommand argv plus the resume subcommand', async () => {
+    const adapter = new CodexAdapter({ configured: () => true });
+    const session = makeSession({ harnessSessionId: 'conv-uuid-7' });
+    expect(await adapter.resumeCommand(session)).toEqual([
+      ...(await adapter.spawnCommand(session)),
+      'resume',
+      'conv-uuid-7',
+    ]);
+  });
+
+  it('resumeCommand throws without a captured conversation id', async () => {
+    const adapter = new CodexAdapter({ configured: () => true });
+    await expect(adapter.resumeCommand(makeSession())).rejects.toThrow(
+      /requires a captured conversation id/,
+    );
   });
 
   it('each -c value is a single argv element parseable as key=value', async () => {

--- a/tui/src/adapters/codex.test.ts
+++ b/tui/src/adapters/codex.test.ts
@@ -200,7 +200,7 @@ describe('CodexAdapter', () => {
     expect(await adapter.resumeCommand(session)).toEqual([
       'codex',
       '-C',
-      '/Users/ko/Development/relos',
+      session.cwd,
       '-c',
       'check_for_update_on_startup=false',
       '-c',

--- a/tui/src/adapters/codex.ts
+++ b/tui/src/adapters/codex.ts
@@ -77,10 +77,9 @@ export class CodexAdapter implements HarnessAdapter {
     return this.isConfigured();
   }
 
-  async spawnCommand(session: Session): Promise<string[]> {
+  private hookFlags(session: Session): string[] {
     const command = hookCommand('codex', session.id);
     return [
-      'codex',
       '-C',
       session.cwd,
       // The update dialog otherwise blocks session startup.
@@ -103,6 +102,24 @@ export class CodexAdapter implements HarnessAdapter {
       // Required: non-managed injected hooks are otherwise skipped until
       // interactively trusted via /hooks.
       '--dangerously-bypass-hook-trust',
+    ];
+  }
+
+  async spawnCommand(session: Session): Promise<string[]> {
+    return ['codex', ...this.hookFlags(session)];
+  }
+
+  // Globals-before-subcommand order, parse-verified against codex 0.139.0
+  // (docs/hooks-research.md, codex resume flag placement).
+  async resumeCommand(session: Session): Promise<string[]> {
+    if (session.harnessSessionId === undefined) {
+      throw new Error('codex resume requires a captured conversation id');
+    }
+    return [
+      'codex',
+      ...this.hookFlags(session),
+      'resume',
+      session.harnessSessionId,
     ];
   }
 }

--- a/tui/src/adapters/fake-agent.ts
+++ b/tui/src/adapters/fake-agent.ts
@@ -21,15 +21,19 @@ interface Step {
 }
 
 // Timeline: ready @0ms, prompt @500ms, tool @1000ms, stop @2500ms.
-const DEFAULT_SCRIPT: Step[] = [
-  { delayMs: 0, event: { kind: 'ready' } },
-  { delayMs: 500, event: { kind: 'prompt' } },
-  { delayMs: 500, event: { kind: 'tool' } },
-  {
-    delayMs: 1500,
-    event: { kind: 'stop', lastMessage: 'fake agent: work complete' },
-  },
-];
+// ready carries a deterministic conversation id (a resumed agent echoes the
+// inherited one) so lineage continuity is observable end-to-end.
+function defaultScript(convId: string): Step[] {
+  return [
+    { delayMs: 0, event: { kind: 'ready', harnessSessionId: convId } },
+    { delayMs: 500, event: { kind: 'prompt' } },
+    { delayMs: 500, event: { kind: 'tool' } },
+    {
+      delayMs: 1500,
+      event: { kind: 'stop', lastMessage: 'fake agent: work complete' },
+    },
+  ];
+}
 
 const DEFAULT_PERMISSION_HOLD_MS = 90000;
 
@@ -41,15 +45,18 @@ function parseArgs(argv: string[]): {
   sessionId: string;
   home?: string;
   script?: string;
+  resume?: string;
 } {
   const sessionId = argv[0] ?? '';
   let home: string | undefined;
   let script: string | undefined;
+  let resume: string | undefined;
   for (let i = 1; i < argv.length - 1; i++) {
     if (argv[i] === '--home') home = argv[++i];
     else if (argv[i] === '--script') script = argv[++i];
+    else if (argv[i] === '--resume') resume = argv[++i];
   }
-  return { sessionId, home, script };
+  return { sessionId, home, script, resume };
 }
 
 function parseScript(json: string | undefined): Step[] | undefined {
@@ -72,14 +79,15 @@ function parseScript(json: string | undefined): Step[] | undefined {
 }
 
 async function run(): Promise<void> {
-  const { sessionId, home, script } = parseArgs(process.argv.slice(2));
+  const { sessionId, home, script, resume } = parseArgs(process.argv.slice(2));
   // Must be set before any client call — paths.ts reads HOLO_HOME lazily.
   if (home) process.env.HOLO_HOME = home;
 
   process.on('SIGTERM', () => process.exit(0));
   process.on('SIGINT', () => process.exit(0));
 
-  const steps = parseScript(script) ?? DEFAULT_SCRIPT;
+  const steps =
+    parseScript(script) ?? defaultScript(resume ?? `${sessionId}-conv`);
   for (const step of steps) {
     if (step.delayMs > 0) await sleep(step.delayMs);
     if (step.event) {

--- a/tui/src/adapters/fake.test.ts
+++ b/tui/src/adapters/fake.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
+import { describe, expect, it } from 'vitest';
 import type { Session } from '../types';
 import { FakeAdapter } from './fake';
 
@@ -68,5 +69,21 @@ describe('FakeAdapter', () => {
       '--script',
       script,
     ]);
+  });
+
+  it('resumeCommand is spawnCommand plus --resume <conversation id>', () => {
+    const adapter = new FakeAdapter();
+    const session = makeSession({ harnessSessionId: 'conv-9' });
+    expect(adapter.resumeCommand(session)).toEqual([
+      ...adapter.spawnCommand(session),
+      '--resume',
+      'conv-9',
+    ]);
+  });
+
+  it('resumeCommand throws without a captured conversation id', () => {
+    expect(() => new FakeAdapter().resumeCommand(makeSession())).toThrow(
+      /requires a captured conversation id/,
+    );
   });
 });

--- a/tui/src/adapters/fake.ts
+++ b/tui/src/adapters/fake.ts
@@ -32,4 +32,15 @@ export class FakeAdapter implements HarnessAdapter {
         : []),
     ];
   }
+
+  resumeCommand(session: Session): string[] {
+    if (session.harnessSessionId === undefined) {
+      throw new Error('fake resume requires a captured conversation id');
+    }
+    return [
+      ...this.spawnCommand(session),
+      '--resume',
+      session.harnessSessionId,
+    ];
+  }
 }

--- a/tui/src/daemon/registry.test.ts
+++ b/tui/src/daemon/registry.test.ts
@@ -637,6 +637,65 @@ describe('fromJSON / toJSON', () => {
     };
     expect(SessionRegistry.fromJSON(data).recentCwds()).toHaveLength(10);
   });
+
+  it('drops bogus codex ids from pre-v1 state but keeps claude ids', () => {
+    // pre-v1 files have no version and minted a random UUID for every harness;
+    // codex never received it (no --session-id) so resuming on it would fail.
+    const data: RegistryJSON = {
+      sessions: [
+        {
+          id: 'codex-1',
+          harness: 'codex',
+          cwd: '/a',
+          tmuxWindow: '@1',
+          status: 'exited',
+          createdAt: T0,
+          statusSince: T0,
+          harnessSessionId: 'bogus-pre-v1-uuid',
+        },
+        {
+          id: 'claude-1',
+          harness: 'claude',
+          cwd: '/b',
+          tmuxWindow: '@2',
+          status: 'exited',
+          createdAt: T0,
+          statusSince: T0,
+          harnessSessionId: 'real-claude-session-id',
+        },
+      ],
+      counters: { codex: 1, claude: 1 },
+      recentCwds: [],
+    };
+    const restored = SessionRegistry.fromJSON(data);
+    expect(restored.get('codex-1')?.harnessSessionId).toBeUndefined();
+    expect(restored.get('claude-1')?.harnessSessionId).toBe(
+      'real-claude-session-id',
+    );
+  });
+
+  it('keeps codex ids from v1 state (already hook-captured)', () => {
+    const data: RegistryJSON = {
+      version: 1,
+      sessions: [
+        {
+          id: 'codex-1',
+          harness: 'codex',
+          cwd: '/a',
+          tmuxWindow: '@1',
+          status: 'exited',
+          createdAt: T0,
+          statusSince: T0,
+          harnessSessionId: 'captured-codex-id',
+        },
+      ],
+      counters: { codex: 1 },
+      recentCwds: [],
+    };
+    expect(
+      SessionRegistry.fromJSON(data).get('codex-1')?.harnessSessionId,
+    ).toBe('captured-codex-id');
+  });
 });
 
 describe('reconcile', () => {

--- a/tui/src/daemon/registry.test.ts
+++ b/tui/src/daemon/registry.test.ts
@@ -1,10 +1,9 @@
+import { describe, expect, it } from 'vitest';
 import type { Session } from '../types';
 import type { RegistryJSON } from './registry';
-import { SessionRegistry } from './registry';
+import { EXITED_GRACE_MS, SessionRegistry } from './registry';
 
 const T0 = 1_000_000;
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function setup(now = T0) {
   const registry = new SessionRegistry();
@@ -27,13 +26,12 @@ describe('createSession', () => {
     expect(session.lastMessage).toBeUndefined();
   });
 
-  it('assigns a UUID harnessSessionId to every harness', () => {
+  it('createSession leaves harnessSessionId unset (capture-only)', () => {
     const registry = new SessionRegistry();
     const claude = registry.createSession('claude', '/a', T0);
     const codex = registry.createSession('codex', '/a', T0);
-    expect(claude.harnessSessionId).toMatch(UUID_RE);
-    expect(codex.harnessSessionId).toMatch(UUID_RE);
-    expect(claude.harnessSessionId).not.toBe(codex.harnessSessionId);
+    expect(claude.harnessSessionId).toBeUndefined();
+    expect(codex.harnessSessionId).toBeUndefined();
   });
 
   it('numbers ids per harness independently', () => {
@@ -46,7 +44,7 @@ describe('createSession', () => {
   it('never reuses ids after pruning', () => {
     const { registry, session } = setup();
     registry.applyEvent(session.id, { kind: 'exit' }, T0 + 1);
-    registry.pruneExited(T0 + 120_000);
+    registry.pruneExited(T0 + EXITED_GRACE_MS + 2);
     expect(registry.get('claude-1')).toBeUndefined();
     expect(registry.createSession('claude', '/a', T0).id).toBe('claude-2');
   });
@@ -690,7 +688,7 @@ describe('pruneExited', () => {
     const registry = new SessionRegistry();
     const session = registry.createSession('claude', '/a', T0);
     registry.applyEvent(session.id, { kind: 'exit' }, T0);
-    expect(registry.pruneExited(T0 + 60_001)).toBe(true);
+    expect(registry.pruneExited(T0 + EXITED_GRACE_MS + 1)).toBe(true);
     expect(registry.get(session.id)).toBeUndefined();
     expect(registry.all()).toEqual([]);
   });
@@ -699,7 +697,7 @@ describe('pruneExited', () => {
     const registry = new SessionRegistry();
     const session = registry.createSession('claude', '/a', T0);
     registry.applyEvent(session.id, { kind: 'exit' }, T0);
-    expect(registry.pruneExited(T0 + 60_000)).toBe(false); // not strictly older
+    expect(registry.pruneExited(T0 + EXITED_GRACE_MS)).toBe(false); // not strictly older
     expect(registry.get(session.id)).toBeDefined();
   });
 
@@ -711,5 +709,158 @@ describe('pruneExited', () => {
     expect(registry.pruneExited(T0 + 11, 10)).toBe(true);
     expect(registry.get(idle.id)).toBeDefined();
     expect(registry.get(gone.id)).toBeUndefined();
+  });
+});
+
+describe('ready capture', () => {
+  it('sets harnessSessionId and returns true even when status did not change', () => {
+    const { registry, session } = setup();
+    registry.applyEvent(
+      session.id,
+      { kind: 'ready', harnessSessionId: 'conv-1' },
+      T0 + 1,
+    );
+    expect(session.harnessSessionId).toBe('conv-1');
+    // status/reason unchanged — only the new id forces true
+    expect(
+      registry.applyEvent(
+        session.id,
+        { kind: 'ready', harnessSessionId: 'conv-2' },
+        T0 + 2,
+      ),
+    ).toBe(true);
+  });
+
+  it('overwrites a differing id (in-app /clear and /resume re-fire SessionStart)', () => {
+    const { registry, session } = setup();
+    registry.applyEvent(
+      session.id,
+      { kind: 'ready', harnessSessionId: 'conv-1' },
+      T0 + 1,
+    );
+    registry.applyEvent(
+      session.id,
+      { kind: 'ready', harnessSessionId: 'conv-2' },
+      T0 + 2,
+    );
+    expect(session.harnessSessionId).toBe('conv-2');
+  });
+
+  it('a plain ready leaves an existing id untouched', () => {
+    const { registry, session } = setup();
+    registry.applyEvent(
+      session.id,
+      { kind: 'ready', harnessSessionId: 'conv-1' },
+      T0 + 1,
+    );
+    expect(registry.applyEvent(session.id, { kind: 'ready' }, T0 + 2)).toBe(
+      false,
+    );
+    expect(session.harnessSessionId).toBe('conv-1');
+  });
+
+  it('rejects capture from a stale ready', () => {
+    const { registry, session } = setup();
+    registry.applyEvent(session.id, { kind: 'prompt' }, T0 + 5_000);
+    expect(
+      registry.applyEvent(
+        session.id,
+        { kind: 'ready', harnessSessionId: 'stale-conv' },
+        T0 + 2_999,
+      ),
+    ).toBe(false);
+    expect(session.harnessSessionId).toBeUndefined();
+  });
+
+  it('skips capture while masked by a held permission', () => {
+    const { registry, session } = setup();
+    registry.beginPermission(session.id, 'Bash', {}, T0 + 999, T0 + 1);
+    expect(
+      registry.applyEvent(
+        session.id,
+        { kind: 'ready', harnessSessionId: 'conv-1' },
+        T0 + 2,
+      ),
+    ).toBe(false);
+    expect(session.harnessSessionId).toBeUndefined();
+  });
+
+  it('rejects capture on exited sessions', () => {
+    const { registry, session } = setup();
+    registry.applyEvent(session.id, { kind: 'exit' }, T0 + 1);
+    expect(
+      registry.applyEvent(
+        session.id,
+        { kind: 'ready', harnessSessionId: 'conv-1' },
+        T0 + 10,
+      ),
+    ).toBe(false);
+    expect(session.harnessSessionId).toBeUndefined();
+  });
+
+  it('round-trips the captured id through toJSON/fromJSON', () => {
+    const { registry, session } = setup();
+    registry.setTmuxWindow(session.id, '@2');
+    registry.applyEvent(
+      session.id,
+      { kind: 'ready', harnessSessionId: 'conv-1' },
+      T0 + 1,
+    );
+    const restored = SessionRegistry.fromJSON(registry.toJSON());
+    expect(restored.get(session.id)?.harnessSessionId).toBe('conv-1');
+  });
+});
+
+describe('adoptLineage', () => {
+  it('copies harnessSessionId and lastMessage onto an existing session', () => {
+    const { registry, session } = setup();
+    registry.adoptLineage(session.id, {
+      harnessSessionId: 'conv-1',
+      lastMessage: 'prior tail',
+    });
+    expect(session.harnessSessionId).toBe('conv-1');
+    expect(session.lastMessage).toBe('prior tail');
+  });
+
+  it('leaves an existing lastMessage untouched when lineage omits it', () => {
+    const { registry, session } = setup();
+    registry.applyEvent(
+      session.id,
+      { kind: 'stop', lastMessage: 'kept' },
+      T0 + 1,
+    );
+    registry.adoptLineage(session.id, { harnessSessionId: 'conv-1' });
+    expect(session.harnessSessionId).toBe('conv-1');
+    expect(session.lastMessage).toBe('kept');
+  });
+
+  it('is a no-op on unknown ids', () => {
+    const registry = new SessionRegistry();
+    expect(() =>
+      registry.adoptLineage('ghost-1', { harnessSessionId: 'conv-1' }),
+    ).not.toThrow();
+  });
+});
+
+describe('remove', () => {
+  it('deletes only the target session', () => {
+    const registry = new SessionRegistry();
+    const a = registry.createSession('claude', '/a', T0);
+    const b = registry.createSession('claude', '/b', T0);
+    registry.applyEvent(a.id, { kind: 'exit' }, T0 + 1);
+    registry.applyEvent(b.id, { kind: 'exit' }, T0 + 1);
+    expect(registry.remove(a.id)).toBe(true);
+    expect(registry.get(a.id)).toBeUndefined();
+    expect(registry.get(b.id)?.status).toBe('exited');
+  });
+
+  it('returns false for unknown ids', () => {
+    expect(new SessionRegistry().remove('ghost-1')).toBe(false);
+  });
+
+  it('never frees the removed id — counters still advance', () => {
+    const { registry, session } = setup();
+    registry.remove(session.id);
+    expect(registry.createSession('claude', '/a', T0).id).toBe('claude-2');
   });
 });

--- a/tui/src/daemon/registry.ts
+++ b/tui/src/daemon/registry.ts
@@ -14,9 +14,14 @@ export interface RegistryJSON {
   counters: Record<string, number>;
   /** most-recent-first spawn targets, deduped, capped */
   recentCwds: string[];
+  /** state-file schema version; absent ⇒ pre-v1 (see fromJSON migration) */
+  version?: number;
 }
 
 const MAX_RECENT_CWDS = 10;
+
+/** current state-file schema version, written by toJSON */
+export const STATE_VERSION = 1;
 
 /** exited sessions stay resumable for this long before the sweep prunes them */
 export const EXITED_GRACE_MS = 30 * 60_000;
@@ -38,8 +43,17 @@ export class SessionRegistry {
 
   static fromJSON(data: RegistryJSON): SessionRegistry {
     const registry = new SessionRegistry();
+    // Pre-v1 state files minted a random UUID as harnessSessionId for EVERY
+    // harness, but codex never received it (it has no --session-id), so that id
+    // is bogus and would make `codex resume` fail. Drop it on load — a live
+    // codex session recaptures its real id from the next SessionStart hook.
+    // claude's pre-v1 id WAS its real --session-id, so it stays resumable.
+    const legacy = (data.version ?? 0) < 1;
     for (const persisted of data.sessions) {
       const session: Session = { ...persisted };
+      if (legacy && session.harness === 'codex') {
+        session.harnessSessionId = undefined;
+      }
       if (session.tmuxWindow === '') {
         // Half-created sessions don't survive a daemon restart — no spawn
         // can be in flight at restore time, and reconcile() never sweeps an
@@ -62,6 +76,7 @@ export class SessionRegistry {
 
   toJSON(): RegistryJSON {
     return {
+      version: STATE_VERSION,
       sessions: this.all().map((session) => ({ ...session })),
       counters: { ...this.counters },
       recentCwds: [...this.cwds],

--- a/tui/src/daemon/registry.ts
+++ b/tui/src/daemon/registry.ts
@@ -5,7 +5,6 @@
  * state-file.ts for load/save).
  */
 
-import { randomUUID } from 'node:crypto';
 import type { SessionEvent } from '../protocol';
 import type { HarnessId, Session, SessionStatus } from '../types';
 
@@ -18,6 +17,9 @@ export interface RegistryJSON {
 }
 
 const MAX_RECENT_CWDS = 10;
+
+/** exited sessions stay resumable for this long before the sweep prunes them */
+export const EXITED_GRACE_MS = 30 * 60_000;
 
 // Hook stamps come from independent processes on a steppable wall clock.
 // Ordering only needs to disambiguate sub-second hook races; a strict guard
@@ -80,7 +82,6 @@ export class SessionRegistry {
       attentionReason: 'starting…',
       createdAt: now,
       statusSince: now,
-      harnessSessionId: randomUUID(),
     };
     this.sessions.set(session.id, session);
     this.touchCwd(cwd);
@@ -127,8 +128,22 @@ export class SessionRegistry {
     this.paneDialogs.delete(id);
 
     switch (event.kind) {
-      case 'ready':
-        return this.transition(session, 'idle', 'awaiting first prompt', ts);
+      case 'ready': {
+        let changed = this.transition(
+          session,
+          'idle',
+          'awaiting first prompt',
+          ts,
+        );
+        if (
+          event.harnessSessionId !== undefined &&
+          event.harnessSessionId !== session.harnessSessionId
+        ) {
+          session.harnessSessionId = event.harnessSessionId;
+          changed = true; // forces persist — codex resume must survive a daemon restart
+        }
+        return changed;
+      }
       case 'prompt':
       case 'tool':
         return this.transition(session, 'running', undefined, ts);
@@ -236,8 +251,28 @@ export class SessionRegistry {
     return changed;
   }
 
+  /** Copy resume lineage onto a freshly minted session. No-op on unknown id. */
+  adoptLineage(
+    id: string,
+    lineage: { harnessSessionId: string; lastMessage?: string },
+  ): void {
+    const session = this.sessions.get(id);
+    if (!session) return;
+    session.harnessSessionId = lineage.harnessSessionId;
+    if (lineage.lastMessage !== undefined) {
+      session.lastMessage = lineage.lastMessage;
+    }
+  }
+
+  /** Targeted removal — resume's old-record drop and failed-spawn rollback. */
+  remove(id: string): boolean {
+    this.lastEventTs.delete(id);
+    this.paneDialogs.delete(id);
+    return this.sessions.delete(id);
+  }
+
   /** Drop exited sessions older than the grace period. */
-  pruneExited(now: number, graceMs = 60_000): boolean {
+  pruneExited(now: number, graceMs = EXITED_GRACE_MS): boolean {
     let changed = false;
     for (const [id, session] of this.sessions) {
       if (session.status === 'exited' && session.statusSince < now - graceMs) {

--- a/tui/src/daemon/server.test.ts
+++ b/tui/src/daemon/server.test.ts
@@ -15,6 +15,7 @@ import {
 import net from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 import { request, subscribe } from '../client';
 import { writeJsonLine } from '../ndjson';
 import { socketPath, statePath } from '../paths';
@@ -27,6 +28,7 @@ import type {
   Session,
   StateSnapshot,
 } from '../types';
+import { EXITED_GRACE_MS } from './registry';
 import { Daemon, type DaemonOptions } from './server';
 import { STATUS_STOPPED_LINE } from './status-line';
 
@@ -45,11 +47,15 @@ function fakeAdapter(
   opts: {
     configured?: boolean;
     spawn?: (session: Session) => string[] | Promise<string[]>;
+    resume?: (session: Session) => string[] | Promise<string[]>;
   } = {},
 ): HarnessAdapter {
   return {
     id,
     spawnCommand: opts.spawn ?? (() => ['sleep', '999']),
+    // wired only when provided — adapters without it exercise the
+    // cannot-resume path
+    ...(opts.resume ? { resumeCommand: opts.resume } : {}),
     configured: () => opts.configured ?? true,
     capabilities: { remotePermission: true, questionText: true },
   };
@@ -283,6 +289,258 @@ describe('new', () => {
     expect(expectError(res)).toMatch(/boom/);
     expect((await ls()).sessions).toEqual([]);
     expect(tmux.windows.size).toBe(0);
+  });
+});
+
+describe('resume', () => {
+  const resumeArgv = (s: Session) => [
+    'resume-bin',
+    s.harnessSessionId ?? '',
+    s.id,
+  ];
+
+  /** Spawn claude-1, capture conv-1 via ready, kill its window → exited. */
+  async function exitedSession(
+    daemon: Daemon,
+    tmux: FakeTmux,
+    opts: { ready?: unknown } = {},
+  ): Promise<void> {
+    await newSession('claude', '/repo/a');
+    await hook(
+      'claude-1',
+      opts.ready ?? { kind: 'ready', harnessSessionId: 'conv-1' },
+    );
+    tmux.closeWindow('@1');
+    await daemon.sweepOnce();
+    await daemon.sweepOnce(); // two-strike termination
+    expect(await status('claude-1')).toBe('exited');
+  }
+
+  it('mints a fresh session that continues the conversation, drops the old record', async () => {
+    const { daemon, tmux } = await startDaemon({
+      adapters: makeAdapters({
+        claude: fakeAdapter('claude', { resume: resumeArgv }),
+      }),
+    });
+    await newSession('claude', '/repo/a');
+    await hook('claude-1', { kind: 'ready', harnessSessionId: 'conv-1' });
+    await hook('claude-1', { kind: 'stop', lastMessage: 'prior tail' });
+    tmux.closeWindow('@1');
+    await daemon.sweepOnce();
+    await daemon.sweepOnce();
+    expect(await status('claude-1')).toBe('exited');
+
+    const session = expectSession(
+      await request({ cmd: 'resume', sessionId: 'claude-1' }),
+    );
+    expect(session.id).toBe('claude-2');
+    expect(session.status).toBe('idle');
+    expect(session.harnessSessionId).toBe('conv-1');
+    expect(session.lastMessage).toBe('prior tail'); // preview shows the prior tail while booting
+    expect(session.tmuxWindow).toBe('@2');
+    const env = { HOLO_HOME: holoHomeDir, HOLO_TMUX_SESSION: 'holo' };
+    expect(tmux.windows.get('@2')).toEqual({
+      name: 'claude-2',
+      cwd: '/repo/a',
+      argv: ['resume-bin', 'conv-1', 'claude-2'],
+      env,
+    });
+    expect(tmux.selected).toBe('@2'); // jump-on-spawn
+    const state = await ls();
+    expect(find(state, 'claude-1')).toBeUndefined();
+    expect(state.sessions).toHaveLength(1);
+  });
+
+  it('unknown session → ok:false, nothing spawned', async () => {
+    const { tmux } = await startDaemon();
+    expect(
+      expectError(await request({ cmd: 'resume', sessionId: 'ghost-1' })),
+    ).toMatch(/unknown session/);
+    expect((await ls()).sessions).toEqual([]);
+    expect(tmux.windows.size).toBe(0);
+  });
+
+  it('non-exited session → ok:false, nothing spawned', async () => {
+    const { tmux } = await startDaemon({
+      adapters: makeAdapters({
+        claude: fakeAdapter('claude', { resume: resumeArgv }),
+      }),
+    });
+    await newSession('claude', '/repo/a');
+    expect(
+      expectError(await request({ cmd: 'resume', sessionId: 'claude-1' })),
+    ).toMatch(/not exited/);
+    expect((await ls()).sessions).toHaveLength(1);
+    expect(tmux.windows.size).toBe(1);
+  });
+
+  it('adapter without resumeCommand → ok:false, nothing spawned', async () => {
+    const { daemon, tmux } = await startDaemon(); // default fakeAdapter: no resume
+    await exitedSession(daemon, tmux);
+    expect(
+      expectError(await request({ cmd: 'resume', sessionId: 'claude-1' })),
+    ).toMatch(/cannot resume/);
+    expect((await ls()).sessions).toHaveLength(1);
+    expect(tmux.windows.size).toBe(0);
+  });
+
+  it('unconfigured harness with resume support → ok:false, nothing spawned', async () => {
+    const state = { configured: true };
+    const { daemon, tmux } = await startDaemon({
+      adapters: makeAdapters({
+        claude: {
+          id: 'claude',
+          spawnCommand: () => ['sleep', '999'],
+          resumeCommand: resumeArgv,
+          configured: () => state.configured,
+          capabilities: { remotePermission: true, questionText: true },
+        },
+      }),
+    });
+    await exitedSession(daemon, tmux);
+    state.configured = false; // uninstalled while exited
+    expect(
+      expectError(await request({ cmd: 'resume', sessionId: 'claude-1' })),
+    ).toMatch(/not configured/);
+    expect((await ls()).sessions).toHaveLength(1);
+    expect(tmux.windows.size).toBe(0);
+  });
+
+  it('exited session that never reported a conversation id → ok:false', async () => {
+    const { daemon, tmux } = await startDaemon({
+      adapters: makeAdapters({
+        claude: fakeAdapter('claude', { resume: resumeArgv }),
+      }),
+    });
+    await exitedSession(daemon, tmux, { ready: { kind: 'ready' } });
+    expect(
+      expectError(await request({ cmd: 'resume', sessionId: 'claude-1' })),
+    ).toMatch(/no conversation id/);
+    expect((await ls()).sessions).toHaveLength(1);
+    expect(tmux.windows.size).toBe(0);
+  });
+
+  it('a throwing resumeCommand rolls back the new session and spares every exited one', async () => {
+    const { daemon, tmux } = await startDaemon({
+      adapters: makeAdapters({
+        claude: fakeAdapter('claude', {
+          resume: () => {
+            throw new Error('resume boom');
+          },
+        }),
+      }),
+    });
+    await newSession('claude', '/repo/a'); // claude-1 @1
+    await newSession('claude', '/repo/b'); // claude-2 @2
+    await hook('claude-1', { kind: 'ready', harnessSessionId: 'conv-1' });
+    await hook('claude-2', { kind: 'ready', harnessSessionId: 'conv-2' });
+    tmux.closeWindow('@1');
+    tmux.closeWindow('@2');
+    await daemon.sweepOnce();
+    await daemon.sweepOnce();
+    expect(await status('claude-1')).toBe('exited');
+    expect(await status('claude-2')).toBe('exited');
+
+    const res = await request({ cmd: 'resume', sessionId: 'claude-1' });
+    expect(expectError(res)).toMatch(/resume boom/);
+    // the old removeSession pruned ALL exited sessions with zero grace —
+    // both records surviving is the regression guard
+    const state = await ls();
+    expect(find(state, 'claude-1')?.status).toBe('exited');
+    expect(find(state, 'claude-2')?.status).toBe('exited');
+    expect(state.sessions).toHaveLength(2); // no half-created claude-3
+    expect(tmux.windows.size).toBe(0);
+  });
+
+  it('selectWindow failure after the spawn is non-fatal', async () => {
+    const { daemon, tmux } = await startDaemon({
+      adapters: makeAdapters({
+        claude: fakeAdapter('claude', { resume: resumeArgv }),
+      }),
+    });
+    await exitedSession(daemon, tmux);
+    const orig = tmux.selectWindow.bind(tmux);
+    tmux.selectWindow = async () => {
+      tmux.selectWindow = orig; // throw once
+      throw new Error('select boom');
+    };
+    const session = expectSession(
+      await request({ cmd: 'resume', sessionId: 'claude-1' }),
+    );
+    expect(session.id).toBe('claude-2');
+    const state = await ls();
+    expect(find(state, 'claude-2')).toBeDefined();
+    expect(find(state, 'claude-1')).toBeUndefined();
+  });
+
+  it('a second resume while one is in flight is rejected', async () => {
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const entered = { value: false };
+    const { daemon, tmux } = await startDaemon({
+      adapters: makeAdapters({
+        claude: fakeAdapter('claude', {
+          resume: async (s) => {
+            entered.value = true;
+            await gate;
+            return resumeArgv(s);
+          },
+        }),
+      }),
+    });
+    await exitedSession(daemon, tmux);
+
+    const first = request({ cmd: 'resume', sessionId: 'claude-1' });
+    await until(() => entered.value, 'first resume in flight');
+    expect(
+      expectError(await request({ cmd: 'resume', sessionId: 'claude-1' })),
+    ).toMatch(/in flight/);
+    release();
+    expect(expectSession(await first).id).toBe('claude-2');
+  });
+
+  it('captured conversation ids survive a daemon restart', async () => {
+    const adapters = () =>
+      makeAdapters({
+        claude: fakeAdapter('claude', { resume: resumeArgv }),
+      });
+    const { daemon, tmux } = await startDaemon({ adapters: adapters() });
+    await newSession('claude', '/repo/a');
+    await hook('claude-1', { kind: 'ready', harnessSessionId: 'conv-1' });
+    await daemon.stop();
+
+    const second = await startDaemon({ tmux, adapters: adapters() });
+    tmux.closeWindow('@1');
+    await second.daemon.sweepOnce();
+    await second.daemon.sweepOnce();
+    const session = expectSession(
+      await request({ cmd: 'resume', sessionId: 'claude-1' }),
+    );
+    expect(session.harnessSessionId).toBe('conv-1');
+    expect(tmux.windows.get('@2')?.argv).toEqual([
+      'resume-bin',
+      'conv-1',
+      'claude-2',
+    ]);
+  });
+
+  it('exited sessions outlive the old 60s horizon and prune after the grace', async () => {
+    const { daemon, tmux } = await startDaemon();
+    await newSession('claude', '/repo/a');
+    tmux.closeWindow('@1');
+    await daemon.sweepOnce();
+    await daemon.sweepOnce();
+    expect(await status('claude-1')).toBe('exited');
+
+    clock.now += 61_000; // pre-feature grace — must no longer prune
+    await daemon.sweepOnce();
+    expect(await status('claude-1')).toBe('exited');
+
+    clock.now += EXITED_GRACE_MS;
+    await daemon.sweepOnce();
+    expect(find(await ls(), 'claude-1')).toBeUndefined();
   });
 });
 
@@ -600,7 +858,7 @@ describe('sweep', () => {
     expect(session?.attentionReason).toBe('window closed');
     expect((await ls()).queue).toEqual([]); // exited never queues
 
-    clock.now += 61_000;
+    clock.now += EXITED_GRACE_MS + 1_000;
     await daemon.sweepOnce();
     expect(find(await ls(), 'claude-1')).toBeUndefined();
   });

--- a/tui/src/daemon/server.ts
+++ b/tui/src/daemon/server.ts
@@ -58,6 +58,8 @@ export class Daemon {
   private readonly connections = new Set<net.Socket>();
   /** held permission connections, keyed by sessionId */
   private readonly holds = new Map<string, Hold>();
+  /** old-session ids with a resume spawn in flight — blocks double-resume */
+  private readonly resuming = new Set<string>();
   private sweepTimer: NodeJS.Timeout | null = null;
   private started = false;
   private stopping: Promise<void> | null = null;
@@ -339,6 +341,9 @@ export class Daemon {
       case 'new':
         await this.handleNew(socket, req);
         return;
+      case 'resume':
+        await this.handleResume(socket, req);
+        return;
       case 'next': {
         const queue = buildQueue(this.registry.all(), this.now());
         const top = queue[0];
@@ -441,6 +446,112 @@ export class Daemon {
     });
   }
 
+  /**
+   * Respawn an exited session's conversation: mint a fresh session carrying
+   * the old one's lineage, spawn via the adapter's resumeCommand, drop the
+   * old record on success. Mirrors handleNew's skeleton deliberately — a
+   * shared spawn helper is deferred until the sibling server.ts branch lands.
+   */
+  private async handleResume(
+    socket: net.Socket,
+    req: { sessionId: string },
+  ): Promise<void> {
+    const old = this.registry.get(req.sessionId);
+    if (!old) {
+      this.reply(socket, {
+        ok: false,
+        error: `unknown session: ${req.sessionId}`,
+      });
+      return;
+    }
+    if (old.status !== 'exited') {
+      this.reply(socket, {
+        ok: false,
+        error: `session not exited: ${req.sessionId}`,
+      });
+      return;
+    }
+    const adapter = this.opts.adapters[old.harness] as
+      | HarnessAdapter
+      | undefined;
+    if (!adapter?.resumeCommand) {
+      this.reply(socket, {
+        ok: false,
+        error: `harness cannot resume: ${old.harness}`,
+      });
+      return;
+    }
+    if (old.harnessSessionId === undefined) {
+      this.reply(socket, {
+        ok: false,
+        error: `no conversation id captured for ${req.sessionId}`,
+      });
+      return;
+    }
+    if (this.resuming.has(req.sessionId)) {
+      this.reply(socket, {
+        ok: false,
+        error: `resume already in flight: ${req.sessionId}`,
+      });
+      return;
+    }
+    // capture lineage before any await — a sweep could prune `old` mid-flight
+    const { harness, cwd, harnessSessionId, lastMessage } = old;
+    this.resuming.add(req.sessionId);
+    try {
+      if (!(await adapter.configured())) {
+        this.reply(socket, {
+          ok: false,
+          error: `harness not configured: ${harness}`,
+        });
+        return;
+      }
+      let session: Session | undefined;
+      let windowId: string;
+      try {
+        await this.opts.tmux.ensureSession(this.opts.tuiArgv, this.paneEnv);
+        session = this.registry.createSession(harness, cwd, this.now());
+        // adopted BEFORE spawning: if the resumed process dies at boot, the
+        // new session exits still carrying the conversation id — retryable
+        this.registry.adoptLineage(session.id, {
+          harnessSessionId,
+          lastMessage,
+        });
+        const argv = await adapter.resumeCommand(
+          this.registry.get(session.id) ?? session,
+        );
+        windowId = await this.opts.tmux.newWindow({
+          name: session.id,
+          cwd,
+          argv,
+          env: this.paneEnv,
+        });
+        this.registry.setTmuxWindow(session.id, windowId);
+      } catch (err) {
+        if (session) this.registry.remove(session.id); // old exited record untouched — retryable
+        this.persist(); // keep counters consistent on disk
+        this.broadcast();
+        this.reply(socket, { ok: false, error: String(err) });
+        return;
+      }
+      this.registry.remove(req.sessionId); // lineage adopted — drop the old record now
+      this.persist();
+      this.broadcast();
+      try {
+        await this.opts.tmux.selectWindow(windowId); // jump-on-spawn, same feel as handleNew
+      } catch {
+        // selection is cosmetic — the resumed session is live and tracked;
+        // rolling back here would orphan a process that's consuming the conversation
+      }
+      this.reply(socket, {
+        ok: true,
+        session: this.registry.get(session.id) ?? session,
+      });
+    } finally {
+      this.resuming.delete(req.sessionId);
+    }
+  }
+
   private handlePermission(
     socket: net.Socket,
     req: {
@@ -509,15 +620,9 @@ export class Daemon {
     this.reply(hold.socket, { ok: true, decision });
   }
 
-  /**
-   * Failed-spawn cleanup. The registry has no targeted remove, so mark the
-   * session exited and prune with zero grace. May also drop other
-   * already-exited sessions slightly early — harmless, they're terminal.
-   */
+  /** Failed-spawn cleanup — targeted removal of the half-created session. */
   private removeSession(id: string): void {
-    const ts = this.now();
-    this.registry.applyEvent(id, { kind: 'exit', reason: 'spawn failed' }, ts);
-    this.registry.pruneExited(ts + 1, 0);
+    this.registry.remove(id);
   }
 
   private snapshot(): StateSnapshot {

--- a/tui/src/daemon/state-file.test.ts
+++ b/tui/src/daemon/state-file.test.ts
@@ -8,7 +8,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Session } from '../types';
-import type { RegistryJSON } from './registry';
+import { type RegistryJSON, STATE_VERSION } from './registry';
 import { loadStateFile, saveStateFile } from './state-file';
 
 let dir: string;
@@ -35,6 +35,7 @@ function sampleData(): RegistryJSON {
     harnessSessionId: 'b9a5e1c0-0000-4000-8000-000000000000',
   };
   return {
+    version: STATE_VERSION,
     sessions: [session],
     counters: { claude: 1 },
     recentCwds: ['/repo/a'],
@@ -64,6 +65,7 @@ describe('loadStateFile', () => {
     const path = join(dir, 'state.json');
     writeFileSync(path, '{}');
     expect(loadStateFile(path)).toEqual({
+      version: 0,
       sessions: [],
       counters: {},
       recentCwds: [],
@@ -81,6 +83,7 @@ describe('loadStateFile', () => {
       }),
     );
     expect(loadStateFile(path)).toEqual({
+      version: 0,
       sessions: [],
       counters: {},
       recentCwds: [],
@@ -91,6 +94,7 @@ describe('loadStateFile', () => {
     const path = join(dir, 'state.json');
     writeFileSync(path, JSON.stringify({ counters: { claude: 3 } }));
     expect(loadStateFile(path)).toEqual({
+      version: 0,
       sessions: [],
       counters: { claude: 3 },
       recentCwds: [],
@@ -125,6 +129,7 @@ describe('saveStateFile', () => {
     const path = join(dir, 'state.json');
     saveStateFile(path, sampleData());
     const updated: RegistryJSON = {
+      version: STATE_VERSION,
       sessions: [],
       counters: { claude: 9 },
       recentCwds: [],

--- a/tui/src/daemon/state-file.ts
+++ b/tui/src/daemon/state-file.ts
@@ -26,6 +26,8 @@ export function loadStateFile(path: string): RegistryJSON | null {
   if (!isPlainObject(parsed)) return null;
   // Minimal shape validation — fill missing/mistyped fields with defaults.
   return {
+    // absent ⇒ 0, which triggers fromJSON's pre-v1 codex-id migration
+    version: typeof parsed.version === 'number' ? parsed.version : 0,
     sessions: Array.isArray(parsed.sessions)
       ? (parsed.sessions as Session[])
       : [],

--- a/tui/src/hook/map.test.ts
+++ b/tui/src/hook/map.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import type { HookAction } from './map';
 import { mapHook } from './map';
 
@@ -34,6 +35,56 @@ describe('mapHook', () => {
         name: 'claude SessionStart source compact → ignore (mid-turn, agent still working)',
         harness: 'claude',
         payload: { hook_event_name: 'SessionStart', source: 'compact' },
+        expected: { type: 'ignore' },
+      },
+
+      // SessionStart conversation-id capture (drives resume lineage)
+      {
+        name: 'claude SessionStart with session_id → ready with harnessSessionId',
+        harness: 'claude',
+        payload: {
+          hook_event_name: 'SessionStart',
+          source: 'startup',
+          session_id: 'abc',
+        },
+        expected: {
+          type: 'event',
+          event: { kind: 'ready', harnessSessionId: 'abc' },
+        },
+      },
+      {
+        name: 'codex SessionStart with session_id → ready with harnessSessionId',
+        harness: 'codex',
+        payload: { hook_event_name: 'SessionStart', session_id: 'abc' },
+        expected: {
+          type: 'event',
+          event: { kind: 'ready', harnessSessionId: 'abc' },
+        },
+      },
+      {
+        name: 'SessionStart with non-string session_id → plain ready',
+        harness: 'codex',
+        payload: { hook_event_name: 'SessionStart', session_id: 42 },
+        expected: { type: 'event', event: { kind: 'ready' } },
+      },
+      {
+        name: 'SessionStart with empty session_id → plain ready',
+        harness: 'claude',
+        payload: {
+          hook_event_name: 'SessionStart',
+          source: 'startup',
+          session_id: '',
+        },
+        expected: { type: 'event', event: { kind: 'ready' } },
+      },
+      {
+        name: 'claude SessionStart source compact with session_id → still ignore',
+        harness: 'claude',
+        payload: {
+          hook_event_name: 'SessionStart',
+          source: 'compact',
+          session_id: 'abc',
+        },
         expected: { type: 'ignore' },
       },
 

--- a/tui/src/hook/map.ts
+++ b/tui/src/hook/map.ts
@@ -43,7 +43,14 @@ export function mapHook(
       if (harness === 'claude' && payload.source === 'compact') {
         return { type: 'ignore' };
       }
-      return { type: 'event', event: { kind: 'ready' } };
+      const sid = payload.session_id;
+      return {
+        type: 'event',
+        event:
+          typeof sid === 'string' && sid !== ''
+            ? { kind: 'ready', harnessSessionId: sid }
+            : { kind: 'ready' },
+      };
     }
 
     case 'UserPromptSubmit':

--- a/tui/src/protocol.ts
+++ b/tui/src/protocol.ts
@@ -31,7 +31,7 @@ import type { HarnessId, Session, StateSnapshot } from './types';
  * - error         → error
  */
 export type SessionEvent =
-  | { kind: 'ready' }
+  | { kind: 'ready'; harnessSessionId?: string }
   | { kind: 'prompt' }
   | { kind: 'tool' }
   | { kind: 'question'; text: string }
@@ -58,6 +58,8 @@ export type Request =
   | { cmd: 'next' }
   /** jump to a specific session's tmux window */
   | { cmd: 'jump'; sessionId: string }
+  /** respawn an exited session's conversation in a fresh window — mints a new session, drops the old record */
+  | { cmd: 'resume'; sessionId: string }
   | { cmd: 'respondPermission'; sessionId: string; allow: boolean }
   | { cmd: 'subscribe' }
   | { cmd: 'ping' }

--- a/tui/src/types.ts
+++ b/tui/src/types.ts
@@ -38,7 +38,7 @@ export interface Session {
   createdAt: number;
   /** when `status` last changed — drives elapsed display + aging bonus */
   statusSince: number;
-  /** harness-native session id (e.g. claude --session-id UUID), when supported */
+  /** harness-native conversation id, captured from the SessionStart hook payload (claude also pins it at spawn via --session-id) */
   harnessSessionId?: string;
 }
 
@@ -73,6 +73,12 @@ export interface HarnessAdapter {
    * hooks) — hence async is allowed.
    */
   spawnCommand(session: Session): string[] | Promise<string[]>;
+  /**
+   * argv that resumes session.harnessSessionId's conversation in a fresh
+   * process. Absent → this harness cannot resume. Like spawnCommand, may
+   * write per-session config first — hence async is allowed.
+   */
+  resumeCommand?(session: Session): string[] | Promise<string[]>;
   /** one-time global setup (config writes) — only if unavoidable */
   setup?(): Promise<void>;
   /** whether this harness is usable on this machine (binary on PATH etc.) */

--- a/tui/src/ui/App.test.tsx
+++ b/tui/src/ui/App.test.tsx
@@ -128,6 +128,13 @@ const withPermission = () =>
       respondBy: Date.now() + 30_000,
     },
   });
+const exited = () =>
+  session({
+    id: 'claude-9',
+    status: 'exited',
+    attentionReason: 'window closed',
+    harnessSessionId: 'conv-9',
+  });
 
 describe('App', () => {
   it('renders sessions, queue, and reasons from a pushed snapshot', async () => {
@@ -225,6 +232,49 @@ describe('App', () => {
     expect(
       gw.requests.filter((r) => r.cmd === 'respondPermission'),
     ).toHaveLength(0);
+    unmount();
+  });
+
+  it('r resumes the selected exited session in the sessions pane', async () => {
+    const { push, input, gw, update, unmount } = await mount();
+    await push(snapshot([running(), exited()]));
+    input.pressTab(); // queue → sessions focus
+    await update();
+    input.pressKey('j'); // codex-1 → claude-9 (exited)
+    await update();
+    input.pressKey('r');
+    await update();
+    expect(gw.requests).toContainEqual({
+      cmd: 'resume',
+      sessionId: 'claude-9',
+    });
+    unmount();
+  });
+
+  it('r does nothing when the selected session is not exited', async () => {
+    const { push, input, gw, update, unmount } = await mount();
+    await push(snapshot([running(), exited()]));
+    input.pressTab(); // sessions focus, codex-1 (running) selected
+    await update();
+    input.pressKey('r');
+    await update();
+    expect(gw.requests.filter((r) => r.cmd === 'resume')).toHaveLength(0);
+    unmount();
+  });
+
+  it('r does nothing with queue focus (exited sessions never queue)', async () => {
+    const { push, input, gw, update, unmount } = await mount();
+    await push(snapshot([needsInput(), exited()]));
+    input.pressKey('r'); // queue focus, claude-1 (needs_input) selected
+    await update();
+    expect(gw.requests.filter((r) => r.cmd === 'resume')).toHaveLength(0);
+    unmount();
+  });
+
+  it('shows the r:resume hint in the status bar', async () => {
+    const { push, frame, unmount } = await mount();
+    await push(snapshot([running()]));
+    expect(frame()).toContain('r:resume');
     unmount();
   });
 

--- a/tui/src/ui/App.tsx
+++ b/tui/src/ui/App.tsx
@@ -182,6 +182,14 @@ export function App({
           allow: key.name === 'a',
         })
         .catch(() => {});
+      return;
+    }
+    if (key.name === 'r') {
+      // exited sessions never appear in the queue (buildQueue filters them),
+      // so this status gate alone restricts 'r' to the SESSIONS pane
+      const session = l.push.sessions.find((s) => s.id === id);
+      if (session?.status !== 'exited') return; // pressed elsewhere: silent ignore
+      void gateway.request({ cmd: 'resume', sessionId: id }).catch(() => {});
     }
   });
 

--- a/tui/src/ui/StatusBar.tsx
+++ b/tui/src/ui/StatusBar.tsx
@@ -18,7 +18,7 @@ export function StatusBar({ daemon }: StatusBarProps) {
     >
       <text>
         <span attributes={DIM}>
-          n:new enter:open j/k:nav a:approve d:deny tab:focus q:quit
+          n:new enter:open j/k:nav a:approve d:deny r:resume tab:focus q:quit
         </span>
       </text>
       <text>


### PR DESCRIPTION
## What

An exited session in the SESSIONS pane can now be resumed with **`r`** — a fresh agent process in a fresh tmux window that *continues the prior conversation* instead of starting from scratch.

- **claude** → `claude --resume <conversation-id> --settings <fresh>`
- **codex** → `codex … resume <conversation-id>` (≥0.139, already the adapter gate; this machine has 0.139.0)
- **fake** → resumes too, so the path is tested end-to-end
- adapters without a `resumeCommand` (cursor/devin stubs) report "harness cannot resume"

## How

- **Conversation-id capture** — the `SessionStart` hook payload's `session_id` now rides the `ready` event and is stored on the session (forcing a persist so it survives a daemon restart). This is the reliable capture point for *both* harnesses and replaces claude's spawn-time pre-minted UUID. codex (which has no `--session-id`) depends on it entirely.
- **`HarnessAdapter.resumeCommand?(session)`** — optional; absent ⇒ the harness can't resume. claude deliberately omits `--session-id` alongside `--resume` (composition unverified) — the capture recovers the real id whichever way claude forks it.
- **`{cmd:'resume', sessionId}`** — mints a fresh session carrying the old one's lineage (`adoptLineage`), spawns via `resumeCommand`, drops the old record on success. Lineage is captured before any `await` (a sweep can't prune it mid-flight), a `resuming` set blocks double-resume, lineage is adopted *before* spawn so a boot-death stays retryable, and a failed spawn rolls back the new record while leaving the old one resumable.
- **Retention** — exited sessions now linger 30 min (`EXITED_GRACE_MS`, a one-constant change) so there's something to press `r` on. The `"nothing revives an exited session"` invariant in `acceptEvent` is deliberately **untouched** — resume mints a new identity rather than reviving the dead one.
- `r` is status-gated to exited sessions (which never appear in the queue, so it's effectively SESSIONS-pane-only); pressed elsewhere it's a silent no-op.

## Design process

Two competing designs (new-session-with-lineage vs in-place revival) were judged; lineage won for keeping the terminal-state invariant intact and making every error path honest. The implementation predates a model outage mid-run, so it was independently re-reviewed (correctness + simplicity lenses) on Opus 4.8 — clean, no actionable issues.

## Verification

- biome + tsc clean; full suite **463 passed / 2 skipped**.
- **End-to-end on real tmux** (isolated `-L` server, throwaway HOLO_HOME): spawn fake → capture conv id from the ready hook → agent exits → reconciles to exited → `resume` → new session carries the conversation id through the *real* `--resume` spawn+hook roundtrip → old record dropped → resume-of-live rejected. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to resume exited sessions using the `r` key
  * Exited sessions remain available on the board (dimmed) for 30 minutes before removal
  * Multiple harnesses now support resuming conversations from where they left off

* **Documentation**
  * Updated help text and README to document the new resume functionality and keybindings

* **Tests**
  * Added comprehensive test coverage for session resume functionality across all harness adapters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->