### PR TITLE
feat(tui): per-agent-window sidebar splits

### DIFF
--- a/tui/README.md
+++ b/tui/README.md
@@ -62,7 +62,10 @@ holo (CLI)
   included — still dies the moment the agent process exits; holod's liveness
   sweep is unchanged. The sidebar is skipped when the window is narrower than
   111 cols (it needs 80 for the agent + 1 separator + 30) or when
-  `HOLO_SIDEBAR=0` is set on the daemon's environment.
+  `HOLO_SIDEBAR=0` is set on the daemon's environment. The width is read at
+  spawn time, so a session started while a wide-terminal client is attached
+  (the usual `n`-in-the-TUI path) gets a sidebar; one spawned via `holo new`
+  against a still-detached session sees tmux's 80-col default and is skipped.
 
 ## TUI keys (window 0 only — zero key capture inside agent windows)
 

--- a/tui/README.md
+++ b/tui/README.md
@@ -55,6 +55,14 @@ holo (CLI)
   holophyte sprout splash, and on first connect to an empty board the
   new-session picker opens automatically — `esc` dismisses it and it will not
   reopen on its own (press `n` to bring it back).
+- **Per-agent-window sidebar**: each agent window gets a 30-col live board pane
+  (`holo sidebar`) beside the agent, so you can see and act on the queue without
+  jumping back to the TUI. The agent pane carries a tmux-native death trap (a
+  pane-scoped `pane-died` hook + `remain-on-exit`) so the whole window — sidebar
+  included — still dies the moment the agent process exits; holod's liveness
+  sweep is unchanged. The sidebar is skipped when the window is narrower than
+  111 cols (it needs 80 for the agent + 1 separator + 30) or when
+  `HOLO_SIDEBAR=0` is set on the daemon's environment.
 
 ## TUI keys (window 0 only — zero key capture inside agent windows)
 
@@ -71,6 +79,29 @@ holo (CLI)
 with the default tmux prefix that's **`ctrl-b` then `Space`** (installed by
 `holo` / `holo setup`; note: tmux bindings are server-global).
 
+## Sidebar keys (the 30-col pane beside each agent — only when tmux-focused)
+
+| Key | Action |
+|---|---|
+| `j/k` (or arrows) | navigate the queue |
+| `enter` | jump to the selected session's window |
+| `a` / `d` | approve / deny a pending permission on the selected item |
+| `q` | close the sidebar pane (the window and agent are unaffected) |
+
+The sidebar receives keys only when you deliberately tmux-focus it; while you
+type in the agent pane it stays read-only.
+
+**Tips:**
+- **`prefix+z` zooms the agent pane fullscreen** (press again to restore) — use
+  it when you want the whole window for the agent, instead of killing the
+  sidebar.
+- **Kill an agent session with `prefix+&` (the whole window) or by exiting the
+  agent — never `prefix+x` on the agent pane.** A pane-kill bypasses the
+  `pane-died` death trap and strands the window sidebar-only; the session then
+  goes stale until you close the window. If the terminal is resized below 111
+  cols both panes get squeezed — zoom with `prefix+z` or close the sidebar
+  with `q`.
+
 ## CLI
 
 ```text
@@ -82,9 +113,9 @@ holo setup           install tmux binding, report harness configuration
 ```
 
 Internal subcommands: `holo tui` (window-0 process), `holo daemon` (foreground
-daemon, for debugging). The spec's `holo hook` is intentionally not a
-subcommand — injected hooks invoke `src/hook/main.ts` directly so the hot path
-skips CLI dispatch.
+daemon, for debugging), `holo sidebar` (the per-agent-window board pane, spawned
+by holod). The spec's `holo hook` is intentionally not a subcommand — injected
+hooks invoke `src/hook/main.ts` directly so the hot path skips CLI dispatch.
 
 ## Development
 

--- a/tui/src/cli.test.ts
+++ b/tui/src/cli.test.ts
@@ -38,6 +38,20 @@ describe('parseArgs', () => {
     expect(parseArgs(['daemon'])).toEqual({ kind: 'daemon' });
   });
 
+  it('sidebar → sidebar (no session)', () => {
+    expect(parseArgs(['sidebar'])).toEqual({
+      kind: 'sidebar',
+      sessionId: undefined,
+    });
+  });
+
+  it('sidebar --session <id>', () => {
+    expect(parseArgs(['sidebar', '--session', 'claude-1'])).toEqual({
+      kind: 'sidebar',
+      sessionId: 'claude-1',
+    });
+  });
+
   it('new <harness>', () => {
     expect(parseArgs(['new', 'claude'])).toEqual({
       kind: 'new',
@@ -365,8 +379,15 @@ function makeDeps(overrides: Partial<CliDeps> = {}): TestDeps {
     tmux: {
       sessionExists: async () => false,
       ensureSession: async (_argv) => {},
-      newWindow: async (_opts) => '@1',
+      newWindow: async (_opts) => ({
+        windowId: '@1',
+        paneId: '%1',
+        width: 200,
+      }),
       selectWindow: async (_id) => {},
+      setKillWindowOnPaneDeath: async () => true,
+      splitSidebar: async () => {},
+      selectPane: async () => {},
       listWindowIds: async () => [],
       setStatusRight: async () => {},
       installReturnBinding: async () => {},
@@ -401,8 +422,11 @@ describe('runCli attach', () => {
           ensureSessionArgv = argv;
           ensureSessionEnv = env;
         },
-        newWindow: async () => '@1',
+        newWindow: async () => ({ windowId: '@1', paneId: '%1', width: 200 }),
         selectWindow: async () => {},
+        setKillWindowOnPaneDeath: async () => true,
+        splitSidebar: async () => {},
+        selectPane: async () => {},
         listWindowIds: async () => [],
         setStatusRight: async () => {},
         installReturnBinding: async () => {},
@@ -748,8 +772,11 @@ describe('runCli setup', () => {
       tmux: {
         sessionExists: async () => false,
         ensureSession: async () => {},
-        newWindow: async () => '@1',
+        newWindow: async () => ({ windowId: '@1', paneId: '%1', width: 200 }),
         selectWindow: async () => {},
+        setKillWindowOnPaneDeath: async () => true,
+        splitSidebar: async () => {},
+        selectPane: async () => {},
         listWindowIds: async () => [],
         setStatusRight: async () => {},
         installReturnBinding: async () => {},
@@ -769,8 +796,11 @@ describe('runCli setup', () => {
       tmux: {
         sessionExists: async () => false,
         ensureSession: async () => {},
-        newWindow: async () => '@1',
+        newWindow: async () => ({ windowId: '@1', paneId: '%1', width: 200 }),
         selectWindow: async () => {},
+        setKillWindowOnPaneDeath: async () => true,
+        splitSidebar: async () => {},
+        selectPane: async () => {},
         listWindowIds: async () => [],
         setStatusRight: async () => {},
         installReturnBinding: async () => {},
@@ -785,8 +815,11 @@ describe('runCli setup', () => {
       tmux: {
         sessionExists: async () => false,
         ensureSession: async () => {},
-        newWindow: async () => '@1',
+        newWindow: async () => ({ windowId: '@1', paneId: '%1', width: 200 }),
         selectWindow: async () => {},
+        setKillWindowOnPaneDeath: async () => true,
+        splitSidebar: async () => {},
+        selectPane: async () => {},
         listWindowIds: async () => [],
         setStatusRight: async () => {},
         installReturnBinding: async () => {

--- a/tui/src/cli.ts
+++ b/tui/src/cli.ts
@@ -21,6 +21,7 @@ export type CliCommand =
   | { kind: 'attach' }
   | { kind: 'tui' }
   | { kind: 'daemon' }
+  | { kind: 'sidebar'; sessionId?: string }
   | { kind: 'new'; harness: string; cwd?: string }
   | { kind: 'next' }
   | { kind: 'ls' }
@@ -44,6 +45,17 @@ export function parseArgs(argv: string[]): CliCommand {
       return { kind: 'tui' };
     case 'daemon':
       return { kind: 'daemon' };
+    case 'sidebar': {
+      let sessionId: string | undefined;
+      const tail = [second, ...rest];
+      for (let i = 0; i < tail.length; i++) {
+        if (tail[i] === '--session' && tail[i + 1]) {
+          sessionId = tail[i + 1];
+          i++;
+        }
+      }
+      return { kind: 'sidebar', sessionId };
+    }
     case 'new': {
       if (!second) return { kind: 'help' };
       let cwd: string | undefined;
@@ -312,7 +324,7 @@ export async function runCli(cmd: CliCommand, deps: CliDeps): Promise<number> {
       return 1;
     }
 
-    // 'tui' and 'daemon' are handled in index.tsx
+    // 'tui', 'daemon', and 'sidebar' are handled in index.tsx
     default:
       return 0;
   }

--- a/tui/src/cli.ts
+++ b/tui/src/cli.ts
@@ -47,7 +47,7 @@ export function parseArgs(argv: string[]): CliCommand {
       return { kind: 'daemon' };
     case 'sidebar': {
       let sessionId: string | undefined;
-      const tail = [second, ...rest];
+      const tail: string[] = [...(second ? [second] : []), ...rest];
       for (let i = 0; i < tail.length; i++) {
         if (tail[i] === '--session' && tail[i + 1]) {
           sessionId = tail[i + 1];

--- a/tui/src/daemon/main.ts
+++ b/tui/src/daemon/main.ts
@@ -10,16 +10,17 @@ import { RealTmux } from '../tmux';
 import { Daemon } from './server';
 
 async function main(): Promise<void> {
+  const entry = fileURLToPath(new URL('../index.tsx', import.meta.url));
   const daemon = new Daemon({
     tmux: new RealTmux(),
     adapters,
     harnesses: await harnessInfos(),
     // 'tui' subcommand renders the TUI in window 0 (stage-3 contract)
-    tuiArgv: [
-      process.execPath,
-      fileURLToPath(new URL('../index.tsx', import.meta.url)),
-      'tui',
-    ],
+    tuiArgv: [process.execPath, entry, 'tui'],
+    // each agent window gets a live 'holo sidebar' pane; HOLO_SIDEBAR=0 opts out
+    ...(process.env.HOLO_SIDEBAR === '0'
+      ? {}
+      : { sidebarArgv: [process.execPath, entry, 'sidebar'] }),
   });
   await daemon.start();
   console.log(`holod listening on ${socketPath()}`);

--- a/tui/src/daemon/registry.test.ts
+++ b/tui/src/daemon/registry.test.ts
@@ -98,6 +98,14 @@ describe('get / all / setTmuxWindow', () => {
     expect(registry.get(session.id)?.tmuxWindow).toBe('@7');
     expect(() => registry.setTmuxWindow('nope', '@9')).not.toThrow();
   });
+
+  it('setTmuxWindow sets agentPane when given, leaves it undefined otherwise', () => {
+    const { registry, session } = setup();
+    registry.setTmuxWindow(session.id, '@1');
+    expect(registry.get(session.id)?.agentPane).toBeUndefined();
+    registry.setTmuxWindow(session.id, '@1', '%1');
+    expect(registry.get(session.id)?.agentPane).toBe('%1');
+  });
 });
 
 describe('applyEvent transitions', () => {
@@ -565,6 +573,14 @@ describe('fromJSON / toJSON', () => {
     expect(restored.toJSON()).toEqual(registry.toJSON());
     expect(restored.get('claude-1')?.status).toBe('running');
     expect(restored.recentCwds()).toEqual(['/b', '/a']);
+  });
+
+  it('round-trips agentPane', () => {
+    const registry = new SessionRegistry();
+    const a = registry.createSession('claude', '/a', T0);
+    registry.setTmuxWindow(a.id, '@1', '%1');
+    const restored = SessionRegistry.fromJSON(registry.toJSON());
+    expect(restored.get('claude-1')?.agentPane).toBe('%1');
   });
 
   it('continues id numbering after a restore', () => {

--- a/tui/src/daemon/registry.ts
+++ b/tui/src/daemon/registry.ts
@@ -87,9 +87,11 @@ export class SessionRegistry {
     return session;
   }
 
-  setTmuxWindow(id: string, windowId: string): void {
+  setTmuxWindow(id: string, windowId: string, agentPane?: string): void {
     const session = this.sessions.get(id);
-    if (session) session.tmuxWindow = windowId;
+    if (!session) return;
+    session.tmuxWindow = windowId;
+    if (agentPane !== undefined) session.agentPane = agentPane;
   }
 
   get(id: string): Session | undefined {

--- a/tui/src/daemon/server.test.ts
+++ b/tui/src/daemon/server.test.ts
@@ -256,6 +256,8 @@ describe('new', () => {
       name: 'claude-1',
       cwd: '/repo/a',
       argv: ['sleep', '999'],
+      agentPane: '%1',
+      deathTrap: false, // sidebar-less default config
       env,
     });
     expect(tmux.selected).toBe('@1'); // jump-on-spawn
@@ -717,6 +719,7 @@ describe('restart persistence', () => {
     await startDaemon({ tmux });
     const state = await ls();
     expect(find(state, 'claude-1')?.status).toBe('idle');
+    expect(find(state, 'claude-1')?.agentPane).toBe('%1'); // survives restart
     expect(state.recentCwds).toEqual(['/repo/a']);
     const session = expectSession(await newSession('claude', '/repo/b'));
     expect(session.id).toBe('claude-2'); // counter never reused
@@ -934,5 +937,144 @@ describe('status line', () => {
       method: 'setStatusRight',
       args: [STATUS_STOPPED_LINE],
     });
+  });
+});
+
+describe('sidebar', () => {
+  const SIDEBAR_ARGV = ['bun', '/holo/index.tsx', 'sidebar'];
+
+  function callMethods(tmux: FakeTmux): string[] {
+    return tmux.calls.map((c) => c.method);
+  }
+
+  it('spawn arms the trap and splits a sidebar (trap before split)', async () => {
+    const { tmux } = await startDaemon({ sidebarArgv: SIDEBAR_ARGV });
+    const env = { HOLO_HOME: holoHomeDir, HOLO_TMUX_SESSION: 'holo' };
+    const session = expectSession(await newSession('claude', '/repo/a'));
+    expect(session.agentPane).toBe('%1');
+    const window = tmux.windows.get('@1');
+    expect(window?.deathTrap).toBe(true);
+    expect(window?.sidebar).toEqual({
+      argv: [...SIDEBAR_ARGV, '--session', 'claude-1'],
+      widthCols: 30,
+      env,
+    });
+    const methods = callMethods(tmux);
+    expect(methods.indexOf('setKillWindowOnPaneDeath')).toBeLessThan(
+      methods.indexOf('splitSidebar'),
+    );
+    expect(tmux.selected).toBe('@1');
+  });
+
+  it('skips the sidebar when the window is too narrow', async () => {
+    const tmux = new FakeTmux();
+    tmux.windowWidth = 80;
+    await startDaemon({ sidebarArgv: SIDEBAR_ARGV, tmux });
+    expect(expectSession(await newSession('claude', '/repo/a')).id).toBe(
+      'claude-1',
+    );
+    const methods = callMethods(tmux);
+    expect(methods).not.toContain('setKillWindowOnPaneDeath');
+    expect(methods).not.toContain('splitSidebar');
+  });
+
+  it('makes no trap/split calls when sidebarArgv is absent', async () => {
+    const { tmux } = await startDaemon();
+    await newSession('claude', '/repo/a');
+    const methods = callMethods(tmux);
+    expect(methods).not.toContain('setKillWindowOnPaneDeath');
+    expect(methods).not.toContain('splitSidebar');
+  });
+
+  it('degrades to no split when the trap fails to arm; spawn still ok', async () => {
+    const tmux = new FakeTmux();
+    tmux.trapResult = false;
+    await startDaemon({ sidebarArgv: SIDEBAR_ARGV, tmux });
+    const session = expectSession(await newSession('claude', '/repo/a'));
+    expect(session.id).toBe('claude-1');
+    expect(callMethods(tmux)).not.toContain('splitSidebar');
+    expect(await status('claude-1')).toBe('idle'); // session live
+  });
+
+  it('degrades to no sidebar when split throws; no rollback', async () => {
+    const tmux = new FakeTmux();
+    tmux.splitSidebar = async () => {
+      throw new Error('boom');
+    };
+    await startDaemon({ sidebarArgv: SIDEBAR_ARGV, tmux });
+    const session = expectSession(await newSession('claude', '/repo/a'));
+    expect(session.id).toBe('claude-1');
+    expect(await status('claude-1')).toBe('idle');
+    expect(tmux.windows.get('@1')).toBeDefined(); // window survives
+  });
+
+  it('CRUX: agent death closes the trapped window; sweep marks exited then prunes', async () => {
+    const { daemon, tmux } = await startDaemon({ sidebarArgv: SIDEBAR_ARGV });
+    await newSession('claude', '/repo/a');
+    expect(tmux.windows.get('@1')?.sidebar).toBeDefined();
+
+    tmux.exitAgentPane('@1'); // pane-died trap fires → whole window closes
+    await daemon.sweepOnce();
+    expect(await status('claude-1')).toBe('idle'); // first miss — still live
+    await daemon.sweepOnce();
+    const session = find(await ls(), 'claude-1');
+    expect(session?.status).toBe('exited');
+    expect(session?.attentionReason).toBe('window closed');
+
+    clock.now += 61_000;
+    await daemon.sweepOnce();
+    expect(find(await ls(), 'claude-1')).toBeUndefined();
+  });
+
+  it('a sidebar dying alone keeps the session live', async () => {
+    const { daemon, tmux } = await startDaemon({ sidebarArgv: SIDEBAR_ARGV });
+    await newSession('claude', '/repo/a');
+    tmux.closeSidebarPane('@1'); // user prefix+x on the sidebar / `q`
+    await daemon.sweepOnce();
+    await daemon.sweepOnce();
+    expect(await status('claude-1')).toBe('idle');
+  });
+
+  it('jump focuses the agent pane, not the sidebar', async () => {
+    const { tmux } = await startDaemon({ sidebarArgv: SIDEBAR_ARGV });
+    await newSession('claude', '/repo/a');
+    await request({ cmd: 'jump', sessionId: 'claude-1' });
+    expect(tmux.selected).toBe('@1');
+    expect(tmux.selectedPane).toBe('%1');
+  });
+
+  it('next focuses the agent pane', async () => {
+    const { tmux } = await startDaemon({ sidebarArgv: SIDEBAR_ARGV });
+    await newSession('claude', '/repo/a');
+    await request({ cmd: 'next' });
+    expect(tmux.selectedPane).toBe('%1');
+  });
+
+  it('jump on a pre-sidebar session (no agentPane) never selects a pane', async () => {
+    // hand-written pre-sidebar state.json: a session with no agentPane
+    writeFileSync(
+      statePath(),
+      JSON.stringify({
+        sessions: [
+          {
+            id: 'claude-1',
+            harness: 'claude',
+            cwd: '/repo/a',
+            tmuxWindow: '@1',
+            status: 'idle',
+            attentionReason: 'awaiting first prompt',
+            createdAt: clock.now,
+            statusSince: clock.now,
+            harnessSessionId: '00000000-0000-0000-0000-000000000000',
+          },
+        ],
+        counters: { claude: 1 },
+        recentCwds: ['/repo/a'],
+      }),
+    );
+    const { tmux } = await startDaemon({ sidebarArgv: SIDEBAR_ARGV });
+    await request({ cmd: 'jump', sessionId: 'claude-1' });
+    expect(tmux.selected).toBe('@1');
+    expect(tmux.selectedPane).toBeNull(); // no agentPane → no selectPane
   });
 });

--- a/tui/src/daemon/server.ts
+++ b/tui/src/daemon/server.ts
@@ -36,6 +36,8 @@ export interface DaemonOptions {
   harnesses: HarnessInfo[];
   /** argv for window 0 (the TUI) when creating the tmux session */
   tuiArgv: string[];
+  /** argv for the per-agent-window sidebar pane (`holo sidebar`). Absent ⇒ sidebars disabled. */
+  sidebarArgv?: string[];
   /** injectable clock for tests, default epoch-ms now */
   now?: () => number;
   sweepIntervalMs?: number;
@@ -50,6 +52,10 @@ interface Hold {
 
 /** longest stop() waits for the tombstone status write before giving up */
 const TOMBSTONE_DEADLINE_MS = 1000;
+
+/** sidebar pane width; the agent must keep ≥80 cols beside it + 1 separator col → 80+1+30 */
+const SIDEBAR_COLS = 30;
+const MIN_SIDEBAR_WINDOW_COLS = 111;
 
 export class Daemon {
   private registry = new SessionRegistry();
@@ -348,7 +354,7 @@ export class Daemon {
           this.reply(socket, { ok: true });
           return;
         }
-        await this.opts.tmux.selectWindow(session.tmuxWindow);
+        await this.focusSession(session);
         this.reply(socket, { ok: true, session });
         return;
       }
@@ -361,7 +367,7 @@ export class Daemon {
           });
           return;
         }
-        await this.opts.tmux.selectWindow(session.tmuxWindow);
+        await this.focusSession(session);
         this.reply(socket, { ok: true, session });
         return;
       }
@@ -418,14 +424,20 @@ export class Daemon {
       await this.opts.tmux.ensureSession(this.opts.tuiArgv, this.paneEnv);
       session = this.registry.createSession(req.harness, req.cwd, this.now());
       const argv = await adapter.spawnCommand(session);
-      const windowId = await this.opts.tmux.newWindow({
+      const spawned = await this.opts.tmux.newWindow({
         name: session.id,
         cwd: req.cwd,
         argv,
         env: this.paneEnv,
       });
-      this.registry.setTmuxWindow(session.id, windowId);
-      await this.opts.tmux.selectWindow(windowId); // jump-on-spawn per spec
+      this.registry.setTmuxWindow(session.id, spawned.windowId, spawned.paneId);
+      await this.opts.tmux.selectWindow(spawned.windowId); // jump-on-spawn per spec
+      await this.trySpawnSidebar(
+        session,
+        spawned.windowId,
+        spawned.paneId,
+        spawned.width,
+      );
     } catch (err) {
       if (session) this.removeSession(session.id);
       this.persist(); // keep counters/recentCwds consistent on disk
@@ -439,6 +451,50 @@ export class Daemon {
       ok: true,
       session: this.registry.get(session.id) ?? session,
     });
+  }
+
+  /**
+   * Best-effort sidebar. Trap-then-split ordering is load-bearing: the split
+   * happens only after the kill-window trap is armed on the agent pane, so a
+   * sidebar can never outlive its agent and hold the window (and the session)
+   * alive past the sweep. Any failure degrades to no sidebar — never a failed
+   * spawn, never an untrapped split.
+   */
+  private async trySpawnSidebar(
+    session: Session,
+    windowId: string,
+    agentPane: string,
+    width: number,
+  ): Promise<void> {
+    const argv = this.opts.sidebarArgv;
+    if (!argv || width < MIN_SIDEBAR_WINDOW_COLS) return;
+    try {
+      if (
+        !(await this.opts.tmux.setKillWindowOnPaneDeath(agentPane, windowId))
+      ) {
+        return;
+      }
+      await this.opts.tmux.splitSidebar({
+        paneId: agentPane,
+        argv: [...argv, '--session', session.id],
+        widthCols: SIDEBAR_COLS,
+        env: this.paneEnv, // same HOLO_HOME/HOLO_TMUX_SESSION pinning as agent panes
+      });
+    } catch (err) {
+      console.error('holod sidebar spawn failed:', err);
+    }
+  }
+
+  /**
+   * Focus a session's window, landing on the agent pane (not the sidebar).
+   * agentPane is absent on pre-sidebar persisted state and sidebar-less
+   * spawns, where window selection is enough.
+   */
+  private async focusSession(session: Session): Promise<void> {
+    await this.opts.tmux.selectWindow(session.tmuxWindow);
+    if (session.agentPane !== undefined) {
+      await this.opts.tmux.selectPane(session.agentPane);
+    }
   }
 
   private handlePermission(

--- a/tui/src/index.tsx
+++ b/tui/src/index.tsx
@@ -29,15 +29,15 @@ if (cmd.kind === 'daemon') {
   // `holo ls`.
   await import('./daemon/main');
   // daemon/main.ts never returns (it sets up signal handlers)
-} else if (cmd.kind === 'tui') {
+} else if (cmd.kind === 'tui' || cmd.kind === 'sidebar') {
   // OpenTUI renderer — dynamic import keeps it out of the fast-path bundle.
-  const [{ createCliRenderer }, { createRoot }, React, { App }] =
-    await Promise.all([
-      import('@opentui/core'),
-      import('@opentui/react'),
-      import('react'),
-      import('./ui/App'),
-    ]);
+  // The component (full TUI vs. per-window sidebar) is chosen by the import.
+  const [{ createCliRenderer }, { createRoot }, React, ui] = await Promise.all([
+    import('@opentui/core'),
+    import('@opentui/react'),
+    import('react'),
+    cmd.kind === 'tui' ? import('./ui/App') : import('./ui/Sidebar'),
+  ]);
 
   const renderer = await createCliRenderer({
     screenMode: 'alternate-screen',
@@ -63,13 +63,17 @@ if (cmd.kind === 'daemon') {
     process.exit(143);
   });
 
+  const onQuit = () => {
+    shutdown();
+    process.exit(0);
+  };
   root.render(
-    React.createElement(App, {
-      onQuit: () => {
-        shutdown();
-        process.exit(0);
-      },
-    }),
+    'App' in ui
+      ? React.createElement(ui.App, { onQuit })
+      : React.createElement(ui.Sidebar, {
+          onQuit,
+          sessionId: cmd.kind === 'sidebar' ? cmd.sessionId : undefined,
+        }),
   );
   renderer.start();
 

--- a/tui/src/sidebar-trap.smoke.test.ts
+++ b/tui/src/sidebar-trap.smoke.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Real-tmux regression tripwire for the sidebar death trap's empirical premise
+ * (verified by the judge on tmux 3.6b). Gated — needs a real tmux server and a
+ * non-sandboxed run (the sandbox blocks Unix-socket creation):
+ *   HOLO_SMOKE=tmux  bun node_modules/vitest/vitest.mjs run src/sidebar-trap.smoke.test.ts
+ *   HOLO_SMOKE=all
+ *
+ * Uses an ISOLATED `tmux -S <tmpdir>/tmux.sock` server — never the live server
+ * or ~/.holo. The server is killed and the tmpdir removed in teardown.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { defaultRunner, RealTmux, type TmuxRunner } from './tmux';
+
+const SMOKE = process.env.HOLO_SMOKE ?? '';
+const RUN = SMOKE === 'tmux' || SMOKE === 'all';
+
+describe.skipIf(!RUN)('sidebar death trap (HOLO_SMOKE=tmux gated)', () => {
+  let dir = '';
+  let runner: TmuxRunner;
+  let tmux: RealTmux;
+
+  async function windowAlive(windowId: string): Promise<boolean> {
+    return (await tmux.listWindowIds()).includes(windowId);
+  }
+
+  async function waitForGone(
+    windowId: string,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (!(await windowAlive(windowId))) return true;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    return !(await windowAlive(windowId));
+  }
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'holo-trap-'));
+    const sock = join(dir, 'tmux.sock');
+    runner = (args) => defaultRunner(['-S', sock, ...args]);
+    tmux = new RealTmux(runner, 'holo');
+    // a detached session is required before new-window can target it
+    await runner([
+      'new-session',
+      '-d',
+      '-s',
+      'holo',
+      '-n',
+      'tui',
+      'sleep',
+      '600',
+    ]);
+  });
+
+  afterAll(async () => {
+    await runner(['kill-server']).catch(() => {});
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('trap + sidebar: agent exit closes the whole window', async () => {
+    const { windowId, paneId } = await tmux.newWindow({
+      name: 'agent',
+      cwd: dir,
+      argv: ['sh', '-c', 'sleep 0.3'],
+    });
+    expect(await tmux.setKillWindowOnPaneDeath(paneId, windowId)).toBe(true);
+    await tmux.splitSidebar({ paneId, argv: ['sleep', '600'], widthCols: 30 });
+    expect(await waitForGone(windowId, 3000)).toBe(true);
+  });
+
+  it('control: without the trap the window survives sidebar-only', async () => {
+    const { windowId, paneId } = await tmux.newWindow({
+      name: 'leak',
+      cwd: dir,
+      argv: ['sh', '-c', 'sleep 0.3'],
+    });
+    await tmux.splitSidebar({ paneId, argv: ['sleep', '600'], widthCols: 30 });
+    // no trap → the agent pane dies but the window stays open on the sidebar
+    expect(await waitForGone(windowId, 1500)).toBe(false);
+    await tmux.selectWindow(windowId); // keep it tidy; teardown kills the server
+  });
+
+  it('sidebar killed first: window still closes on agent exit', async () => {
+    const { windowId, paneId } = await tmux.newWindow({
+      name: 'agent2',
+      cwd: dir,
+      argv: ['sh', '-c', 'sleep 0.6'],
+    });
+    expect(await tmux.setKillWindowOnPaneDeath(paneId, windowId)).toBe(true);
+    await tmux.splitSidebar({ paneId, argv: ['sleep', '600'], widthCols: 30 });
+    // kill the sidebar pane first — leaves the trapped single-pane window
+    await runner(['kill-pane', '-t', `${windowId}.1`]);
+    expect(await waitForGone(windowId, 3000)).toBe(true);
+  });
+});

--- a/tui/src/tmux.test.ts
+++ b/tui/src/tmux.test.ts
@@ -223,15 +223,17 @@ describe('RealTmux', () => {
   });
 
   describe('newWindow', () => {
-    it('builds the full argv with a single quoted shell-command and returns the trimmed window id', async () => {
-      const { runner, calls } = fakeRunner([{ status: 0, stdout: '@3\n' }]);
+    it('builds the full argv with a single quoted shell-command and returns id, pane, width', async () => {
+      const { runner, calls } = fakeRunner([
+        { status: 0, stdout: '@3 %7 211\n' },
+      ]);
       const tmux = new RealTmux(runner, 'holo');
-      const id = await tmux.newWindow({
+      const result = await tmux.newWindow({
         name: 'claude-1',
         cwd: '/tmp/repo',
         argv: ['claude', '--session-id', 'abc 123'],
       });
-      expect(id).toBe('@3');
+      expect(result).toEqual({ windowId: '@3', paneId: '%7', width: 211 });
       expect(calls).toEqual([
         [
           'new-window',
@@ -244,7 +246,7 @@ describe('RealTmux', () => {
           '/tmp/repo',
           '-P',
           '-F',
-          '#{window_id}',
+          '#{window_id} #{pane_id} #{window_width}',
           "'claude' '--session-id' 'abc 123'",
         ],
       ]);
@@ -260,8 +262,34 @@ describe('RealTmux', () => {
       ).rejects.toThrow("can't find session: holo");
     });
 
+    it('throws on malformed output (too few fields)', async () => {
+      const { runner } = fakeRunner([{ status: 0, stdout: '@3 %7\n' }]);
+      const tmux = new RealTmux(runner, 'holo');
+      await expect(
+        tmux.newWindow({ name: 'x', cwd: '/tmp', argv: ['true'] }),
+      ).rejects.toThrow('malformed output');
+    });
+
+    it('throws on malformed output (NaN width)', async () => {
+      const { runner } = fakeRunner([{ status: 0, stdout: '@3 %7 wide\n' }]);
+      const tmux = new RealTmux(runner, 'holo');
+      await expect(
+        tmux.newWindow({ name: 'x', cwd: '/tmp', argv: ['true'] }),
+      ).rejects.toThrow('malformed output');
+    });
+
+    it('throws on empty output', async () => {
+      const { runner } = fakeRunner([{ status: 0, stdout: '\n' }]);
+      const tmux = new RealTmux(runner, 'holo');
+      await expect(
+        tmux.newWindow({ name: 'x', cwd: '/tmp', argv: ['true'] }),
+      ).rejects.toThrow('malformed output');
+    });
+
     it('passes env as -e KEY=VALUE flags', async () => {
-      const { runner, calls } = fakeRunner([{ status: 0, stdout: '@4\n' }]);
+      const { runner, calls } = fakeRunner([
+        { status: 0, stdout: '@4 %9 80\n' },
+      ]);
       const tmux = new RealTmux(runner, 'holo');
       await tmux.newWindow({
         name: 'claude-1',
@@ -281,7 +309,7 @@ describe('RealTmux', () => {
           '/tmp/repo',
           '-P',
           '-F',
-          '#{window_id}',
+          '#{window_id} #{pane_id} #{window_width}',
           '-e',
           'HOLO_HOME=/tmp/h',
           '-e',
@@ -298,6 +326,102 @@ describe('RealTmux', () => {
       const tmux = new RealTmux(runner, 'holo');
       await tmux.selectWindow('@2');
       expect(calls).toEqual([['select-window', '-t', '@2']]);
+    });
+  });
+
+  describe('setKillWindowOnPaneDeath', () => {
+    it('arms hook then remain-on-exit and returns true when both succeed', async () => {
+      const { runner, calls } = fakeRunner([{ status: 0 }, { status: 0 }]);
+      const tmux = new RealTmux(runner, 'holo');
+      await expect(tmux.setKillWindowOnPaneDeath('%1', '@1')).resolves.toBe(
+        true,
+      );
+      expect(calls).toEqual([
+        ['set-hook', '-p', '-t', '%1', 'pane-died', 'kill-window -t @1'],
+        ['set-option', '-p', '-t', '%1', 'remain-on-exit', 'on'],
+      ]);
+    });
+
+    it('returns false and never makes the second call when the hook fails', async () => {
+      const { runner, calls } = fakeRunner([{ status: 1 }]);
+      const tmux = new RealTmux(runner, 'holo');
+      await expect(tmux.setKillWindowOnPaneDeath('%1', '@1')).resolves.toBe(
+        false,
+      );
+      expect(calls).toHaveLength(1);
+    });
+
+    it('returns false when remain-on-exit fails', async () => {
+      const { runner, calls } = fakeRunner([{ status: 0 }, { status: 1 }]);
+      const tmux = new RealTmux(runner, 'holo');
+      await expect(tmux.setKillWindowOnPaneDeath('%1', '@1')).resolves.toBe(
+        false,
+      );
+      expect(calls).toHaveLength(2);
+    });
+
+    it('propagates a runner rejection', async () => {
+      const runner: TmuxRunner = async () => {
+        throw new Error('tmux ENOENT');
+      };
+      const tmux = new RealTmux(runner, 'holo');
+      await expect(tmux.setKillWindowOnPaneDeath('%1', '@1')).rejects.toThrow(
+        'ENOENT',
+      );
+    });
+  });
+
+  describe('splitSidebar', () => {
+    it('builds the exact split-window argv (no -P, no -c)', async () => {
+      const { runner, calls } = fakeRunner([{ status: 0 }]);
+      const tmux = new RealTmux(runner, 'holo');
+      await tmux.splitSidebar({
+        paneId: '%7',
+        argv: ['bun', '/holo/index.tsx', 'sidebar', '--session', 'claude-1'],
+        widthCols: 30,
+        env: { HOLO_HOME: '/tmp/h', HOLO_TMUX_SESSION: 'holo' },
+      });
+      expect(calls).toEqual([
+        [
+          'split-window',
+          '-d',
+          '-h',
+          '-l',
+          '30',
+          '-t',
+          '%7',
+          '-e',
+          'HOLO_HOME=/tmp/h',
+          '-e',
+          'HOLO_TMUX_SESSION=holo',
+          "'bun' '/holo/index.tsx' 'sidebar' '--session' 'claude-1'",
+        ],
+      ]);
+    });
+
+    it('throws with status and stderr on failure', async () => {
+      const { runner } = fakeRunner([
+        { status: 1, stderr: 'no space for new pane\n' },
+      ]);
+      const tmux = new RealTmux(runner, 'holo');
+      await expect(
+        tmux.splitSidebar({ paneId: '%1', argv: ['x'], widthCols: 30 }),
+      ).rejects.toThrow('split-window failed (1): no space for new pane');
+    });
+  });
+
+  describe('selectPane', () => {
+    it('runs select-pane with the pane id', async () => {
+      const { runner, calls } = fakeRunner([{}]);
+      const tmux = new RealTmux(runner, 'holo');
+      await tmux.selectPane('%1');
+      expect(calls).toEqual([['select-pane', '-t', '%1']]);
+    });
+
+    it('resolves even on a non-zero exit', async () => {
+      const { runner } = fakeRunner([{ status: 1 }]);
+      const tmux = new RealTmux(runner, 'holo');
+      await expect(tmux.selectPane('%1')).resolves.toBeUndefined();
     });
   });
 
@@ -486,27 +610,36 @@ describe('FakeTmux', () => {
 
   it('round-trips newWindow → listWindowIds → closeWindow → listWindowIds', async () => {
     const tmux = new FakeTmux();
-    const id1 = await tmux.newWindow({
+    const w1 = await tmux.newWindow({
       name: 'claude-1',
       cwd: '/tmp/a',
       argv: ['claude'],
     });
-    const id2 = await tmux.newWindow({
+    const w2 = await tmux.newWindow({
       name: 'codex-1',
       cwd: '/tmp/b',
       argv: ['codex', '-C', '/tmp/b'],
     });
-    expect(id1).toBe('@1');
-    expect(id2).toBe('@2');
+    expect(w1).toEqual({ windowId: '@1', paneId: '%1', width: 200 });
+    expect(w2).toEqual({ windowId: '@2', paneId: '%2', width: 200 });
     expect(tmux.windows.get('@1')).toEqual({
       name: 'claude-1',
       cwd: '/tmp/a',
       argv: ['claude'],
+      agentPane: '%1',
+      deathTrap: false,
     });
     await expect(tmux.listWindowIds()).resolves.toEqual(['@1', '@2']);
 
     tmux.closeWindow('@1');
     await expect(tmux.listWindowIds()).resolves.toEqual(['@2']);
+  });
+
+  it('newWindow returns the windowWidth prop', async () => {
+    const tmux = new FakeTmux();
+    tmux.windowWidth = 80;
+    const w = await tmux.newWindow({ name: 'w', cwd: '/t', argv: ['x'] });
+    expect(w.width).toBe(80);
   });
 
   it('newWindow records env on the window', async () => {
@@ -521,31 +654,146 @@ describe('FakeTmux', () => {
       name: 'claude-1',
       cwd: '/tmp/a',
       argv: ['claude'],
+      agentPane: '%1',
+      deathTrap: false,
       env: { HOLO_HOME: '/tmp/h' },
     });
   });
 
   it('selectWindow tracks the selected window id', async () => {
     const tmux = new FakeTmux();
-    const id = await tmux.newWindow({ name: 'w', cwd: '/tmp', argv: ['true'] });
-    await tmux.selectWindow(id);
-    expect(tmux.selected).toBe(id);
+    const { windowId } = await tmux.newWindow({
+      name: 'w',
+      cwd: '/tmp',
+      argv: ['true'],
+    });
+    await tmux.selectWindow(windowId);
+    expect(tmux.selected).toBe(windowId);
   });
 
   it('closeWindow clears selection when the selected window dies', async () => {
     const tmux = new FakeTmux();
-    const id = await tmux.newWindow({ name: 'w', cwd: '/tmp', argv: ['true'] });
-    await tmux.selectWindow(id);
-    tmux.closeWindow(id);
+    const { windowId } = await tmux.newWindow({
+      name: 'w',
+      cwd: '/tmp',
+      argv: ['true'],
+    });
+    await tmux.selectWindow(windowId);
+    tmux.closeWindow(windowId);
     expect(tmux.selected).toBeNull();
   });
 
   it('never reuses window ids after close', async () => {
     const tmux = new FakeTmux();
-    const id1 = await tmux.newWindow({ name: 'a', cwd: '/t', argv: ['x'] });
-    tmux.closeWindow(id1);
-    const id2 = await tmux.newWindow({ name: 'b', cwd: '/t', argv: ['y'] });
-    expect(id2).toBe('@2');
+    const { windowId } = await tmux.newWindow({
+      name: 'a',
+      cwd: '/t',
+      argv: ['x'],
+    });
+    tmux.closeWindow(windowId);
+    const w2 = await tmux.newWindow({ name: 'b', cwd: '/t', argv: ['y'] });
+    expect(w2.windowId).toBe('@2');
+  });
+
+  it('mints pane ids %1, %2, … never reused', async () => {
+    const tmux = new FakeTmux();
+    const a = await tmux.newWindow({ name: 'a', cwd: '/t', argv: ['x'] });
+    expect(a.paneId).toBe('%1');
+    tmux.closeWindow(a.windowId);
+    const b = await tmux.newWindow({ name: 'b', cwd: '/t', argv: ['y'] });
+    expect(b.paneId).toBe('%2');
+  });
+
+  it('setKillWindowOnPaneDeath records the call, arms the trap, and respects trapResult', async () => {
+    const tmux = new FakeTmux();
+    const w = await tmux.newWindow({ name: 'a', cwd: '/t', argv: ['x'] });
+    await expect(
+      tmux.setKillWindowOnPaneDeath(w.paneId, w.windowId),
+    ).resolves.toBe(true);
+    expect(tmux.windows.get(w.windowId)?.deathTrap).toBe(true);
+    expect(tmux.calls).toContainEqual({
+      method: 'setKillWindowOnPaneDeath',
+      args: [w.paneId, w.windowId],
+    });
+
+    tmux.trapResult = false;
+    const w2 = await tmux.newWindow({ name: 'b', cwd: '/t', argv: ['y'] });
+    await expect(
+      tmux.setKillWindowOnPaneDeath(w2.paneId, w2.windowId),
+    ).resolves.toBe(false);
+    expect(tmux.windows.get(w2.windowId)?.deathTrap).toBe(false);
+  });
+
+  it('setKillWindowOnPaneDeath returns false for an unknown window or pane', async () => {
+    const tmux = new FakeTmux();
+    const w = await tmux.newWindow({ name: 'a', cwd: '/t', argv: ['x'] });
+    await expect(tmux.setKillWindowOnPaneDeath(w.paneId, '@99')).resolves.toBe(
+      false,
+    );
+    await expect(
+      tmux.setKillWindowOnPaneDeath('%99', w.windowId),
+    ).resolves.toBe(false);
+  });
+
+  it('splitSidebar records the call and sets .sidebar; throws on unknown pane', async () => {
+    const tmux = new FakeTmux();
+    const w = await tmux.newWindow({ name: 'a', cwd: '/t', argv: ['x'] });
+    await tmux.splitSidebar({
+      paneId: w.paneId,
+      argv: ['bun', 'sidebar'],
+      widthCols: 30,
+      env: { HOLO_HOME: '/tmp/h' },
+    });
+    expect(tmux.windows.get(w.windowId)?.sidebar).toEqual({
+      argv: ['bun', 'sidebar'],
+      widthCols: 30,
+      env: { HOLO_HOME: '/tmp/h' },
+    });
+    expect(tmux.calls.some((c) => c.method === 'splitSidebar')).toBe(true);
+    await expect(
+      tmux.splitSidebar({ paneId: '%99', argv: ['x'], widthCols: 30 }),
+    ).rejects.toThrow('no such pane');
+  });
+
+  it('selectPane records the call and sets selectedPane', async () => {
+    const tmux = new FakeTmux();
+    await tmux.selectPane('%5');
+    expect(tmux.selectedPane).toBe('%5');
+    expect(tmux.calls).toContainEqual({ method: 'selectPane', args: ['%5'] });
+  });
+
+  it('exitAgentPane closes the window when the trap is armed', async () => {
+    const tmux = new FakeTmux();
+    const w = await tmux.newWindow({ name: 'a', cwd: '/t', argv: ['x'] });
+    await tmux.setKillWindowOnPaneDeath(w.paneId, w.windowId);
+    await tmux.splitSidebar({ paneId: w.paneId, argv: ['s'], widthCols: 30 });
+    tmux.exitAgentPane(w.windowId);
+    await expect(tmux.listWindowIds()).resolves.toEqual([]);
+  });
+
+  it('exitAgentPane closes the window when there is no sidebar (last pane)', async () => {
+    const tmux = new FakeTmux();
+    const w = await tmux.newWindow({ name: 'a', cwd: '/t', argv: ['x'] });
+    tmux.exitAgentPane(w.windowId);
+    await expect(tmux.listWindowIds()).resolves.toEqual([]);
+  });
+
+  it('exitAgentPane LEAKS sidebar-only when untrapped with a sidebar', async () => {
+    const tmux = new FakeTmux();
+    const w = await tmux.newWindow({ name: 'a', cwd: '/t', argv: ['x'] });
+    await tmux.splitSidebar({ paneId: w.paneId, argv: ['s'], widthCols: 30 });
+    tmux.exitAgentPane(w.windowId);
+    await expect(tmux.listWindowIds()).resolves.toEqual([w.windowId]);
+    expect(tmux.windows.get(w.windowId)?.agentPane).toBe('');
+    expect(tmux.windows.get(w.windowId)?.sidebar).toBeDefined();
+  });
+
+  it('closeSidebarPane deletes .sidebar', async () => {
+    const tmux = new FakeTmux();
+    const w = await tmux.newWindow({ name: 'a', cwd: '/t', argv: ['x'] });
+    await tmux.splitSidebar({ paneId: w.paneId, argv: ['s'], widthCols: 30 });
+    tmux.closeSidebarPane(w.windowId);
+    expect(tmux.windows.get(w.windowId)?.sidebar).toBeUndefined();
   });
 });
 

--- a/tui/src/tmux.ts
+++ b/tui/src/tmux.ts
@@ -61,14 +61,32 @@ export interface Tmux {
    * tui window if it died (TUI quit); always (re)install the return binding
    */
   ensureSession(tuiArgv: string[], env?: Record<string, string>): Promise<void>;
-  /** spawn an agent window; returns the stable window id (e.g. "@3") */
+  /** spawn an agent window; returns the stable window id, its initial (agent) pane id, and the window's width in cols */
   newWindow(opts: {
     name: string;
     cwd: string;
     argv: string[];
     env?: Record<string, string>;
-  }): Promise<string>;
+  }): Promise<{ windowId: string; paneId: string; width: number }>;
   selectWindow(windowId: string): Promise<void>;
+  /**
+   * Arm the sidebar death trap: pane-scoped pane-died hook + remain-on-exit on
+   * the AGENT pane, so the whole window dies the moment the agent process does.
+   * Two sequential calls, hook first — remain-on-exit must never be set without
+   * the hook (a dead pane would hold the window open forever). Returns false on
+   * any non-zero tmux exit (callers then skip the split); rejects only when
+   * tmux could not be asked at all.
+   */
+  setKillWindowOnPaneDeath(paneId: string, windowId: string): Promise<boolean>;
+  /** narrow right-hand split beside the agent pane; -d keeps the agent pane active; throws on non-zero exit */
+  splitSidebar(opts: {
+    paneId: string;
+    argv: string[];
+    widthCols: number;
+    env?: Record<string, string>;
+  }): Promise<void>;
+  /** focus a pane within its window (jump/next land on the agent, not the sidebar). Non-zero exit ignored, like selectWindow. */
+  selectPane(paneId: string): Promise<void>;
   /** window ids in the holo session; [] when the session is gone; rejects when tmux could not be asked */
   listWindowIds(): Promise<string[]>;
   /**
@@ -149,7 +167,7 @@ export class RealTmux implements Tmux {
     cwd: string;
     argv: string[];
     env?: Record<string, string>;
-  }): Promise<string> {
+  }): Promise<{ windowId: string; paneId: string; width: number }> {
     // trailing "<session>:" target = "next free index in this session"
     const { status, stdout, stderr } = await this.run([
       'new-window',
@@ -162,18 +180,89 @@ export class RealTmux implements Tmux {
       opts.cwd,
       '-P',
       '-F',
-      '#{window_id}',
+      '#{window_id} #{pane_id} #{window_width}',
       ...envFlags(opts.env),
       shellQuote(opts.argv),
     ]);
     if (status !== 0) {
       throw new Error(`tmux new-window failed (${status}): ${stderr.trim()}`);
     }
-    return stdout.trim();
+    // '@N'/'%N' never contain spaces, so three space-separated fields
+    const fields = stdout.trim().split(' ');
+    const [windowId, paneId, widthField] = fields;
+    const width = Number(widthField);
+    if (
+      fields.length !== 3 ||
+      !windowId ||
+      !paneId ||
+      !widthField ||
+      Number.isNaN(width)
+    ) {
+      throw new Error(`tmux new-window returned malformed output: ${stdout}`);
+    }
+    return { windowId, paneId, width };
   }
 
   async selectWindow(windowId: string): Promise<void> {
     await this.run(['select-window', '-t', windowId]);
+  }
+
+  async setKillWindowOnPaneDeath(
+    paneId: string,
+    windowId: string,
+  ): Promise<boolean> {
+    // hook FIRST: remain-on-exit without the hook wedges a window forever
+    // (the dead pane holds it open). Separate calls, never a ';' chain — a
+    // chain keeps executing after an earlier failure. The window id is
+    // embedded literally; tmux never reuses @N within a server lifetime, so
+    // the trap can't kill a recycled window.
+    const hook = await this.run([
+      'set-hook',
+      '-p',
+      '-t',
+      paneId,
+      'pane-died',
+      `kill-window -t ${windowId}`,
+    ]);
+    if (hook.status !== 0) return false;
+    const remain = await this.run([
+      'set-option',
+      '-p',
+      '-t',
+      paneId,
+      'remain-on-exit',
+      'on',
+    ]);
+    return remain.status === 0;
+  }
+
+  async splitSidebar(opts: {
+    paneId: string;
+    argv: string[];
+    widthCols: number;
+    env?: Record<string, string>;
+  }): Promise<void> {
+    // no -P (the sidebar pane id is unused), no -c (the sidebar ignores cwd;
+    // it dials the socket via HOLO_HOME from -e). -e needs tmux >= 3.2 — the
+    // same floor envFlags already assumes.
+    const { status, stderr } = await this.run([
+      'split-window',
+      '-d',
+      '-h',
+      '-l',
+      String(opts.widthCols),
+      '-t',
+      opts.paneId,
+      ...envFlags(opts.env),
+      shellQuote(opts.argv),
+    ]);
+    if (status !== 0) {
+      throw new Error(`tmux split-window failed (${status}): ${stderr.trim()}`);
+    }
+  }
+
+  async selectPane(paneId: string): Promise<void> {
+    await this.run(['select-pane', '-t', paneId]);
   }
 
   async listWindowIds(): Promise<string[]> {
@@ -230,6 +319,10 @@ export interface FakeWindow {
   cwd: string;
   argv: string[];
   env?: Record<string, string>;
+  agentPane: string;
+  /** kill-window-on-agent-death trap armed (hook + remain-on-exit) */
+  deathTrap: boolean;
+  sidebar?: { argv: string[]; widthCols: number; env?: Record<string, string> };
 }
 
 /** In-memory Tmux for daemon tests — no tmux server involved. */
@@ -237,11 +330,18 @@ export class FakeTmux implements Tmux {
   readonly windows = new Map<string, FakeWindow>();
   readonly calls: Array<{ method: string; args: unknown[] }> = [];
   selected: string | null = null;
+  selectedPane: string | null = null;
   statusRight: string | null = null;
+  /** width newWindow reports — tests set 80 for the narrow-terminal case */
+  windowWidth = 200;
+  /** outcome of setKillWindowOnPaneDeath — tests set false for trap failure */
+  trapResult = true;
   /** models the dedicated "tui" window apart from agent windows so agent window ids stay stable */
   tuiWindow: { argv: string[]; env?: Record<string, string> } | null = null;
   private created = false;
   private nextId = 1;
+  /** pane ids are server-global and never reused, independent of window ids */
+  private nextPaneId = 1;
 
   async sessionExists(): Promise<boolean> {
     return this.created;
@@ -268,20 +368,60 @@ export class FakeTmux implements Tmux {
     cwd: string;
     argv: string[];
     env?: Record<string, string>;
-  }): Promise<string> {
+  }): Promise<{ windowId: string; paneId: string; width: number }> {
     const id = `@${this.nextId++}`;
+    const agentPane = `%${this.nextPaneId++}`;
     const window: FakeWindow = {
       name: opts.name,
       cwd: opts.cwd,
       argv: [...opts.argv],
+      agentPane,
+      deathTrap: false,
     };
     if (opts.env) window.env = { ...opts.env };
     this.windows.set(id, window);
-    return id;
+    return { windowId: id, paneId: agentPane, width: this.windowWidth };
   }
 
   async selectWindow(windowId: string): Promise<void> {
     this.selected = windowId;
+  }
+
+  async setKillWindowOnPaneDeath(
+    paneId: string,
+    windowId: string,
+  ): Promise<boolean> {
+    this.calls.push({
+      method: 'setKillWindowOnPaneDeath',
+      args: [paneId, windowId],
+    });
+    const window = this.windows.get(windowId);
+    if (!window || window.agentPane !== paneId) return false;
+    window.deathTrap = this.trapResult;
+    return this.trapResult;
+  }
+
+  async splitSidebar(opts: {
+    paneId: string;
+    argv: string[];
+    widthCols: number;
+    env?: Record<string, string>;
+  }): Promise<void> {
+    this.calls.push({ method: 'splitSidebar', args: [opts] });
+    const window = [...this.windows.values()].find(
+      (w) => w.agentPane === opts.paneId,
+    );
+    if (!window) throw new Error(`no such pane: ${opts.paneId}`); // mirrors tmux
+    window.sidebar = {
+      argv: [...opts.argv],
+      widthCols: opts.widthCols,
+      ...(opts.env ? { env: { ...opts.env } } : {}),
+    };
+  }
+
+  async selectPane(paneId: string): Promise<void> {
+    this.calls.push({ method: 'selectPane', args: [paneId] });
+    this.selectedPane = paneId;
   }
 
   async listWindowIds(): Promise<string[]> {
@@ -301,6 +441,28 @@ export class FakeTmux implements Tmux {
   closeWindow(id: string): void {
     this.windows.delete(id);
     if (this.selected === id) this.selected = null;
+  }
+
+  /**
+   * test helper: the agent process exits — models the live-verified tmux
+   * semantics. Trap armed (or no sidebar pane left) → the whole window
+   * closes; an untrapped window with a sidebar LEAKS sidebar-only, which is
+   * exactly what the death trap prevents.
+   */
+  exitAgentPane(id: string): void {
+    const window = this.windows.get(id);
+    if (!window) return;
+    if (window.deathTrap || window.sidebar === undefined) {
+      this.closeWindow(id);
+      return;
+    }
+    window.agentPane = '';
+  }
+
+  /** test helper: the user kills the sidebar pane (prefix+x / sidebar `q`) */
+  closeSidebarPane(id: string): void {
+    const window = this.windows.get(id);
+    if (window) delete window.sidebar;
   }
 
   /** test helper: simulate the TUI process quitting (its window dies with it) */

--- a/tui/src/types.ts
+++ b/tui/src/types.ts
@@ -29,6 +29,13 @@ export interface Session {
   cwd: string;
   /** tmux window id (e.g. "@3") — stable across window renames/reorders */
   tmuxWindow: string;
+  /**
+   * tmux pane id of the agent's pane (e.g. "%5") — jump/next focus target when
+   * a sidebar pane exists. Liveness keys on tmuxWindow ONLY: the pane-died trap
+   * makes the window die with the agent. Absent on sessions persisted by
+   * pre-sidebar daemons and on sidebar-less spawns.
+   */
+  agentPane?: string;
   status: SessionStatus;
   /** "Approve database migration", "Clarify naming convention", ... */
   attentionReason?: string;

--- a/tui/src/ui/App.test.tsx
+++ b/tui/src/ui/App.test.tsx
@@ -4,53 +4,14 @@ import { join } from 'node:path';
 import { act } from 'react';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { buildQueue } from '../daemon/scoring';
-import type { Request, Response, StatePush } from '../protocol';
+import type { StatePush } from '../protocol';
 import type { Session } from '../types';
 import { App } from './App';
-import type { Gateway } from './gateway';
-import { renderSetup } from './test-utils';
+import { FakeGateway, renderSetup } from './test-utils';
 
 beforeAll(() => {
   process.env.HOLO_HOME = mkdtempSync(join(tmpdir(), 'holo-ui-'));
 });
-
-class FakeGateway implements Gateway {
-  requests: Request[] = [];
-  nextResponse: Response = { ok: true };
-  subscribeCount = 0;
-  private handlers: {
-    onState: (s: StatePush) => void;
-    onClose?: () => void;
-  } | null = null;
-
-  subscribe(handlers: {
-    onState: (s: StatePush) => void;
-    onClose?: () => void;
-  }) {
-    this.subscribeCount += 1;
-    this.handlers = handlers;
-    return {
-      close: () => {
-        this.handlers = null;
-      },
-    };
-  }
-
-  async request(req: Request): Promise<Response> {
-    this.requests.push(req);
-    return this.nextResponse;
-  }
-
-  pushState(s: StatePush) {
-    this.handlers?.onState(s);
-  }
-
-  dropConnection() {
-    const handlers = this.handlers;
-    this.handlers = null;
-    handlers?.onClose?.();
-  }
-}
 
 function session(over: Partial<Session> & Pick<Session, 'id'>): Session {
   const now = Date.now();

--- a/tui/src/ui/App.tsx
+++ b/tui/src/ui/App.tsx
@@ -14,6 +14,7 @@ import { QueuePane } from './QueuePane';
 import { formatElapsed, SessionsPane, statusLabel } from './SessionsPane';
 import { Splash } from './Splash';
 import { StatusBar } from './StatusBar';
+import { effectiveId } from './selection';
 import { useDaemonState } from './useDaemonState';
 
 const BOLD = createTextAttributes({ bold: true });
@@ -30,15 +31,6 @@ export interface AppProps {
 }
 
 type Focus = 'queue' | 'sessions';
-
-/** Selected id if still present in the list, else the first item (clamp). */
-export function effectiveId(
-  ids: string[],
-  selectedId: string | null,
-): string | null {
-  if (selectedId !== null && ids.includes(selectedId)) return selectedId;
-  return ids[0] ?? null;
-}
 
 export function App({
   gateway = liveGateway,

--- a/tui/src/ui/App.tsx
+++ b/tui/src/ui/App.tsx
@@ -1,7 +1,6 @@
 import { createTextAttributes } from '@opentui/core';
 import { useKeyboard, useTerminalDimensions } from '@opentui/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { StatePush } from '../protocol';
 import type { HarnessId } from '../types';
 import { buildCwdCandidates, scanDevRepos } from './cwd-candidates';
 import type { DiffStatRunner } from './diffstat';
@@ -14,14 +13,13 @@ import { PreviewPane } from './PreviewPane';
 import { QueuePane } from './QueuePane';
 import { formatElapsed, SessionsPane, statusLabel } from './SessionsPane';
 import { Splash } from './Splash';
-import type { DaemonStatus } from './StatusBar';
 import { StatusBar } from './StatusBar';
+import { useDaemonState } from './useDaemonState';
 
 const BOLD = createTextAttributes({ bold: true });
 const DIM = createTextAttributes({ dim: true });
 
 const SIDEBAR_WIDTH = 30;
-const RETRY_MS = 1000;
 
 export interface AppProps {
   gateway?: Gateway;
@@ -34,7 +32,10 @@ export interface AppProps {
 type Focus = 'queue' | 'sessions';
 
 /** Selected id if still present in the list, else the first item (clamp). */
-function effectiveId(ids: string[], selectedId: string | null): string | null {
+export function effectiveId(
+  ids: string[],
+  selectedId: string | null,
+): string | null {
   if (selectedId !== null && ids.includes(selectedId)) return selectedId;
   return ids[0] ?? null;
 }
@@ -46,60 +47,21 @@ export function App({
   diffStat = gitDiffStat,
 }: AppProps) {
   const dims = useTerminalDimensions();
-  const [push, setPush] = useState<StatePush | null>(null);
-  const [daemon, setDaemon] = useState<DaemonStatus>('connecting');
   const [focus, setFocus] = useState<Focus>('queue');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
-  const [now, setNow] = useState(() => Date.now());
 
   // One-shot: auto-open the picker if the FIRST snapshot says the board is
   // empty. A ref, not state — read/flipped inside the subscription handler;
   // must never re-arm on reconnect, esc, or later sessions-all-exited pushes.
   const autoOpened = useRef(false);
 
-  // Subscription lifecycle — external system: subscribe on mount, retry every
-  // second after the connection drops until the daemon is back.
-  useEffect(() => {
-    let disposed = false;
-    let sub: { close(): void } | null = null;
-    let retry: ReturnType<typeof setTimeout> | null = null;
-    const connect = () => {
-      if (disposed) return;
-      try {
-        sub = gateway.subscribe({
-          onState: (s) => {
-            setPush(s);
-            setDaemon('up');
-            if (!autoOpened.current) {
-              autoOpened.current = true;
-              if (s.sessions.length === 0) setModalOpen(true);
-            }
-          },
-          onClose: () => {
-            sub = null;
-            setDaemon('down');
-            retry = setTimeout(connect, RETRY_MS);
-          },
-        });
-      } catch {
-        setDaemon('down');
-        retry = setTimeout(connect, RETRY_MS);
-      }
-    };
-    connect();
-    return () => {
-      disposed = true;
-      if (retry !== null) clearTimeout(retry);
-      sub?.close();
-    };
-  }, [gateway]);
-
-  // 1s tick so elapsed-in-state displays stay current.
-  useEffect(() => {
-    const timer = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(timer);
-  }, []);
+  const { push, daemon, now } = useDaemonState(gateway, (s) => {
+    if (!autoOpened.current) {
+      autoOpened.current = true;
+      if (s.sessions.length === 0) setModalOpen(true);
+    }
+  });
 
   const sessions = push?.sessions ?? [];
   const queue = push?.queue ?? [];

--- a/tui/src/ui/SessionsPane.tsx
+++ b/tui/src/ui/SessionsPane.tsx
@@ -11,6 +11,8 @@ export interface SessionsPaneProps {
   selectedId: string | null;
   focused: boolean;
   now: number;
+  /** message shown when there are no sessions (sidebar has no `n` key) */
+  emptyHint?: string;
 }
 
 export function formatElapsed(ms: number): string {
@@ -52,6 +54,7 @@ export function SessionsPane({
   selectedId,
   focused,
   now,
+  emptyHint = 'none — n to spawn',
 }: SessionsPaneProps) {
   return (
     <box flexDirection="column" flexShrink={0} overflow="hidden">
@@ -63,7 +66,7 @@ export function SessionsPane({
       </text>
       {sessions.length === 0 ? (
         <text>
-          <span attributes={DIM}> none — n to spawn</span>
+          <span attributes={DIM}> {emptyHint}</span>
         </text>
       ) : (
         sessions.map((session) => {

--- a/tui/src/ui/Sidebar.test.tsx
+++ b/tui/src/ui/Sidebar.test.tsx
@@ -1,0 +1,192 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { act } from 'react';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { buildQueue } from '../daemon/scoring';
+import type { StatePush } from '../protocol';
+import type { Session } from '../types';
+import { Sidebar } from './Sidebar';
+import { FakeGateway, renderSetup } from './test-utils';
+
+beforeAll(() => {
+  process.env.HOLO_HOME = mkdtempSync(join(tmpdir(), 'holo-sb-'));
+});
+
+function session(over: Partial<Session> & Pick<Session, 'id'>): Session {
+  const now = Date.now();
+  return {
+    harness: 'claude',
+    cwd: '/Users/x/Development/relos',
+    tmuxWindow: '@1',
+    status: 'running',
+    createdAt: now - 120_000,
+    statusSince: now - 30_000,
+    ...over,
+  };
+}
+
+function snapshot(sessions: Session[]): StatePush {
+  return {
+    type: 'state',
+    sessions,
+    queue: buildQueue(sessions, Date.now()),
+    harnesses: [{ id: 'claude', configured: true }],
+    recentCwds: [],
+  };
+}
+
+async function mount(sessionId = 'claude-1') {
+  const gw = new FakeGateway();
+  const quits: number[] = [];
+  const el = await renderSetup(
+    <Sidebar gateway={gw} onQuit={() => quits.push(1)} sessionId={sessionId} />,
+    { width: 30, height: 40 },
+  );
+  const push = async (s: StatePush) => {
+    await act(async () => {
+      gw.pushState(s);
+    });
+    await el.update();
+  };
+  return { ...el, gw, quits, push };
+}
+
+const needsInput = () =>
+  session({
+    id: 'claude-1',
+    status: 'needs_input',
+    attentionReason: 'Clarify naming convention',
+  });
+const idle = () =>
+  session({
+    id: 'claude-2',
+    status: 'idle',
+    attentionReason: 'review / next prompt',
+  });
+const running = () => session({ id: 'codex-1', harness: 'codex' });
+const withPermission = () =>
+  session({
+    id: 'claude-1',
+    status: 'permission',
+    attentionReason: 'approve: Bash',
+    pendingPermission: {
+      tool: 'Bash',
+      input: { command: 'rm -rf node_modules' },
+      respondBy: Date.now() + 30_000,
+    },
+  });
+
+describe('Sidebar', () => {
+  it('renders the header with the session id, SESSIONS, QUEUE, and reasons', async () => {
+    const { push, frame, unmount } = await mount('claude-1');
+    await push(snapshot([needsInput(), running()]));
+    const out = frame();
+    expect(out).toContain('holo');
+    expect(out).toContain('claude-1');
+    expect(out).toContain('SESSIONS');
+    expect(out).toContain('QUEUE');
+    expect(out).toContain('Clarify naming convention');
+    unmount();
+  });
+
+  it('shows the bare empty hint, not the n-to-spawn one', async () => {
+    const { push, frame, unmount } = await mount();
+    await push(snapshot([]));
+    const out = frame();
+    expect(out).toContain('none');
+    expect(out).not.toContain('n to spawn');
+    unmount();
+  });
+
+  it('j/k move queue selection', async () => {
+    const { push, input, frame, update, unmount } = await mount();
+    await push(snapshot([needsInput(), idle(), running()]));
+    expect(frame()).toMatch(/› 1\. claude-1/);
+    input.pressKey('j');
+    await update();
+    expect(frame()).toMatch(/› 2\. claude-2/);
+    input.pressKey('k');
+    await update();
+    expect(frame()).toMatch(/› 1\. claude-1/);
+    unmount();
+  });
+
+  it('enter sends a jump for the selected queue session', async () => {
+    const { push, input, gw, update, unmount } = await mount();
+    await push(snapshot([needsInput(), running()]));
+    input.pressEnter();
+    await update();
+    expect(gw.requests).toContainEqual({ cmd: 'jump', sessionId: 'claude-1' });
+    unmount();
+  });
+
+  it('a/d respond to a pending permission on the selected item only', async () => {
+    const { push, input, gw, update, unmount } = await mount();
+    await push(snapshot([withPermission(), running()]));
+    input.pressKey('a');
+    await update();
+    expect(gw.requests).toContainEqual({
+      cmd: 'respondPermission',
+      sessionId: 'claude-1',
+      allow: true,
+    });
+    input.pressKey('d');
+    await update();
+    expect(gw.requests).toContainEqual({
+      cmd: 'respondPermission',
+      sessionId: 'claude-1',
+      allow: false,
+    });
+    unmount();
+  });
+
+  it('a does nothing when the selected session has no pending permission', async () => {
+    const { push, input, gw, update, unmount } = await mount();
+    await push(snapshot([needsInput(), running()]));
+    input.pressKey('a');
+    await update();
+    expect(
+      gw.requests.filter((r) => r.cmd === 'respondPermission'),
+    ).toHaveLength(0);
+    unmount();
+  });
+
+  it('q calls onQuit', async () => {
+    const { push, input, quits, unmount } = await mount();
+    await push(snapshot([needsInput()]));
+    input.pressKey('q');
+    expect(quits).toHaveLength(1);
+    unmount();
+  });
+
+  it('n and tab produce no gateway requests', async () => {
+    const { push, input, gw, update, unmount } = await mount();
+    await push(snapshot([needsInput(), running()]));
+    input.pressKey('n');
+    input.pressTab();
+    await update();
+    expect(gw.requests).toHaveLength(0);
+    unmount();
+  });
+
+  it('shows the retrying footer when disconnected and heals on reconnect', async () => {
+    const { push, gw, frame, update, unmount } = await mount();
+    await push(snapshot([needsInput()]));
+    expect(frame()).not.toContain('retrying');
+    const subsBefore = gw.subscribeCount;
+    await act(async () => {
+      gw.dropConnection();
+    });
+    await update();
+    expect(frame()).toContain('retrying');
+    // the hook re-subscribes after its 1s retry — wait that out, then push
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+    });
+    expect(gw.subscribeCount).toBeGreaterThan(subsBefore);
+    await push(snapshot([needsInput()]));
+    expect(frame()).not.toContain('retrying');
+    unmount();
+  });
+});

--- a/tui/src/ui/Sidebar.tsx
+++ b/tui/src/ui/Sidebar.tsx
@@ -8,11 +8,11 @@
 import { createTextAttributes } from '@opentui/core';
 import { useKeyboard, useTerminalDimensions } from '@opentui/react';
 import { useEffect, useRef, useState } from 'react';
-import { effectiveId } from './App';
 import type { Gateway } from './gateway';
 import { liveGateway } from './gateway';
 import { QueuePane } from './QueuePane';
 import { SessionsPane } from './SessionsPane';
+import { effectiveId } from './selection';
 import { ACCENT } from './theme';
 import { useDaemonState } from './useDaemonState';
 
@@ -120,7 +120,7 @@ export function Sidebar({
       />
       <box flexGrow={1} />
       <text>
-        <span attributes={DIM}>↵ jump  a/d </span>
+        <span attributes={DIM}>↵ jump a/d </span>
         {daemon === 'up' ? (
           <span fg="green">●</span>
         ) : daemon === 'connecting' ? (

--- a/tui/src/ui/Sidebar.tsx
+++ b/tui/src/ui/Sidebar.tsx
@@ -1,0 +1,134 @@
+/**
+ * Per-agent-window sidebar pane (`holo sidebar`). A 30-col read-mostly board:
+ * SESSIONS (informational) + QUEUE (navigable). Subscribes to the daemon via
+ * the shared useDaemonState hook and self-heals across daemon restarts. Keys
+ * fire only when the user deliberately tmux-focuses this pane.
+ */
+
+import { createTextAttributes } from '@opentui/core';
+import { useKeyboard, useTerminalDimensions } from '@opentui/react';
+import { useEffect, useRef, useState } from 'react';
+import { effectiveId } from './App';
+import type { Gateway } from './gateway';
+import { liveGateway } from './gateway';
+import { QueuePane } from './QueuePane';
+import { SessionsPane } from './SessionsPane';
+import { ACCENT } from './theme';
+import { useDaemonState } from './useDaemonState';
+
+const BOLD = createTextAttributes({ bold: true });
+const DIM = createTextAttributes({ dim: true });
+
+export interface SidebarProps {
+  gateway?: Gateway;
+  onQuit: () => void;
+  /** session whose window this sidebar lives in — shown in the header */
+  sessionId?: string;
+}
+
+export function Sidebar({
+  gateway = liveGateway,
+  onQuit,
+  sessionId,
+}: SidebarProps) {
+  const dims = useTerminalDimensions();
+  const { push, daemon, now } = useDaemonState(gateway);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const sessions = push?.sessions ?? [];
+  const queue = push?.queue ?? [];
+  const runningCount = sessions.filter((s) => s.status === 'running').length;
+  const queueIds = queue.map((q) => q.sessionId);
+  const selected = effectiveId(queueIds, selectedId);
+
+  // Keyboard handlers fire between commits — route reads through a ref so they
+  // never act on stale state (bramble pattern, same as App).
+  const live = useRef({ push, selectedId });
+  useEffect(() => {
+    live.current = { push, selectedId };
+  });
+
+  const moveSelection = (delta: number) => {
+    const l = live.current;
+    if (l.push === null) return;
+    const ids = l.push.queue.map((q) => q.sessionId);
+    const current = effectiveId(ids, l.selectedId);
+    if (current === null) return;
+    const idx = ids.indexOf(current);
+    const next = Math.min(ids.length - 1, Math.max(0, idx + delta));
+    setSelectedId(ids[next] ?? null);
+  };
+
+  useKeyboard((key) => {
+    if (key.name === 'q') {
+      onQuit();
+      return;
+    }
+    if (key.name === 'j' || key.name === 'down') {
+      moveSelection(1);
+      return;
+    }
+    if (key.name === 'k' || key.name === 'up') {
+      moveSelection(-1);
+      return;
+    }
+    const l = live.current;
+    if (l.push === null) return;
+    const ids = l.push.queue.map((q) => q.sessionId);
+    const id = effectiveId(ids, l.selectedId);
+    if (id === null) return;
+    if (key.name === 'return' || key.name === 'enter') {
+      void gateway.request({ cmd: 'jump', sessionId: id }).catch(() => {});
+      return;
+    }
+    if (key.name === 'a' || key.name === 'd') {
+      const session = l.push.sessions.find((s) => s.id === id);
+      if (session?.pendingPermission === undefined) return;
+      void gateway
+        .request({
+          cmd: 'respondPermission',
+          sessionId: id,
+          allow: key.name === 'a',
+        })
+        .catch(() => {});
+    }
+  });
+
+  return (
+    <box flexDirection="column" width={dims.width} height={dims.height}>
+      <text>
+        <span fg={ACCENT} attributes={BOLD}>
+          holo
+        </span>
+        {sessionId !== undefined ? (
+          <span attributes={DIM}> · {sessionId}</span>
+        ) : null}
+      </text>
+      <SessionsPane
+        sessions={sessions}
+        selectedId={null}
+        focused={false}
+        now={now}
+        emptyHint="none"
+      />
+      <text> </text>
+      <QueuePane
+        queue={queue}
+        selectedId={selected}
+        focused
+        runningCount={runningCount}
+      />
+      <box flexGrow={1} />
+      <text>
+        <span attributes={DIM}>↵ jump  a/d </span>
+        {daemon === 'up' ? (
+          <span fg="green">●</span>
+        ) : daemon === 'connecting' ? (
+          <span fg="yellow">…</span>
+        ) : (
+          <span fg="red">○ retrying</span>
+        )}
+      </text>
+    </box>
+  );
+}

--- a/tui/src/ui/selection.ts
+++ b/tui/src/ui/selection.ts
@@ -1,0 +1,10 @@
+/** Shared list-selection helper for the TUI and the sidebar pane. */
+
+/** Selected id if still present in the list, else the first item (clamp). */
+export function effectiveId(
+  ids: string[],
+  selectedId: string | null,
+): string | null {
+  if (selectedId !== null && ids.includes(selectedId)) return selectedId;
+  return ids[0] ?? null;
+}

--- a/tui/src/ui/test-utils.tsx
+++ b/tui/src/ui/test-utils.tsx
@@ -3,6 +3,47 @@
 import { testRender } from '@opentui/react/test-utils';
 import type { ReactNode } from 'react';
 import { act } from 'react';
+import type { Request, Response, StatePush } from '../protocol';
+import type { Gateway } from './gateway';
+
+/** In-memory Gateway for UI tests — records requests, drives state pushes. */
+export class FakeGateway implements Gateway {
+  requests: Request[] = [];
+  nextResponse: Response = { ok: true };
+  subscribeCount = 0;
+  private handlers: {
+    onState: (s: StatePush) => void;
+    onClose?: () => void;
+  } | null = null;
+
+  subscribe(handlers: {
+    onState: (s: StatePush) => void;
+    onClose?: () => void;
+  }) {
+    this.subscribeCount += 1;
+    this.handlers = handlers;
+    return {
+      close: () => {
+        this.handlers = null;
+      },
+    };
+  }
+
+  async request(req: Request): Promise<Response> {
+    this.requests.push(req);
+    return this.nextResponse;
+  }
+
+  pushState(s: StatePush) {
+    this.handlers?.onState(s);
+  }
+
+  dropConnection() {
+    const handlers = this.handlers;
+    this.handlers = null;
+    handlers?.onClose?.();
+  }
+}
 
 export async function renderFrame(node: ReactNode): Promise<{
   frame: string;

--- a/tui/src/ui/useDaemonState.ts
+++ b/tui/src/ui/useDaemonState.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared daemon-subscription hook for the TUI and the per-window sidebar.
+ * Owns the subscribe-with-retry loop (reconnect every second after the
+ * connection drops) and a 1s tick so elapsed-in-state displays stay current.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { StatePush } from '../protocol';
+import type { Gateway } from './gateway';
+import type { DaemonStatus } from './StatusBar';
+
+const RETRY_MS = 1000;
+
+export function useDaemonState(
+  gateway: Gateway,
+  onState?: (s: StatePush) => void,
+): { push: StatePush | null; daemon: DaemonStatus; now: number } {
+  const [push, setPush] = useState<StatePush | null>(null);
+  const [daemon, setDaemon] = useState<DaemonStatus>('connecting');
+  const [now, setNow] = useState(() => Date.now());
+
+  // Route onState through a ref so a fresh callback identity each render never
+  // tears down and re-subscribes the connection — only the gateway should.
+  const onStateRef = useRef(onState);
+  useEffect(() => {
+    onStateRef.current = onState;
+  });
+
+  // Subscription lifecycle — external system: subscribe on mount, retry every
+  // second after the connection drops until the daemon is back.
+  useEffect(() => {
+    let disposed = false;
+    let sub: { close(): void } | null = null;
+    let retry: ReturnType<typeof setTimeout> | null = null;
+    const connect = () => {
+      if (disposed) return;
+      try {
+        sub = gateway.subscribe({
+          onState: (s) => {
+            setPush(s);
+            setDaemon('up');
+            onStateRef.current?.(s);
+          },
+          onClose: () => {
+            sub = null;
+            setDaemon('down');
+            retry = setTimeout(connect, RETRY_MS);
+          },
+        });
+      } catch {
+        setDaemon('down');
+        retry = setTimeout(connect, RETRY_MS);
+      }
+    };
+    connect();
+    return () => {
+      disposed = true;
+      if (retry !== null) clearTimeout(retry);
+      sub?.close();
+    };
+  }, [gateway]);
+
+  // 1s tick so elapsed-in-state displays stay current.
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return { push, daemon, now };
+}


### PR DESCRIPTION
## What

When you attach to an agent's tmux window you lose sight of the board (the status line softens that, but it's one line). Now each agent window gets a narrow **30-col right-hand pane** running a live compact `holo` view — sessions + queue, always in peripheral vision. `prefix+z` (tmux zoom) fullscreens the agent pane when you want focus; `prefix+&` kills the window.

## The crux (and how it's solved)

holod detects agent death by **window disappearance** — `sweepOnce` reconciles `session.tmuxWindow` against `listWindowIds()`, because a single-pane window closes when the agent process exits. A second (sidebar) pane *breaks that*: the agent dies but the sidebar keeps the window — and the session — alive forever.

Solved with a **tmux-native death trap**, verified on real tmux 3.6b: before splitting, holod arms a pane-scoped `pane-died` hook (`kill-window`) + `remain-on-exit` on the **agent** pane. When the agent process exits, tmux kills the whole window — so the daemon's window-id liveness model stays **byte-for-byte untouched** (`sweepOnce`/`reconcile`/two-strike unchanged, zero protocol changes, zero state migration). Trap-is-armed-*before*-split is load-bearing: a sidebar can never outlive its agent.

`Session.agentPane` is added purely as a **focus target** — `jump`/`next` now land on the agent pane, not the sidebar — and is absent on pre-sidebar persisted state (falls back to window selection).

## How

- **`holo sidebar` CLI kind** (dynamic-imported like `tui`) renders a 30-col borderless board reusing `SessionsPane`/`QueuePane`. Read-mostly keys: `j/k/enter/a/d/q` (no `n`/`tab`). Subscription + 1s tick extracted into a shared `useDaemonState` hook; `App` refactors onto it.
- **`tmux.ts`** gains `splitSidebar`, `selectPane`, `setKillWindowOnPaneDeath` (hook-first, two separate calls so a dead pane can't wedge the window); `newWindow` now returns `{windowId, paneId, width}`.
- **`handleNew`** arms the trap then splits — **best-effort**: any failure, or a window narrower than **111 cols** (80 agent + 1 sep + 30 sidebar), degrades to no sidebar, never a failed spawn. `HOLO_SIDEBAR=0` opts out at the composition root. The TUI window itself never gets a sidebar.

## Design process

Two competing designs (agent-pane tracking vs window-semantics-preserving) were judged; the window-preserving trap won for zero churn in the daemon's liveness model — the judge re-verified every tmux claim on an isolated server before accepting it. Independently re-reviewed (correctness + simplicity) on Opus 4.8 after a mid-run model outage; clean, one cosmetic nit applied.

## Verification

- biome + tsc clean; full suite **467 passed / 5 skipped** (the extra skips are the gated real-tmux test).
- **`HOLO_SMOKE=tmux` smoke test on real tmux 3.6b** (isolated `-S` server): trap+sidebar → window closes on agent exit; no-trap control → leaks sidebar-only; sidebar-killed-first → window still closes. 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)